### PR TITLE
fix: add vite back to react-stack dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,7 @@ updates:
         patterns:
           - "react"
           - "react-dom"
+          - "vite"
           - "@vitejs/plugin-react"
       shadcn-radix:
         patterns:


### PR DESCRIPTION
## Summary
- Reverts the previous grouping change: adds `vite` (exact name, not glob) back to `react-stack`
- Root cause: `@vitejs/plugin-react` v6 requires `vite@^8`, so react, react-dom, vite, and the plugin **must** upgrade atomically — Dependabot can't resolve the cascade if they're in separate PRs
- Using exact name `"vite"` instead of the old `"vite*"` glob to avoid pulling in unrelated `vite-plugin-*` packages

## Note
The bundled react-stack PR will still fail CI until a manual `feat/upgrade-react19-vite8` branch is created to handle any breaking changes in Vite 8 / React 19 / plugin-react 6. This config change ensures Dependabot bundles them correctly when that upgrade lands.