### PR TITLE
Add HSTS checks to web_checker

### DIFF
--- a/apps/web_checker/analyzer.py
+++ b/apps/web_checker/analyzer.py
@@ -1,7 +1,7 @@
 """Web Checker analyzer — converts HTTP response data into Finding objects.
 
 Finding categories:
-  - Missing security headers (CSP, X-Frame-Options, X-Content-Type-Options, etc.)
+  - Missing security headers (CSP, X-Frame-Options, X-Content-Type-Options, HSTS, etc.)
   - Cookie security flags (Secure, HttpOnly, SameSite)
   - CORS misconfiguration (wildcard, origin reflection)
   - Server version disclosure (Server, X-Powered-By headers)
@@ -69,6 +69,10 @@ _HEADER_CHECKS = [
 ]
 
 
+_HSTS_MIN_MAX_AGE_SECONDS = 15552000  # 6 months
+_HSTS_MAX_AGE_RE = re.compile(r"(?:^|;)\s*max-age\s*=\s*(\d+)", re.IGNORECASE)
+
+
 def _security_header_findings(result: dict, session) -> list[Finding]:
     """Return findings for missing security headers."""
     if result.get("error"):
@@ -97,6 +101,76 @@ def _security_header_findings(result: dict, session) -> list[Finding]:
             ))
 
     return findings
+
+
+def _hsts_findings(result: dict, session) -> list[Finding]:
+    """Return findings for missing or weak HTTPS Strict-Transport-Security."""
+    if result.get("error"):
+        return []
+
+    url = result["url"]
+    if not url.startswith("https://"):
+        return []
+
+    headers = result.get("headers", {})
+    header_lower = {k.lower(): v for k, v in headers.items()}
+    hsts = header_lower.get("strict-transport-security")
+
+    if not hsts:
+        return [Finding(
+            session=session,
+            source="web_checker",
+            check_type="missing_hsts",
+            severity="medium",
+            title=f"Missing Strict-Transport-Security on {url}",
+            description=(
+                f"The HTTPS response from {url} does not set Strict-Transport-Security. "
+                f"Browsers may allow future visits over HTTP, leaving users exposed to "
+                f"downgrade and SSL-stripping attacks."
+            ),
+            remediation=(
+                "Add a Strict-Transport-Security header with a max-age of at least "
+                "six months. Example: Strict-Transport-Security: "
+                "max-age=31536000; includeSubDomains"
+            ),
+            url=result["url_fk"],
+            port=result["port_fk"],
+            target=url,
+            extra={"header": "Strict-Transport-Security", "url": url},
+        )]
+
+    match = _HSTS_MAX_AGE_RE.search(hsts)
+    max_age = int(match.group(1)) if match else None
+    if max_age is None or max_age < _HSTS_MIN_MAX_AGE_SECONDS:
+        return [Finding(
+            session=session,
+            source="web_checker",
+            check_type="weak_hsts",
+            severity="low",
+            title=f"Weak Strict-Transport-Security on {url}",
+            description=(
+                f"The Strict-Transport-Security header on {url} has an insufficient "
+                f"max-age. Short or missing HSTS lifetimes reduce protection against "
+                f"HTTPS downgrade attacks."
+            ),
+            remediation=(
+                "Set Strict-Transport-Security with max-age of at least 15552000 "
+                "seconds. Example: Strict-Transport-Security: "
+                "max-age=31536000; includeSubDomains"
+            ),
+            url=result["url_fk"],
+            port=result["port_fk"],
+            target=url,
+            extra={
+                "header": "Strict-Transport-Security",
+                "value": hsts,
+                "max_age": max_age,
+                "minimum_max_age": _HSTS_MIN_MAX_AGE_SECONDS,
+                "url": url,
+            },
+        )]
+
+    return []
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +449,7 @@ def analyze(session, results: list[dict]) -> list[Finding]:
 
     For each URL result, generates findings across:
       - Missing security headers
+      - HSTS configuration
       - Cookie security flags
       - CORS misconfiguration
       - Server version disclosure
@@ -384,6 +459,7 @@ def analyze(session, results: list[dict]) -> list[Finding]:
 
     for r in results:
         findings.extend(_security_header_findings(r, session))
+        findings.extend(_hsts_findings(r, session))
         findings.extend(_cookie_findings(r, session))
         findings.extend(_cors_findings(r, session))
         findings.extend(_server_disclosure_findings(r, session))

--- a/tests/unit/test_web_checker.py
+++ b/tests/unit/test_web_checker.py
@@ -136,10 +136,12 @@ class TestWebCheckerHeaders:
             "X-Content-Type-Options": "nosniff",
             "Permissions-Policy": "camera=()",
             "Referrer-Policy": "strict-origin-when-cross-origin",
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
         })]
         findings = analyze(sess, results)
         header_types = {"missing_csp", "missing_xfo", "missing_xcto",
-                        "missing_permissions_policy", "missing_referrer_policy"}
+                        "missing_permissions_policy", "missing_referrer_policy",
+                        "missing_hsts", "weak_hsts"}
         assert not any(f.check_type in header_types for f in findings)
 
     def test_error_result_skipped(self):
@@ -147,6 +149,48 @@ class TestWebCheckerHeaders:
         results = [_make_result(port_fk=port_fk, error="Connection refused")]
         findings = analyze(sess, results)
         assert len(findings) == 0
+
+
+@pytest.mark.django_db
+class TestWebCheckerHSTS:
+    def _make_port(self):
+        from apps.core.scans.models import ScanSession
+        from apps.core.assets.models import IPAddress, Port
+        sess = ScanSession.objects.create(domain="example.com", scan_type="full")
+        ip = IPAddress.objects.create(session=sess, address="1.2.3.4", version=4, source="dnsx")
+        p = Port.objects.create(session=sess, ip_address=ip, address="1.2.3.4",
+                                port=443, protocol="tcp", state="open", service="https", source="naabu")
+        return sess, p
+
+    def test_https_missing_hsts_medium(self):
+        sess, port_fk = self._make_port()
+        results = [_make_result(port_fk=port_fk, headers={})]
+        findings = analyze(sess, results)
+        f = next((f for f in findings if f.check_type == "missing_hsts"), None)
+        assert f is not None and f.severity == "medium"
+
+    def test_http_skips_hsts_check(self):
+        sess, port_fk = self._make_port()
+        results = [_make_result(port_fk=port_fk, url="http://example.com", headers={})]
+        findings = analyze(sess, results)
+        assert not any(f.check_type == "missing_hsts" for f in findings)
+
+    def test_hsts_max_age_less_than_six_months_low(self):
+        sess, port_fk = self._make_port()
+        results = [_make_result(port_fk=port_fk, headers={
+            "Strict-Transport-Security": "max-age=3600; includeSubDomains",
+        })]
+        findings = analyze(sess, results)
+        f = next((f for f in findings if f.check_type == "weak_hsts"), None)
+        assert f is not None and f.severity == "low"
+
+    def test_strong_hsts_no_finding(self):
+        sess, port_fk = self._make_port()
+        results = [_make_result(port_fk=port_fk, headers={
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        })]
+        findings = analyze(sess, results)
+        assert not any(f.check_type in {"missing_hsts", "weak_hsts"} for f in findings)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- add HTTPS-only Strict-Transport-Security checks to web_checker
- report missing HSTS as medium severity and weak/short max-age HSTS as low severity
- add unit coverage for missing, weak, strong, and HTTP-skip HSTS cases

Closes #17

## Tests
- Focused local pytest for `tests/unit/test_web_checker.py`: 38 passed

Note: I used a minimal local Django settings module for this focused test because installing the full project dependency set on this macOS machine failed while building `pycairo` from the PDF export dependency chain (`xhtml2pdf -> svglib -> rlpycairo -> pycairo`) due missing local cairo/pkg-config.