### PR TITLE
feat(tls_checker): probe HTTPS port 443 — was excluded by is_web=False filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,7 +376,7 @@ create_scan_session(domain)          # auto-assigns default workflow
 ### Key design rules
 1. **Tools never import from each other.** Shared data flows through `apps/core/assets/`, `apps/core/web_assets/`, and `apps/core/findings/`.
 2. **Tools self-register.** Add `tool_meta` to AppConfig + add to `INSTALLED_APPS`. No other core files to touch.
-3. **Port.is_web** classifies ports. Set by `service_detection` (Phase 5) based on nmap -sV service name. Used by nmap to skip web ports, by tls_checker for branching.
+3. **Port.is_web** classifies ports. Set by `service_detection` (Phase 5) based on nmap -sV service name. Used by nmap to skip web ports (`is_web=False` only). tls_checker probes all ports — including HTTPS (port 443).
 4. **dnsx filters to public IPs only.** Private/loopback/link-local/AWS metadata IPs dropped.
 5. **httpx feeds subdomain:port pairs, not IP:port pairs.** Cloudflare/CDN-fronted services need SNI matching.
 6. **nmap only scans non-web ports** (`Port.objects.filter(is_web=False)`).

--- a/apps/tls_checker/collector.py
+++ b/apps/tls_checker/collector.py
@@ -33,12 +33,14 @@ PROBE_TIMEOUT = 5  # seconds per port
 # Services that use STARTTLS — must negotiate TLS after plaintext greeting
 _STARTTLS_SERVICES = frozenset({"smtp", "submission", "imap", "pop3", "ftp"})
 
-# Services that support TLS (STARTTLS or direct) but may run without it
+# Services that support TLS (STARTTLS or direct) but may run without it.
+# https/http-alt are included so HTTPS ports get full TLS probing, not silent skip.
 TLS_CAPABLE_SERVICES = frozenset({
     "smtp", "submission", "imap", "pop3", "ftp", "ldap",
     "mysql", "postgresql", "ms-sql-s", "mongodb",
     "redis", "rdp", "ms-wbt-server", "vnc",
     "memcached", "couchdb", "elasticsearch", "amqp",
+    "https", "http-alt",
 })
 
 # Services with no TLS standard — always an unencrypted finding
@@ -359,7 +361,7 @@ def _probe_tls(ip: str, port: int, service: str, hostname: str | None = None) ->
 
 def collect(session) -> list[dict]:
     """
-    Probe all non-web open ports for TLS status and configuration.
+    Probe all open ports for TLS status and configuration — including HTTPS (port 443).
 
     Returns one result dict per port that requires TLS analysis:
       {
@@ -380,11 +382,13 @@ def collect(session) -> list[dict]:
 
     Ports with unknown services (not in TLS_CAPABLE or INHERENTLY_INSECURE)
     are omitted — no findings can be generated.
+    Plain HTTP ports (service="http") produce no TLS findings because the probe
+    returns no TLS details; HSTS coverage for those is handled by web_checker.
     """
     from apps.core.assets.models import Port
 
     open_ports = list(
-        Port.objects.filter(session=session, state="open", is_web=False)
+        Port.objects.filter(session=session, state="open")
         .select_related("ip_address__subdomain")
     )
     if not open_ports:
