### PR TITLE
docs(prd): refresh end-to-end + add agentic AI roadmap direction

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -18,7 +18,8 @@ Existing commercial tools (Shodan, Censys, AttackSurfaceMapper) are expensive, c
 
 **Stakeholders:**
 - Open source community (contributors, users)
-- Rathnakara G N (creator, Cybersecify)
+- Rathnakara G N (co-creator, Cybersecify)
+- Ashok S Kamat (co-creator, Cybersecify)
 
 ## What
 
@@ -36,17 +37,19 @@ A self-hosted web platform that automatically discovers and monitors an organiza
 - Add domains and run on-demand or scheduled scans
 - View findings by severity with remediation guidance
 - Track finding lifecycle (open → acknowledged → resolved)
-- Export reports (CSV, PDF)
-- Get alerted via Slack/Teams when new issues are found
+- Export reports (CSV, PDF) with optional minimum-severity filter
+- Get alerted via Slack/Teams when new issues are found, configurable from the UI without restart
+- Continuous per-domain monitoring on configurable interval (6h / 12h / 24h / 48h / weekly)
+- Subscan — re-run a subset of tools against an existing scan's assets without repeating discovery
 - See trends and insights over time
 - JWT-authenticated REST API with OpenAPI docs
 
 ## Where
 
-- **Deployment:** Self-hosted (local machine, VPS, Docker)
+- **Deployment:** Self-hosted (local machine, VPS, Docker, Kubernetes)
 - **Access:** Web browser (React SPA at `/`)
 - **API:** REST API at `/api/` with Swagger UI at `/api/docs`
-- **Distribution:** Open source on GitHub
+- **Distribution:** Open source on GitHub (`ghcr.io/cybersecify/openeasd:latest`)
 
 ## When
 
@@ -65,7 +68,7 @@ A self-hosted web platform that automatically discovers and monitors an organiza
 - Unified finding model across all tools
 - Finding lifecycle tracking (open, acknowledged, resolved, false positive)
 - CSV and PDF report export
-- Async task queue via Huey (no more silent thread crashes)
+- Async task queue via Huey (later replaced by Django-Q2 in v0.5)
 - Configurable scan workflows (enable/disable tools)
 - Performance improvements (query optimization)
 
@@ -79,36 +82,69 @@ A self-hosted web platform that automatically discovers and monitors an organiza
 
 **v0.4 — Network Vuln Expansion + Active Recon**
 - Amass integration for active subdomain enumeration (Phase 2)
-- Nuclei Network scanner for network protocol vulnerabilities (Phase 7, 319 templates)
+- Nuclei Network scanner for network protocol vulnerabilities (Phase 7, service-aware nuclei network templates against non-web ports)
 - Nuclei Network runs after service detection, targets non-web ports
-
-**v1.0 — Stable Public Release**
 - Django Ninja REST API replacing plain JsonResponse views
 - JWT Bearer authentication (access + refresh tokens, JTI blacklist)
 - Auto-generated OpenAPI docs at `/api/docs`
 - `main.py` single-command launcher (auto-migrate, first-run admin creation)
