### PR TITLE
chore(ci): add CodeQL workflow for Python + JS/TS semantic security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+# CodeQL scans Python (Django backend) and JavaScript/TypeScript (React
+# frontend) for security anti-patterns: SQL injection, XSS, hardcoded secrets,
+# unsafe deserialisation, dataflow vulnerabilities. Findings appear in the
+# Security tab. Complements bandit (already in ci.yml) — bandit does pattern
+# matching, CodeQL does semantic dataflow analysis.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    # Run weekly even without commits to catch newly-discovered CWE patterns
+    # against unchanged code. Monday 04:00 UTC = quiet time for CI runners.
+    - cron: "0 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # default query suite — security-extended would catch more but is
+          # noisier; we can flip later if the default suite is too quiet
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds `.github/workflows/codeql.yml` — GitHub's native semantic code analysis. Scans Python (Django backend) and JavaScript/TypeScript (React frontend) via two parallel matrix jobs. Runs on push, PR, and weekly cron (Mon 04:00 UTC). Uses the `security-and-quality` query suite.

## Why

Complements the existing `bandit` step in `ci.yml`. They cover different ground:

| | bandit (already in CI) | CodeQL (this PR) |
|---|---|---|
| Approach | Pattern matching | Semantic dataflow analysis |
| Catches | `subprocess(shell=True)`, weak crypto, hardcoded passwords | Taint tracking through function boundaries; sanitization checks; injection paths through indirection |

Pre-this-PR, the repo's Security tab said "Code scanning alerts → Needs setup" — visible "not actually doing the work we ask others to do" gap for a security tool. Post-merge: Security tab shows active scanning, PR annotations on any issues.

Also addresses external audit (2026-05-31): "Code scanning not set up → notable gap for a security tool."

## Hypothesis

CodeQL will produce zero or near-zero findings in the first scan because the codebase has already been audited. Value lands when:
- A future contributor PRs something introducing a real CWE pattern → CodeQL annotation surfaces it inline
- A CodeQL rule fires on a previously-unseen pattern pulled in from upstream deps

## Evidence

**Data-oriented** on the bandit-vs-CodeQL coverage delta — GitHub's CodeQL docs explicitly list patterns dataflow analysis catches that pattern-matching SAST misses.

**Speculative** on the "zero findings" claim — could surface 3-5 genuine issues, in which case those become follow-up cleanup tasks.

## Trade-offs

- **CI minutes**: ~5-10 min added per push (parallel with existing jobs, minimal wall-clock impact). Free quota for public repo.
- **Query suite**: `security-and-quality` is the default balance. `security-extended` is louder; we can flip later if the default is too quiet.

## Why the workflow file approach (not default setup)

We tried `PUT /repos/{owner}/{repo}/code-scanning/default-setup` first — returned 404. The workflow-file approach (this PR) is the standard fallback that works for any repo without needing GHAS.

## Test plan

- [x] YAML is valid (verified locally)
- [ ] First push to main triggers the workflow successfully
- [ ] Security tab on github.com shows "Code scanning" as active afterwards
- [ ] Any initial findings get triaged in follow-up PRs

## Per the role division

CI / Security surface is Rathnakar's. Tagged for his review/merge.