### PR TITLE
docs(license): add Ashok S Kamat as co-copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Rathnakara G N / CyberSecify
+Copyright (c) 2026 Rathnakara G N and Ashok S Kamat / CyberSecify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -335,4 +335,4 @@ MIT License - see [LICENSE](LICENSE)
 
 ## Author
 
-[Rathnakara G N](https://cybersecify.com) / [CyberSecify](https://cybersecify.com)
+[Rathnakara G N](https://cybersecify.com) and [Ashok S Kamat](https://cybersecify.com) / [CyberSecify](https://cybersecify.com)


### PR DESCRIPTION
## Summary

LICENSE + README footer listed only Rathnakara G N; both co-founders should be on the copyright. Adds **Ashok S Kamat** alongside Rathnakara, year unchanged.

## Test plan

- [x] LICENSE diff — single line change, no other content
- [x] README diff — single line change in the Author footer
- [x] No code touched

## Notes

xiaoke949's `guard-surface-cn` fork inherited the prior LICENSE text. That's a snapshot; our update doesn't propagate. They can choose to sync the attribution if they want. Either way the MIT requirement they preserved (carrying the upstream copyright notice) is still met by what they have.