### PR TITLE
fix: add LinkedIn profile URLs to LICENSE copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Rathnakara G N and Ashok S Kamat / CyberSecify
+Copyright (c) 2026 Rathnakara G N (https://www.linkedin.com/in/rathnakaragn/) and Ashok S Kamat (https://www.linkedin.com/in/ashokskamat/) / CyberSecify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
Adds LinkedIn profile URLs alongside both authors in the LICENSE copyright line, consistent with the README footer.