### PR TITLE
docs(readme): drop paid-consulting CTA from hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ docker run -d \
 
 Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced to set a new password) → add a domain → run a scan. Full env-var reference, update path, Kubernetes manifests, and standalone (no-Docker) install are under [Deployment](#deployment).
 
-**Prefer not to self-host?** See [cybersecify.com/openeasd](https://cybersecify.com/openeasd) for an overview of what OpenEASD covers. If you want help interpreting your findings, we offer a paid founder-led walkthrough — [Security on Demand](https://cybersecify.com/pricing/#consulting) (INR 9,999, fully refundable if we can't help).
-
 ## Features
 
 - **Automated pipeline** — 13-tool scan workflow from domain to findings


### PR DESCRIPTION
## Summary

Removes the "Prefer not to self-host? → Security on Demand INR 9,999" line from the README hero. It shipped in `2c9caeb` as part of the hero rewrite, but lands wrong for the ICP we're targeting on the GitHub side — bug bounty hunters, engineers, security folks. They'd react badly to a paid-consulting pitch on the front page of an OSS tool.

## Why

Already agreed during session strategy review:
- The website tier (domain + email + phone → we run it → emailed report) is the correct alt-path for "doesn't want to self-host"
- That form is being built jsprco-side; until it's live, the OpenEASD README hero is single-path (self-host via Docker)
- The cybersecify.com / paid consulting story belongs on cybersecify.com, not in our OSS repo's front page

## Test plan

- [x] `git diff` shows only the one paragraph removed; no other content changes
- [x] README still renders cleanly without that line — Quick start flows directly into Features
- [ ] When jsprco ships the snapshot form, follow-up PR adds the proper CTA pointing to it

## Notes

Heads-up: `xiaoke949/guard-surface-cn` (a responsible-fork Chinese localization that opened on the same day) inherited the README with the paid-CTA line still in it. Their fork is a snapshot — our fixes don't auto-propagate. They may choose to sync; their call, not ours.