### PR TITLE
docs(readme): close the Phase 6 gap in Scan Pipeline section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Phase 2  Amass              - Active subdomain enumeration
 Phase 3  DNSx               - DNS resolution, public IP filtering
 Phase 4  Naabu              - TCP port scanning (top 100)
 Phase 5  Service Detection  - Classify ports as web/non-web via nmap -sV (auto)
-Phase 7  Nmap               - CVE scanning via NSE vulners (non-web ports)
-Phase 7  TLS Checker        - Certificate, cipher, and protocol analysis
-Phase 7  SSH Checker        - SSH configuration audit
-Phase 7  Nuclei Network     - Service-aware nuclei network templates against non-web ports
-Phase 8  httpx              - Web probing, URL discovery
-Phase 9  Katana             - Deep URL crawling on top of httpx (Phase 9, asset producer)
-Phase 9  Nuclei             - Web vulnerability scanning (community templates)
-Phase 9  Web Checker        - Security headers, cookies, CORS analysis
+Phase 6  Nmap               - CVE scanning via NSE vulners (non-web ports)
+Phase 6  TLS Checker        - Certificate, cipher, and protocol analysis
+Phase 6  SSH Checker        - SSH configuration audit
+Phase 6  Nuclei Network     - Service-aware nuclei network templates against non-web ports
+Phase 7  httpx              - Web probing, URL discovery
+Phase 8  Katana             - Deep URL crawl on top of httpx (asset producer)
+Phase 8  Nuclei             - Web vulnerability scanning (community templates)
+Phase 8  Web Checker        - Security headers, cookies, CORS analysis
 ```
 
 ## Architecture


### PR DESCRIPTION
## What

Renumbers README's Scan Pipeline phases from non-contiguous (1, 2, 2, 3, 4, 5, **7**, 7, 7, 7, **8**, **9**, 9 — no Phase 6) to contiguous (1, 2, 2, 3, 4, 5, **6**, 6, 6, 6, **7**, **8**, 8). Same tools, same execution order, only the visible numbers change.

## Why

Phase 6 has been silently missing since v0.4. A reader glancing at the pipeline sees "Phase 5 jumps to Phase 7" and either (a) assumes a step is missing from the docs, or (b) loses trust on a small-but-visible inconsistency. For a security tool, the bar for "this looks unmaintained" details is low.

## Hypothesis

Closing the gap raises perceived doc quality at zero cost. Speculative on magnitude (no measurable "reader trust" signal) but eliminating a 5-second-noticeable doc bug is strictly positive.

## Evidence

**Data-oriented** on the gap itself — verified pre-PR:
```bash
$ grep -nE "^Phase " README.md
# returns 1, 2, 2, 3, 4, 5, 7, 7, 7, 7, 8, 9, 9 — Phase 6 absent
```

External repo audit (2026-05-31) explicitly called this out: *"Scan Pipeline numbering gap in README — Phase 6 is skipped entirely. This looks like a documentation bug."*

## Why this doesn't touch code

`apps/*/apps.py` `tool_meta.phase` values retain their existing numbers — they're pipeline-execution-order identifiers in code, separate from how phases are presented to a README reader. Per [D-007](https://github.com/cybersecify/OpenEASD/blob/main/docs/DECISIONS.md#d-007--canonical-11-attack-vectors-customer-facing) ("11 customer-facing vectors ≠ 13 internal pipeline phases"), the README's pipeline numbering is a presentation abstraction. Renumbering README cleanly to 1-8 is consistent with that two-abstraction framing.

## Alternative considered

Add a `Phase 6 (reserved)` marker line. Rejected because (a) it's still presentation noise, (b) future readers would ask "reserved for *what*?" with no useful answer.

## Test plan

- [x] Pre-PR: phase numbering jumped 5 → 7 → 8 → 9 (visible gap)
- [x] Post-PR: phase numbering reads 1, 2, 2, 3, 4, 5, 6, 6, 6, 6, 7, 8, 8 (contiguous)
- [x] Same tool list, same order, same number of parallel-stage groupings
- [x] No code changes