### PR TITLE
fix: replace xml.etree.ElementTree with defusedxml in tls_checker

### DIFF
--- a/apps/tls_checker/collector.py
+++ b/apps/tls_checker/collector.py
@@ -21,7 +21,7 @@ import smtplib
 import socket
 import ssl
 import subprocess
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from django.utils import timezone as django_tz
 


### PR DESCRIPTION
## Summary

Fixes the bandit B314 (medium severity, high confidence) failure in CI:

```
Issue: [B314] Using xml.etree.ElementTree.fromstring to parse untrusted XML
Location: apps/tls_checker/collector.py:381
```

`defusedxml` is already in `pyproject.toml`. Swapping the import is the correct fix — it protects against XML bomb / entity expansion attacks on nmap output and silences the SAST warning cleanly.

## Test plan
- [ ] 87 `test_tls_checker.py` tests pass
- [ ] `bandit -r apps/tls_checker/collector.py -ll` reports 0 medium/high issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)