### PR TITLE
fix: remove vite* glob from react-stack dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,7 @@ updates:
         patterns:
           - "react"
           - "react-dom"
-          - "vite*"
+          - "@vitejs/plugin-react"
       shadcn-radix:
         patterns:
           - "@radix-ui/*"


### PR DESCRIPTION
## Summary
- `vite*` in the `react-stack` group was bundling Vite major bumps (5→8) with React updates
- `@vitejs/plugin-react@4.7.0` only supports up to Vite 7, so PRs #6 and #12 both failed with a peer-dep conflict
- Replaced `vite*` with `@vitejs/plugin-react` — Vite now gets its own standalone PR, and the react plugin stays grouped with React

## Test plan
- [ ] No CI changes needed — this only affects future Dependabot PR generation