### PR TITLE
feat: backport-aware CVE matching to reduce false positives

### DIFF
--- a/apps/nmap/analyzer.py
+++ b/apps/nmap/analyzer.py
@@ -6,6 +6,7 @@ import defusedxml.ElementTree as ET
 
 from apps.core.assets.models import Port
 from apps.core.findings.models import Finding
+from apps.nmap.backports import check_backport
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +106,7 @@ def analyze(session, xml_outputs: dict[str, str]) -> list[Finding]:
                 if service_el is not None:
                     product = service_el.get("product", "")
                     ver = service_el.get("version", "")
+                    extrainfo = service_el.get("extrainfo", "")
                     version = f"{product} {ver}".strip()
 
                 port_fk = port_map.get((ip, port_num))
@@ -129,24 +131,35 @@ def analyze(session, xml_outputs: dict[str, str]) -> list[Finding]:
                             continue
                         seen.add(key)
 
+                        extra = {
+                            "cve": v["id"],
+                            "cvss_score": v["cvss"],
+                            "service": service_name,
+                            "version": version,
+                            "nse_script": "vulners",
+                            "port_number": port_num,
+                            "address": ip,
+                        }
+                        
+                        severity = _severity_from_cvss(v["cvss"])
+                        
+                        # Check backports
+                        full_version_string = f"{version} {extrainfo}".strip()
+                        backport_info = check_backport(product, full_version_string, v["id"])
+                        if backport_info:
+                            severity = "info"
+                            extra.update(backport_info)
+
                         findings.append(Finding(
                             session=session,
                             source="nmap",
                             check_type="cve",
                             port=port_fk,
                             target=f"{ip}:{port_num}",
-                            severity=_severity_from_cvss(v["cvss"]),
+                            severity=severity,
                             title=f"{v['id']} on {service_name or 'unknown'} {version}".strip(),
                             description=output[:2000],
-                            extra={
-                                "cve": v["id"],
-                                "cvss_score": v["cvss"],
-                                "service": service_name,
-                                "version": version,
-                                "nse_script": "vulners",
-                                "port_number": port_num,
-                                "address": ip,
-                            },
+                            extra=extra,
                         ))
 
     return findings

--- a/apps/nmap/backports.json
+++ b/apps/nmap/backports.json
@@ -1,0 +1,6 @@
+{
+  "ubuntu": {
+    "CVE-2024-6387": {"openssh": "3ubuntu13.3"},
+    "CVE-2024-39894": {"openssh": "3ubuntu13.4"}
+  }
+}

--- a/apps/nmap/backports.py
+++ b/apps/nmap/backports.py
@@ -1,0 +1,85 @@
+import json
+import re
+from pathlib import Path
+
+BACKPORTS_FILE = Path(__file__).parent / "backports.json"
+
+def _load_backports():
+    if not BACKPORTS_FILE.exists():
+        return {}
+    with open(BACKPORTS_FILE, "r") as f:
+        return json.load(f)
+
+BACKPORTS = _load_backports()
+
+def compare_debian_versions(v1: str, v2: str) -> int:
+    """
+    Simplified Debian version compare.
+    Returns 1 if v1 > v2, -1 if v1 < v2, 0 if v1 == v2.
+    """
+    def parse_parts(v):
+        return [int(x) if x.isdigit() else x for x in re.split(r'([0-9]+)', v) if x]
+    
+    p1 = parse_parts(v1)
+    p2 = parse_parts(v2)
+    
+    for a, b in zip(p1, p2):
+        if a == b:
+            continue
+        if type(a) == type(b):
+            return 1 if a > b else -1
+        # In debian, strings and numbers compare strangely, but casting to str works for most simple cases
+        return 1 if str(a) > str(b) else -1
+        
+    if len(p1) > len(p2):
+        return 1
+    elif len(p1) < len(p2):
+        return -1
+    return 0
+
+def check_backport(product: str, version_string: str, cve: str) -> dict:
+    """
+    Checks if a CVE has been patched via backport based on the version string.
+    Returns a dict with demote information if a backport is applied, else None.
+    """
+    if not version_string or not product:
+        return None
+        
+    product = product.lower()
+    
+    # Identify distro and distro-specific version from nmap extrainfo strings.
+    # Examples:
+    #   "OpenSSH 9.6p1 Ubuntu Linux; 3ubuntu13.4"
+    #   "OpenSSH 9.6p1 Ubuntu-3ubuntu13.4"
+    #   "OpenSSH 8.4p1 Debian-5+deb11u3"
+    match = re.search(r'(?i)(ubuntu|debian)(?:\s+linux)?[-; ]+([a-z0-9.~+-]+)', version_string)
+    
+    distro = None
+    distro_version = None
+    
+    if match:
+        distro = match.group(1).lower()
+        distro_version = match.group(2).strip()
+                
+    if not distro or not distro_version:
+        return None
+        
+    distro_data = BACKPORTS.get(distro, {})
+    cve_data = distro_data.get(cve)
+    if not cve_data:
+        return None
+        
+    # Get the fixed version for this product
+    fixed_version = cve_data.get(product)
+    if not fixed_version:
+        return None
+        
+    # Compare distro_version with fixed_version
+    # If installed version >= fixed_version, it is patched
+    if compare_debian_versions(distro_version, fixed_version) >= 0:
+        return {
+            "backport_applied": True,
+            "first_fixed_in": fixed_version
+        }
+        
+    return None

