### PR TITLE
docs(readme): drift cleanup — katana, React 19, test counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 It surfaces the **lowest hanging fruits** — what someone scanning your perimeter sees first. Eleven attack vectors across DNS, email, TLS, SSH, ports, CVEs, and web hygiene.
 
-![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 13 tool steps tracked live](docs/screenshots/scan-detail-live.png)
+![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 14 tool steps tracked live](docs/screenshots/scan-detail-live.png)
 
 ## Quick start
 
@@ -30,7 +30,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline** — 13-tool scan workflow from domain to findings
+- **Automated pipeline** — 14-tool scan workflow from domain to findings
 - **Network attack surface scanning** — CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **Dynamic workflows** — Create custom scan configurations, enable/disable tools per workflow
 - **Tool auto-registration** — Add new tools with zero core modification
@@ -59,6 +59,7 @@ Phase 7  TLS Checker        - Certificate, cipher, and protocol analysis
 Phase 7  SSH Checker        - SSH configuration audit
 Phase 7  Nuclei Network     - Service-aware nuclei network templates against non-web ports
 Phase 8  httpx              - Web probing, URL discovery
+Phase 9  Katana             - Deep URL crawling on top of httpx (Phase 9, asset producer)
 Phase 9  Nuclei             - Web vulnerability scanning (community templates)
 Phase 9  Web Checker        - Security headers, cookies, CORS analysis
 ```
@@ -93,10 +94,11 @@ apps/                   - Tool apps (add/remove freely)
   ssh_checker/          - SSH configuration audit
   nuclei_network/       - Network protocol vuln scanning
   httpx/                - Web probing
+  katana/               - Deep URL crawl on top of httpx (asset producer)
   nuclei/               - Web vulnerability scanning
   web_checker/          - Security headers, cookies, CORS
 
-frontend/               - React 18 + Vite SPA
+frontend/               - React 19 + Vite 8 SPA
   src/pages/            - Page components
   src/components/       - Shared UI primitives (Badge, Spinner, Pagination, ConfirmButton)
   src/components/ui/    - shadcn/ui primitives (Button, Card, Table, AlertDialog, …)
@@ -250,7 +252,7 @@ uv run python main.py --no-worker      # web server only (no worker)
 ## CI/CD
 
 GitHub Actions runs on every push to `main` and `v*` tags:
-- **pytest** — fast test suite (~522 tests, excludes slow DNS/RDAP tests)
+- **pytest** — fast test suite (~750 tests, excludes the 41 slow DNS/RDAP tests in `test_domain_security.py`)
 - **bandit** — Python SAST scan
 - **pip-audit** — dependency CVE scan
 - **Frontend build** — `npm ci && npm run build`
@@ -302,7 +304,7 @@ apps/my_tool/
 ## Running Tests
 
 ```bash
-# Fast tests (excludes slow DNS tests, ~629 tests)
+# Fast tests (excludes slow DNS tests, ~750 tests)
 uv run pytest tests/ --ignore=tests/unit/test_domain_security.py
 
 # All tests (~670 total)
@@ -324,7 +326,7 @@ uv run pytest tests/
 - **django-ninja-jwt** — JWT auth for the Ninja API (wraps `djangorestframework-simplejwt`); access + refresh tokens, blacklist on logout
 
 **Frontend:**
-- **React 18 + Vite** — SPA with hot module replacement
+- **React 19 + Vite 8** — SPA with hot module replacement
 - **Tailwind CSS 3 + shadcn/ui** — Utility-first styling with Radix UI component primitives
 - **sonner** — Toast notifications
 - Vanilla popstate router (no react-router)


### PR DESCRIPTION
## What

Four real drifts in the README, all caught in an audit pass on 2026-05-31:

### 1. `katana` was missing in 3 places
Added in PR #48 (v0.6), README never updated. Now in:
- Pipeline phase listing — Phase 9, asset producer (matches `apps/katana/apps.py:phase=9`)
- Architecture `apps/` tree — added alongside httpx and nuclei
- Tool-count claims: "13-tool" → "14-tool", hero image alt text "13 tool steps" → "14"

### 2. React + Vite versions stale in 2 places
v0.5 upgrade documented in CHANGELOG but never reflected in README:
- Architecture: "React 18 + Vite SPA" → "React 19 + Vite 8 SPA"
- Tech Stack: same fix

### 3. Test counts stale AND internally inconsistent
Two different numbers in the same README:
- CI/CD section: "~522 tests" → "~750 tests"
- Running Tests section: "~629 tests" → "~750 tests"

Note added that fast suite excludes the 41 slow DNS/RDAP tests in `test_domain_security.py`. Both numbers now match each other and reality.

## Why

README drift erodes trust in security tools faster than other categories — the audience is professionally suspicious. Stale test counts, stale tool list, stale framework versions all read as "this repo isn't actively maintained" to a sophisticated visitor.

Lying about a 13-tool workflow when there are actually 14 is a small bug today but becomes a bigger one every release otherwise.

## Hypothesis

Current README will (a) reduce visitor bounce from drift signals; (b) make the next contributor adding a tool more likely to update the README in the same PR (precedent matters); (c) close the gap with the external auditor's findings.

## Evidence

**Data-oriented across all 4 drifts:**

| Claim | Verified by |
|---|---|
| katana exists | `ls apps/katana/apps.py` |
| katana at phase 9 | `tool_meta.phase=9` in `apps/katana/apps.py` |
| React 19, Vite 8 | `package.json`: `react: ^19.2.6`, `vite: ^8.0.14` |
| Test count 791 total | `grep -rnE '^\s*def test_' tests/ --include='*.py'` |
| Test count 750 fast | Same grep, excluding `test_domain_security.py` |
| React 19 upgrade landed in v0.5 | CHANGELOG.md v0.5 section |

External audit explicitly called out all four items on 2026-05-31.

## Coordination

PR #70 also touches the Phase listing section (renumbering to close the Phase 6 gap). One will need a small rebase after the other merges:
- If #70 merges first → this PR rebases the katana Phase 9 line
- If this PR merges first → #70 rebases to renumber the new katana entry too

Either order works.

## Test plan

- [x] All 4 drifts confirmed against ground truth
- [x] Single section (Pipeline listing) is the only area conflicting with PR #70
- [x] No code touched