### PR TITLE
docs(discussions): seed three starter posts for the Discussions tab

### DIFF
--- a/docs/discussions/01-welcome.md
+++ b/docs/discussions/01-welcome.md
@@ -1,0 +1,35 @@
+---
+category: Announcements
+title: 👋 Welcome to OpenEASD Discussions
+action: post + pin to top of Discussions tab
+---
+
+👋 Welcome to OpenEASD Discussions.
+
+OpenEASD is a self-hosted external attack surface scanner that wraps the open-source recon tools you already trust — `subfinder`, `amass`, `dnsx`, `naabu`, `httpx`, `nuclei`, `nmap` — behind a single web UI with scheduling, alerts, and findings tracking. MIT-licensed, one `docker run` to install, results stay on your machine.
+
+## Where to ask what
+
+- 🐛 **Found a bug?** → [Open a Bug Report](https://github.com/cybersecify/OpenEASD/issues/new?template=bug_report.yml)
+- 💡 **Feature idea?** → [Open a Feature Request](https://github.com/cybersecify/OpenEASD/issues/new?template=feature_request.yml)
+- 🛠️ **Want to add a new scanner tool?** → [Use the New Tool template](https://github.com/cybersecify/OpenEASD/issues/new?template=new_tool.yml). The four-file plugin pattern is documented in [CONTRIBUTING.md](https://github.com/cybersecify/OpenEASD/blob/main/CONTRIBUTING.md#quickest-contribution-path-add-a-new-tool).
+- 🔒 **Security vulnerability?** → Use [Private Vulnerability Reporting](https://github.com/cybersecify/OpenEASD/security/advisories/new) — not a public issue. See [SECURITY.md](https://github.com/cybersecify/OpenEASD/blob/main/SECURITY.md).
+- 🤔 **Everything else** — questions, ideas, "is X in scope?", "how do I configure Y?" — start a Discussion here.
+
+## What we're building toward
+
+We're security folks building OpenEASD as our contribution back to the OSS community whose tools we use every day. Two outside contributors already shipped meaningful work on day one of the community infrastructure going live — @xiaoke949 (HSTS check) and @turfin-logic (backport-aware CVE matching). If you have skills in any of: Python, Django, React, recon tools, security-tool plugin design, LLM agent design — we'd love your help.
+
+The roadmap and contribution paths are in the repo:
+
+- [README](https://github.com/cybersecify/OpenEASD#readme) — what it does, how to run it
+- [CONTRIBUTING.md](https://github.com/cybersecify/OpenEASD/blob/main/CONTRIBUTING.md) — how to send a PR
+- [PRD.md](https://github.com/cybersecify/OpenEASD/blob/main/PRD.md) — direction and planned versions, including the upcoming v2.0 Agentic AI work
+- [`good first issue` label](https://github.com/cybersecify/OpenEASD/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — scoped onboarding tasks
+- [`help wanted` label](https://github.com/cybersecify/OpenEASD/issues?q=is%3Aopen+label%3A%22help+wanted%22) — meatier work that needs experience
+
+## Code of conduct
+
+Be reasonable. Be specific. Help others when you can. The OSS security space attracts opinionated people — bring the opinions, leave the snark.
+
+— Rathnakara G N ([@rathnakaragn](https://github.com/rathnakaragn)) and Ashok S Kamat ([@ashok-kamat](https://github.com/ashok-kamat)) / [CyberSecify](https://cybersecify.com)

--- a/docs/discussions/02-qa-starter.md
+++ b/docs/discussions/02-qa-starter.md
@@ -1,0 +1,40 @@
+---
+category: Q&A
+title: What's the difference between OpenEASD and just running `subfinder | dnsx | naabu | nuclei` by hand?
+action: post (no pin needed); answer your own question with the body below
+---
+
+Fair question — it's the first one people ask. Three things you get from OpenEASD that hand-rolled CLI pipelines don't:
+
+### 1. Persistent findings lifecycle
+
+Every finding tracks `open → acknowledged → in-progress → resolved → false positive`, with notes, across scans. When you re-scan next week, OpenEASD shows you the **delta** — new findings since last scan, resolved findings that came back. CLI pipelines emit fresh output every time and you re-do triage from scratch.
+
+### 2. Asset graph, not flat output
+
+OpenEASD persists the `Domain → Subdomain → IPAddress → Port → URL` relationships. Each tool in the pipeline reads from the same graph instead of re-parsing the previous tool's stdout. That means:
+
+- The `nmap` stage knows which ports came from `naabu` *and* which subdomains those ports belong to
+- Subscan ("re-run just Nuclei on the existing scan") works without repeating discovery
+- Findings can be filtered by hostname / IP / port / source tool / severity — not just grep
+
+### 3. The boring-but-load-bearing operational layer
+
+- Schedule a daily scan or per-domain monitoring (6h/12h/24h/48h/weekly)
+- Slack and Teams alerts at a severity threshold you set in the UI (no restart needed)
+- CSV/PDF export of any scan (with optional minimum-severity filter)
+- JWT-authenticated REST API at `/api/` with auto-generated OpenAPI docs
+- Backport-aware CVE matching (since v0.5) — Ubuntu/Debian backports are recognised so already-patched CVEs aren't shown as live findings
+
+### When the hand-rolled pipeline still wins
+
+- Scanning one target once for a single output dump → CLI is faster, no install
+- You don't want a long-running container
+- You want exotic flag combinations that aren't exposed via the Workflows UI
+- You're scripting against very specific raw tool output
+
+OpenEASD's value compounds with **multiple targets over time**. For a single ad-hoc scan it's overkill.
+
+---
+
+Got a different angle on this comparison? Drop a comment — happy to refine the answer.

--- a/docs/discussions/03-show-and-tell-prompt.md
+++ b/docs/discussions/03-show-and-tell-prompt.md
@@ -1,0 +1,28 @@
+---
+category: Show and tell
+title: 🔭 Found something interesting with OpenEASD? Share the story.
+action: post; this is a prompt, not a question — replies come from the community
+---
+
+What surfaced that you wouldn't have caught otherwise?
+
+- A forgotten staging subdomain still serving an admin panel?
+- An expired cert nobody was watching?
+- A `DMARC p=none` on a domain you assumed was locked down?
+- A subdomain takeover candidate via dangling DNS?
+- A Postfix SMTP open relay because someone misread a config?
+- An undocumented service on a port you didn't know was open?
+
+Drop a short writeup — what you found, how it surfaced (which tool / which scan stage), what fixing it looked like. We love hearing these and they help other folks decide whether OpenEASD fits their workflow.
+
+### A request
+
+**Please redact anything identifying** — real IPs, organisation names, specific CVE-on-real-host attributions if the host is identifiable. Sanitised pattern descriptions are what's useful and what's safe.
+
+Example of a good redacted writeup:
+
+> Ran OpenEASD against a small-ish corp domain (~40 subdomains). `httpx` flagged a 200 on `https://internal.<redacted>.com` which I didn't recognise. `tls_checker` confirmed valid LetsEncrypt cert. Turned out to be a developer-staging copy of the customer portal that someone had spun up 18 months earlier and forgotten — full source map exposed in the JS bundle and the auth was disabled "for testing." Took it down same day. Wouldn't have noticed without the subdomain enum + httpx combo.
+
+That's the level of useful. Concrete enough to learn from, redacted enough that the original target isn't identifiable.
+
+— Look forward to reading what you find 🫡

--- a/docs/discussions/README.md
+++ b/docs/discussions/README.md
@@ -1,0 +1,34 @@
+# GitHub Discussions — Seed Drafts
+
+These three markdown files are drafts of the initial posts to seed the
+[OpenEASD Discussions](https://github.com/cybersecify/OpenEASD/discussions) surface.
+They live in the repo so they're durable, reviewable, and editable via PR — but
+posting them is a manual action (paste into the New Discussion form on github.com).
+
+## Why drafts in the repo
+
+Discussions on GitHub are tied to the repo's surface. We want:
+
+1. **Durability** — drafts in the repo survive context resets and session changes; chat-only drafts don't.
+2. **Reviewability** — Rathnakar can suggest tone/wording edits via PR before the post goes live.
+3. **Voice control** — Ashok (per [project-github-role-division](https://github.com/cybersecify/OpenEASD/blob/main/CLAUDE.md)) owns Discussions and makes the call on tone. These drafts are starting points, not commits.
+
+## How to post each draft
+
+For each `NN-*.md` file in this directory:
+
+1. Open https://github.com/cybersecify/OpenEASD/discussions/new
+2. Pick the category indicated at the top of the draft (Announcements, Q&A, Show and tell, etc.)
+3. Copy the title from the draft into the discussion title field
+4. Copy the body (everything below the `---` separator) into the discussion body
+5. Adjust voice/tone freely — these drafts are templates, not scripts
+6. For the Welcome post, pin it after posting (right sidebar → "Pin discussion")
+
+## After posting
+
+- Delete the corresponding `NN-*.md` draft from this directory in a follow-up PR
+- Or leave them as a reference of what was originally posted; up to you
+
+## Adding new drafts
+
+When new seed-post ideas come up (e.g., "Show and tell — community scans" prompt after the first month of usage), drop a new `NN-*.md` here under PR review before posting.


### PR DESCRIPTION
## What

Adds `docs/discussions/` with three drafts:

1. `01-welcome.md` — Welcome post for the Announcements category (intended to be pinned)
2. `02-qa-starter.md` — Q&A starter answering the most common visitor question ("what's the difference between OpenEASD and running the CLIs by hand?")
3. `03-show-and-tell-prompt.md` — prompt inviting community to share interesting findings with redaction guidance

Plus a `README.md` explaining how to post each one and the rationale for repo-resident drafts.

## Why

Discussions was enabled today but starts empty. Empty Discussions = "nobody's here" → opposite of the community vibe we want for the contributors who just converted (`@xiaoke949`, `@turfin-logic`) and the next wave.

## Hypothesis

Pinned Welcome + starter Q&A + Show-and-tell prompt will (a) reduce "is anyone home" bounce, (b) give a non-issue place for "is X in scope?" questions, (c) seed social proof that converts curious visitors into contributors.

## Evidence

- **Speculative on conversion uplift** — no Discussions-tab traffic baseline yet.
- **Data-oriented on the routing piece** — today's traffic showed 122 views / 246 unique cloners but only 2 contributors. Gap between visitor → contributor is large; Discussions is the softest lower-friction step.

## Posting flow (after merge)

These drafts don't auto-post. Per the role division, Ashok controls Discussions voice and posts manually:

1. Open https://github.com/cybersecify/OpenEASD/discussions/new
2. Pick the category from the draft's front matter
3. Copy title + body, edit voice/tone freely
4. Pin Welcome to the top after posting

## Test plan

- [x] All three drafts render as expected markdown
- [x] Internal links resolve (good first issue label query, help wanted label query, CONTRIBUTING.md, SECURITY.md, PRD.md)
- [x] README explains the post-then-delete flow so drafts don't drift forever after they're live