### PR TITLE
docs(readme): fix broken Docker Image badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Stars](https://img.shields.io/github/stars/cybersecify/OpenEASD?style=social)](https://github.com/cybersecify/OpenEASD/stargazers)
 [![CI](https://github.com/cybersecify/OpenEASD/actions/workflows/ci.yml/badge.svg)](https://github.com/cybersecify/OpenEASD/actions/workflows/ci.yml)
-[![Docker Image](https://ghcr-badge.egpl.dev/cybersecify/openeasd/latest_tag?trim=major&label=ghcr.io)](https://github.com/cybersecify/OpenEASD/pkgs/container/openeasd)
+[![Docker Image](https://img.shields.io/badge/ghcr.io%2Fcybersecify%2Fopeneasd-latest-2496ed?logo=docker&logoColor=white)](https://github.com/cybersecify/OpenEASD/pkgs/container/openeasd)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **See your domain like an attacker does.** OpenEASD is a self-hosted scanner that wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `dnsx`, `naabu`, `httpx`, `nuclei`, `nmap` — behind a single web UI with scheduling, alerts, and findings tracking. Free, MIT-licensed, one `docker run`. Results stay on your machine.


### PR DESCRIPTION
## Summary

The Docker Image badge in the README has been rendering as a broken-image icon. Root cause: the badge provider (`ghcr-badge.egpl.dev`) is hosted on Render's free tier and has been suspended — returns HTTP 503 with `x-render-routing: suspend`.

Image itself is healthy:
```
$ docker manifest inspect ghcr.io/cybersecify/openeasd:latest
mediaType: application/vnd.oci.image.index.v1+json — 4 architectures present
```

## Fix

Switching to a static `shields.io` badge that:
- Renders reliably (shields.io is well-maintained, not on free Render)
- Shows the Docker logo
- Links to https://github.com/cybersecify/OpenEASD/pkgs/container/openeasd where users see real tag versions

## Trade-off

Static badge says "latest" instead of dynamically reading the latest tag. Fine for a project README — the badge's job is "image is published, click here for tags," and the link delivers that.

## Test plan

- [x] New badge URL verified: `curl -sI` returns `HTTP/2 200, content-type: image/svg+xml`
- [x] Click target unchanged (still points to GHCR package page)
- [x] Single-line change, no other content affected