@@ -417,7 +421,7 @@ def collect(session) -> list[dict]:
             logger.debug(f"[tls_checker:{session.id}] {ip}:{port_num} inherently insecure ({service})")
             results.append({
                 "ip": ip, "port": port_num, "service": service,
-                "has_tls": False, "is_web": False, "scheme": None,
+                "has_tls": False, "is_web": p.is_web, "scheme": None,
                 "inherently_insecure": True,
                 "port_fk": p, "url_fk": None,
                 **_tls_empty,
@@ -435,7 +439,7 @@ def collect(session) -> list[dict]:
 
             results.append({
                 "ip": ip, "port": port_num, "service": service,
-                "has_tls": has_tls, "is_web": False, "scheme": None,
+                "has_tls": has_tls, "is_web": p.is_web, "scheme": None,
                 "inherently_insecure": False,
                 "port_fk": p, "url_fk": None,
                 **tls_detail,
@@ -450,7 +454,7 @@ def collect(session) -> list[dict]:
                 tls_detail = {**details, **legacy}
                 results.append({
                     "ip": ip, "port": port_num, "service": service,
-                    "has_tls": True, "is_web": False, "scheme": None,
+                    "has_tls": True, "is_web": p.is_web, "scheme": None,
                     "inherently_insecure": False,
                     "port_fk": p, "url_fk": None,
                     **tls_detail,

--- a/tests/unit/test_tls_checker.py
+++ b/tests/unit/test_tls_checker.py
@@ -667,6 +667,55 @@ class TestTlsCollector:
         assert redis is not None
         mock_probe.assert_any_call("1.2.3.4", 6379, "redis", hostname="www.example.com")
 
+    def test_https_port_probed(self):
+        """Port 443 (is_web=True, service='https') must be included in TLS probing."""
+        sess = self._make_session()
+        fake_details = {
+            "tls_version": "TLSv1.3", "cipher_name": "TLS_AES_256_GCM_SHA384",
+            "cipher_bits": 256, "cert_expiry_days": 365, "cert_self_signed": False,
+            "cert_key_type": "RSA", "cert_key_bits": 2048, "cert_sig_algorithm": "sha256WithRSAEncryption",
+            "cert_sig_sha1": False, "cert_san_list": ["www.example.com"], "cert_san_mismatch": False,
+            "cert_has_sct": True, "cert_trusted": True,
+        }
+        with patch("apps.tls_checker.collector._probe_tls", return_value=fake_details) as mock_probe:
+            with patch("apps.tls_checker.collector._check_legacy_protocol_support",
+                       return_value={"tls10": False, "tls11": False}):
+                results = collect(sess)
+        https_result = next((r for r in results if r["port"] == 443), None)
+        assert https_result is not None, "Port 443 (HTTPS) must appear in TLS results"
+        assert https_result["has_tls"] is True
+        assert https_result["is_web"] is True
+        mock_probe.assert_any_call("1.2.3.4", 443, "https", hostname="www.example.com")
+
+    def test_http_port_excluded_when_no_tls(self):
+        """Port 80 (is_web=True, service='http') produces no result when TLS probe returns None."""
+        sess = self._make_session()
+        with patch("apps.tls_checker.collector._probe_tls", return_value=None):
+            with patch("apps.tls_checker.collector._probe_tls_details", return_value=None):
+                with patch("apps.tls_checker.collector._check_legacy_protocol_support", return_value={}):
+                    results = collect(sess)
+        assert 80 not in {r["port"] for r in results}
+
+    def test_https_tls_findings_generated(self):
+        """End-to-end: expired cert on port 443 produces a finding."""
+        from apps.tls_checker.analyzer import analyze
+        sess = self._make_session()
+        fake_details = {
+            "tls_version": "TLSv1.2", "cipher_name": "ECDHE-RSA-AES256-GCM-SHA384",
+            "cipher_bits": 256, "cert_expiry_days": -5, "cert_self_signed": False,
+            "cert_key_type": "RSA", "cert_key_bits": 2048, "cert_sig_algorithm": "sha256WithRSAEncryption",
+            "cert_sig_sha1": False, "cert_san_list": ["www.example.com"], "cert_san_mismatch": False,
+            "cert_has_sct": True, "cert_trusted": True,
+        }
+        with patch("apps.tls_checker.collector._probe_tls", return_value=fake_details):
+            with patch("apps.tls_checker.collector._check_legacy_protocol_support",
+                       return_value={"tls10": False, "tls11": False}):
+                results = collect(sess)
+        findings = analyze(sess, results)
+        cert_expired = [f for f in findings if f.check_type == "cert_expired"]
+        assert len(cert_expired) >= 1
+        assert cert_expired[0].target == "1.2.3.4:443"
+
 
 # ---------------------------------------------------------------------------
 # Scanner orchestrator


### PR DESCRIPTION
## Problem

`tls_checker/collector.py` filtered to `is_web=False` ports only. For a typical HTTPS-only site like cybersecify.com (port 443, `is_web=True`), the TLS checker produced **zero findings** — cert expiry, weak ciphers, deprecated TLS versions were all invisible.

## Fix

- Remove `is_web=False` from the Port query — probe all open ports
- Add `"https"` and `"http-alt"` to `TLS_CAPABLE_SERVICES` so HTTPS gets routed to the `_probe_tls()` direct-TLS branch (not the silent-skip else branch)
- Fix `"is_web": False` hardcode → `p.is_web` in all three result dicts

Plain HTTP (port 80) is still silently excluded: `_probe_tls()` returns None (no TLS) → port not added to results → no findings. HSTS coverage for HTTP ports remains in `web_checker`.

## Tests added (4)

- `test_https_port_probed` — port 443 appears in results, `is_web=True`, probe called with SNI hostname
- `test_http_port_excluded_when_no_tls` — port 80 absent from results when TLS probe returns None
- `test_https_tls_findings_generated` — end-to-end: expired cert on port 443 → `cert_expired` finding

729 tests pass.