### PR TITLE
chore(ci): bump action versions to Node 24, drop FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,16 @@ on:
   pull_request:
     branches: ["main"]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   test:
     name: Test & Security Scan
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -51,12 +48,12 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Set up Node 20
+      - name: Set up Node 22 (current LTS)
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
@@ -71,7 +68,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -95,7 +92,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Log in to GHCR
         uses: docker/login-action@v4


### PR DESCRIPTION
## What

Five surgical changes to `.github/workflows/ci.yml`:

1. `actions/checkout@v4` → `@v5` (4 instances — every job step) — v5 natively targets Node 24
2. `actions/setup-python@v5` → `@v6` (test job) — v6 natively targets Node 24
3. `setup-node`: `node-version: "20"` → `"22"` (frontend job) — Node 22 is current LTS (supported until April 2027); Node 20 EOL April 2026
4. Step name updated to "Set up Node 22 (current LTS)"
5. `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var removed entirely

## Why

Recent CI runs (latest: PR #59) emit Node 20 deprecation warnings on every job because the previous workaround was the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var — a temporary patch that forced actions onto Node 24 without actually bumping them. The real fix is bumping the action versions themselves so Node 24 is the native runtime, not forced. Cleans up CI annotations and removes ongoing technical debt.

Frontend job's pinned `node-version: "20"` was the other live concern — Node 20 EOL is April 2026 (5 months from now). Bumping to Node 22 LTS gives us until April 2027 without chasing Node 24 (latest, not LTS-stable until October 2026).

## Hypothesis

After these bumps:
- Zero Node 20 deprecation warnings on `actions/checkout` and `actions/setup-python` annotations
- Build succeeds end-to-end on every job
- One less env var, clearer Node-version naming
- No functional change — actions do the same things on a newer runtime

## Evidence

**Data-oriented.**
- `actions/checkout@v5` release notes explicitly call out native Node 24 support
- `nodejs.org/en/about/previous-releases`: Node 20 EOL = 2026-04-30; Node 22 LTS = 2027-04-30
- The deprecation warnings on PR #59 CI runs were the user-visible trigger — verified in the GitHub Actions annotations panel

## Trade-off accepted

`docker/build-push-action@v6` still internally targets Node 20 (no v7 release yet). Without the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var, that single action will continue to emit a Node 20 warning until docker/build-push-action releases v7. Acceptable because:
- It's informational, not breaking
- GitHub gives advance notice before Node 20 actually stops working
- docker/build-push-action will ship v7 with native Node 24 support before that happens

## Test plan

- [x] CI runs on this PR — all 4 jobs (test, frontend, docker, publish-skipped) succeed
- [x] Annotation panel shows fewer Node 20 warnings (only docker actions remain)
- [x] Docker image build itself is unaffected — Dockerfile uses its own Node 20 install (`setup_20.x` from nodesource); Vite 8 supports both Node 20 and Node 22 so the resulting bundle is identical
- [ ] Follow-up (not this PR): bump the Dockerfile's `setup_20.x` to `setup_22.x` for consistency between CI validation and image build

## Notes

Per the [role division memory](https://github.com/cybersecify/OpenEASD/blob/main/CLAUDE.md), CI is Rathnakar's surface for review.