### PR TITLE
fix(web_checker): deduplicate URLs by host — one fetch per host not per crawled path

### DIFF
--- a/apps/web_checker/collector.py
+++ b/apps/web_checker/collector.py
@@ -91,7 +91,21 @@ def collect(session) -> list[dict]:
     """
     from apps.core.web_assets.models import URL
 
-    urls = list(URL.objects.filter(session=session).select_related("port", "subdomain"))
+    # Deduplicate to one representative URL per (host, port_number).
+    # Security headers and cookies are server-wide — checking 50 katana-crawled
+    # paths on the same host would produce 50 identical findings and 50× the
+    # HTTP requests. httpx URLs (ordered first) are the canonical root URLs.
+    all_urls = URL.objects.filter(session=session).select_related(
+        "port", "subdomain"
+    ).order_by("source")  # "httpx" < "katana" alphabetically → httpx wins
+    seen_hosts: set[tuple] = set()
+    urls = []
+    for u in all_urls:
+        key = (u.host, u.port_number)
+        if key not in seen_hosts:
+            seen_hosts.add(key)
+            urls.append(u)
+
     if not urls:
         logger.info(f"[web_checker:{session.id}] No URLs to check")
         return []

--- a/tests/unit/test_web_checker.py
+++ b/tests/unit/test_web_checker.py
@@ -406,6 +406,73 @@ class TestWebCheckerCollector:
         results = collect(sess)
         assert results == []
 
+    def test_deduplicates_same_host_across_sources(self):
+        """katana URLs on same host as httpx URL must not produce a second fetch."""
+        from apps.core.scans.models import ScanSession
+        from apps.core.assets.models import Subdomain, IPAddress, Port
+        from apps.core.web_assets.models import URL
+
+        sess = ScanSession.objects.create(domain="example.com", scan_type="full")
+        ip = IPAddress.objects.create(session=sess, address="1.2.3.4", version=4, source="dnsx")
+        port = Port.objects.create(session=sess, ip_address=ip, address="1.2.3.4",
+                                   port=443, protocol="tcp", state="open", source="naabu")
+        sub = Subdomain.objects.create(session=sess, domain="example.com",
+                                       subdomain="www.example.com", source="subfinder")
+        URL.objects.create(session=sess, subdomain=sub, port=port,
+                           url="https://www.example.com", host="www.example.com",
+                           port_number=443, scheme="https", source="httpx")
+        # Katana adds multiple crawled paths on the same host
+        for path in ["/admin", "/login", "/api/docs"]:
+            URL.objects.create(session=sess, subdomain=sub, port=port,
+                               url=f"https://www.example.com{path}",
+                               host="www.example.com", port_number=443,
+                               scheme="https", source="katana")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.text = ""
+        mock_resp.raw.headers.getlist.return_value = []
+        mock_resp.cookies = []
+
+        with patch("apps.web_checker.collector.requests.get", return_value=mock_resp) as mock_get:
+            results = collect(sess)
+
+        # Only 1 fetch for www.example.com:443 despite 4 URLs in the session
+        assert mock_get.call_count == 1
+        assert len(results) == 1
+
+    def test_different_hosts_each_get_fetched(self):
+        """Two different subdomains on the same port → two fetches."""
+        from apps.core.scans.models import ScanSession
+        from apps.core.assets.models import Subdomain, IPAddress, Port
+        from apps.core.web_assets.models import URL
+
+        sess = ScanSession.objects.create(domain="example.com", scan_type="full")
+        ip = IPAddress.objects.create(session=sess, address="1.2.3.4", version=4, source="dnsx")
+        # Both subdomains share the same IP:port (common behind a CDN/load balancer)
+        port = Port.objects.create(session=sess, ip_address=ip, address="1.2.3.4",
+                                   port=443, protocol="tcp", state="open", source="naabu")
+        for host in ["www.example.com", "api.example.com"]:
+            sub = Subdomain.objects.create(session=sess, domain="example.com",
+                                           subdomain=host, source="subfinder")
+            URL.objects.create(session=sess, subdomain=sub, port=port,
+                               url=f"https://{host}", host=host,
+                               port_number=443, scheme="https", source="httpx")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.text = ""
+        mock_resp.raw.headers.getlist.return_value = []
+        mock_resp.cookies = []
+
+        with patch("apps.web_checker.collector.requests.get", return_value=mock_resp) as mock_get:
+            results = collect(sess)
+
+        assert mock_get.call_count == 2
+        assert len(results) == 2
+
 
 # ---------------------------------------------------------------------------
 # Scanner orchestrator


### PR DESCRIPTION
## Problem

Adding katana (Phase 9) exposed a bug: `web_checker/collector.py` queried all session URLs without filtering by source. With katana crawling hundreds of paths per host, this caused:
- Duplicate findings: "Missing CSP on https://example.com/admin", "Missing CSP on https://example.com/login", etc. — same header, 50× the findings
- 50× the HTTP requests (katana paths × 10s timeout = very slow)

## Fix

Deduplicate to one representative URL per `(host, port_number)` before fetching. httpx URLs are preferred (ordered first alphabetically). Security headers, HSTS, server disclosure, and directory listing are server-wide — per-path deduplication is correct.

## Tests added
- `test_deduplicates_same_host_across_sources`: 1 httpx + 3 katana paths on same host → 1 fetch
- `test_different_hosts_each_get_fetched`: 2 different subdomains → 2 fetches

726 tests pass.