-- ~598 automated tests covering all modules
-- Dead code cleanup — removed 5 legacy orphaned app directories
+- Dead code cleanup — removed legacy orphaned app directories
+
+**v0.5 — Community Infra + Pipeline Polish + First External Contributors** *(2026-05-31)*
+- **First two outside contributors converted on the same day the community infra went live**: `@xiaoke949` shipped HSTS checks (PR #22); `@turfin-logic` shipped backport-aware CVE matching (PR #56). Validated the discovery-via-label hypothesis with hard data — both arrived via GitHub-internal surfaces, zero external referrers.
+- **HSTS checks in web_checker** — `missing_hsts` (medium) on HTTPS responses without `Strict-Transport-Security`; `weak_hsts` (low) when `max-age` < 6 months. Contributed by @xiaoke949.
+- **Backport-aware CVE matching in nmap analyzer** — distro-backported CVE fixes (Ubuntu USNs, Debian Security Tracker) are recognised and suppressed/demoted via a curated `backports.json`, so already-patched hosts no longer trigger false-positive CVE findings. Contributed by @turfin-logic.
+- **Continuous monitoring** — per-domain rescans at configurable intervals (6h/12h/24h/48h/weekly), managed via Django-Q2 schedules
+- **Subscan** — re-run specific tools (e.g. Nuclei + TLS Checker) on an existing completed scan's assets without repeating discovery
+- **Notifications UI** — Slack and Teams webhooks + severity threshold configurable in-app without restart; per-channel Test button and alert history with pagination
+- **Katana URL crawler** (Phase 9) — deep URL discovery on top of httpx's first-level probe
+- **CSV/PDF export filter** — `?min_severity=` query param + UI dropdown so exports can be limited to high/critical
+- **Setup wizard Copy button** — one-click clipboard for the `docker run` snippet
+- **APScheduler replaced by Django-Q2** — one task queue, one scheduler, fewer dependencies; `croniter` added for CRON schedules
+- **GitHub Flow workflow adopted** — `feat/` / `fix/` branch + PR + squash-merge; ends the solo-developer direct-push pattern
+- **Frontend stack upgrade** — React 19, Vite 8, `@vitejs/plugin-react` 6 (coupled package set in dependabot grouping)
+- **Co-founder attribution** — LICENSE, README, `pyproject.toml`, and `PRD.md` updated to credit both co-creators with LinkedIn profile links
+- **Community infrastructure** — `CONTRIBUTING.md`, `SECURITY.md` (with GitHub Private Vulnerability Reporting enabled), issue templates (Bug / Feature / New Tool), PR template, Dependabot config with grouped weekly PRs, Discussions tab enabled, repo topics expanded from 7 to 17
+- **Tool startup health check** — `tools_healthcheck` management command probes all 8 external tools at container boot, surfaces silent-failure modes early
+- **Partial-status watchdog** — scans reaped by the 90-min watchdog are marked `partial` (not `failed`) if any pipeline step completed, preserving the findings that were captured before the reap
+- **README hero rewrite** — sharpened "see your domain like an attacker does" framing + live scan screenshot of a real `nmap.org` scan
+- **README claims-trace audit** — every customer-visible README claim grep-verified against analyzer/scanner code; two drifts corrected (nuclei "319 templates" → timeless phrasing; PyJWT → django-ninja-jwt)
+- **Documentation discipline** — every CHANGELOG entry, PR body, and non-trivial commit now captures What / Why / Hypothesis / Evidence (data-oriented vs speculative vs user-driven vs external-signal) so future readers can reconstruct the reasoning
 
 ### Planned
 
-**v1.1 — Deployment Ready**
-- Docker Compose setup (one-command deploy)
-- Environment configuration guide (`.env.example`)
-- Production deployment guide (nginx + gunicorn)
-- GitHub Actions CI pipeline
+**v1.0 — First stable public release**
+- Cut a real `v1.0` git tag (current latest tag is `v0.3`; v0.4 and v0.5 work is on `main` but untagged)
+- Tag-aligned launch sequence: Show HN + r/netsec + r/blueteamsec post; submit to `awesome-security`, `awesome-pentest`, `awesome-osint`, `awesome-selfhosted`
+- Demo GIF in README (30s of a real scan completing) replacing the static screenshot
+- Twitter/X seed post with a real (sanitised) finding
+- `backports.json` seed dataset expanded beyond Ubuntu LTS / Debian stable to RHEL/Rocky/Alma and Alpine for the noisiest CVE false positives
 
-**v1.2 — Collaboration + Usability**
-- Finding assignment to team members
-- Comments on findings
-- Email notifications
+**v1.x — Collaboration + Usability**
+- Finding assignment to team members; comments on findings; email notifications
 - Dashboard customization
 
-**v1.3 — Advanced Scanning**
+**v1.x — Advanced Scanning**
 - Custom Nuclei template support
-- Scan diff view (visual delta between scans)
+- Visual scan diff view (delta between scans rendered as a graph)
 - Asset tagging and grouping
+
+**v2.0 — Agentic AI OpenEASD** *(direction set 2026-05-31, design TBD)*
+
+Direction: turn OpenEASD from a scanner that emits findings into an analyst that produces prioritised, contextualised remediation guidance. Move from "here are 76 findings, 3 critical" to "here are the 3 things that actually matter on this surface, here's why, here's the fix in order."
+
+Candidate scopes (specific shape to be defined — these are sketches, not commitments):
+
+- **LLM-powered triage** — feed scan output + asset context + organisation profile into an LLM that produces a ranked "fix this first" list with reasoning, not just raw CVE/severity dumps
+- **Chat interface over findings** — "show me everything critical on `staging.example.com`", "summarise this scan in one paragraph", "what's the biggest delta from last week's scan?"
+- **Auto-generated tool integrations** — an agent that reads a new scanner tool's docs/GitHub README and produces a draft of the four-file plugin (`apps.py`, `collector.py`, `analyzer.py`, `scanner.py`) for human review
+- **Multi-agent recon planning** — a coordinating agent that decides which scanners to run based on initial discovery (e.g., "host runs Postfix on 25 — load the email-relay-misconfig profile" rather than blindly running every Phase-7 tool)
+- **Remediation playbooks** — auto-generated step-by-step fix guides per finding type, with reasoning the user can verify
+
+**Hypothesis:** AI turns OpenEASD from "another scanner wrapper" into an analyst-grade tool. The current OSS recon-tool space is saturated with wrappers; analyst-grade output is genuinely scarce. If we ship even one of the candidate scopes well, it becomes the durable differentiation vs. running `nuclei + nmap + subfinder` by hand.
+
+**Status:** planning phase. Specific scope, model selection (local LLM vs API), cost-per-scan envelope, and user opt-in mechanics all undefined. Decision needed before any code is committed.
 
 ---
 
-*This document tracks what we're building and why. Technical details live in CLAUDE.md.*
+*This document tracks what we're building and why. Technical details live in CLAUDE.md. Per-version detail lives in CHANGELOG.md (with the What/Why/Hypothesis/Evidence discipline).*


### PR DESCRIPTION
## What

End-to-end refresh of `PRD.md`. Three drift fixes, two missing version sections added, v1.0 reframed from "delivered" to "planned" (latest git tag is `v0.3`), and a new **v2.0 — Agentic AI** direction added.

## Why

PRD is the strategy document new contributors and users read to understand where the project is heading. Stale claims (`319 templates` that don't appear in code; v1.0 listed as delivered when it isn't tagged; `Huey` when we moved to Django-Q2) erode the "claims trace to reality" discipline locked in the README claims-trace audit (`390ff1f`).

## Hypothesis

A current PRD will (a) increase contributor trust ("they maintain their own docs"), (b) set right v1.0 launch expectations rather than the rolling "v1.0 happens someday" ambiguity, (c) signal the agentic-AI direction publicly so contributors with relevant skills (LLM evals, prompt design, agent frameworks) can volunteer.

## Evidence

**Data-oriented.**

| Drift item | Pre-PR state | Post-PR state |
|---|---|---|
| `Huey` reference | Line 68 said "Async task queue via Huey" | "via Huey (later replaced by Django-Q2 in v0.5)" — flags the migration explicitly |
| `319 templates` | Line 82 had the exact number | Reworded to "service-aware nuclei network templates against non-web ports" (same fix as README in `390ff1f`) |
| v1.0 misframed | Listed as "Delivered" | Moved to **Planned** with clear "next milestone is tag + launch sequence" framing |
| v0.4 missing | No section despite content existing on `main` | New section added with accurate content |
| v0.5 missing | No section despite CHANGELOG having `[v0.5] — 2026-05-31` | New section added; mirrors CHANGELOG; explicitly credits @xiaoke949 and @turfin-logic |
| Agentic AI direction | Not captured | **New v2.0 section** with 5 candidate scopes, explicitly flagged as design-TBD not commitment |

**Verification commands:**
- `grep -rn Huey apps/` → 0 matches (codebase moved to Django-Q2)
- `grep -rn "319" apps/nuclei_network/` → 0 matches
- `git tag --sort=-v:refname` → `v0.3` is latest, no v0.4/v0.5/v1.0 tags exist
- `grep -nE "^## \[v" CHANGELOG.md` → `## [v0.5] — 2026-05-31`

## v2.0 — Agentic AI direction

Direction is set; specific scope is **not yet committed**. Five candidate scopes outlined in the PRD:
- LLM-powered triage (ranked "fix this first" list with reasoning)
- Chat interface over findings
- Auto-generated tool integrations (LLM reads scanner docs → drafts the four-file plugin)
- Multi-agent recon planning
- Remediation playbooks

Each is sketched, not designed. Decision needed before code is committed — but the direction is captured so it survives between sessions.

## Test plan

- [x] PRD renders cleanly on github.com (no markdown break)
- [x] All version sections have consistent structure (heading, bullet list)
- [x] No drift remaining — verified each claim against code / git state / CHANGELOG
- [x] Commit body itself follows the new What/Why/Hypothesis/Evidence discipline as a worked example