--- a/tests/unit/test_nmap.py
+++ b/tests/unit/test_nmap.py
@@ -221,6 +221,70 @@ class TestNmapAnalyzer:
 
 
 # ---------------------------------------------------------------------------
+# Backport XML Matching
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestBackportMatching:
+    SAMPLE_XML_UBUNTU = """<?xml version="1.0"?>
+<nmaprun>
+<host>
+<address addr="1.2.3.4" addrtype="ipv4"/>
+<ports><port protocol="tcp" portid="22">
+<state state="open"/>
+<service name="ssh" product="OpenSSH" version="9.6p1" extrainfo="Ubuntu Linux; 3ubuntu13.4"/>
+<script id="vulners">
+<table key="cpe:/a:openbsd:openssh:9.6p1">
+<table>
+<elem key="id">CVE-2024-6387</elem>
+<elem key="cvss">8.1</elem>
+<elem key="type">cve</elem>
+</table>
+<table>
+<elem key="id">CVE-2024-39894</elem>
+<elem key="cvss">5.3</elem>
+<elem key="type">cve</elem>
+</table>
+</table>
+</script>
+</port></ports>
+</host>
+</nmaprun>
+"""
+
+    def _make_session(self):
+        from apps.core.scans.models import ScanSession
+        from apps.core.assets.models import IPAddress, Port
+        sess = ScanSession.objects.create(domain="example.com", scan_type="full")
+        ip = IPAddress.objects.create(session=sess, address="1.2.3.4", version=4, source="dnsx")
+        Port.objects.create(
+            session=sess, ip_address=ip, address="1.2.3.4", port=22,
+            protocol="tcp", state="open", source="naabu",
+        )
+        return sess
+
+    @patch("apps.nmap.backports.BACKPORTS", {
+        "ubuntu": {
+            "CVE-2024-6387": {"openssh": "3ubuntu13.3"}
+        }
+    })
+    def test_backport_applied_demotes_to_info(self):
+        sess = self._make_session()
+        findings = analyze(sess, {"1.2.3.4": self.SAMPLE_XML_UBUNTU})
+        
+        by_cve = {f.cve: f for f in findings}
+        
+        # CVE-2024-6387 is patched in 3ubuntu13.3, and we are running 3ubuntu13.4 -> info
+        f1 = by_cve["CVE-2024-6387"]
+        assert f1.severity == "info"
+        assert f1.extra.get("backport_applied") is True
+        
+        # CVE-2024-39894 is not in our mock BACKPORTS -> original severity
+        f2 = by_cve["CVE-2024-39894"]
+        assert f2.severity == "medium"
+        assert f2.extra.get("backport_applied") is None
+
+# ---------------------------------------------------------------------------
 # Web/non-web classification via Port.is_web
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #43.

Nmap's --script vulners reports CVEs based on the upstream version string (e.g., OpenSSH 9.6p1), but Linux distros like Ubuntu and Debian backport security patches without bumping the upstream version. This causes a flood of **false-positive** findings that waste analyst time.

This PR adds a lightweight backport-matching layer that:

1. **Parses the nmap extrainfo attribute** to detect the distro and its package version (e.g., Ubuntu Linux; 3ubuntu13.4).
2. **Checks a curated ackports.json registry** mapping (distro, CVE, package) → first-fixed-version.
3. **Demotes patched CVEs to info severity** instead of suppressing them, and tags the finding with ackport_applied: true so analysts retain full visibility.

### Files Changed

| File | Change |
|------|--------|
| pps/nmap/backports.json | **New** — curated backport registry (Ubuntu OpenSSH seed data) |
| pps/nmap/backports.py | **New** — distro detection, version comparison, and backport check |
| pps/nmap/analyzer.py | **Modified** — extracts extrainfo, invokes backport logic, demotes severity |
| 	ests/unit/test_nmap.py | **Modified** — adds TestBackportMatching class with patched/unpatched assertions |

### Test Results

All **23 tests pass** (22 existing + 1 new backport test).

### Design Decisions

- **Demote to info instead of suppress**: Analysts can still see the CVE was scanned and filtered, rather than silently hiding it.
- **No external dependencies**: Uses a lightweight native Python version comparator instead of python-debian to keep the dependency footprint minimal.
- **Extensible registry**: Adding new backports is as simple as editing the JSON file — no code changes required.