### PR TITLE
docs(readme): add explicit "Who this is for / isn't for" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ It surfaces the **lowest hanging fruits** — what someone scanning your perimet
 
 ![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 13 tool steps tracked live](docs/screenshots/scan-detail-live.png)
 
+## Who this is for
+
+- **In-house security engineers and IT-doing-security teams** at small-to-mid orgs scanning their own external surface
+- **Small security consultancies** monitoring a handful of clients
+- **Bug bounty hunters** who want a unified view of recon output across programs they're authorised to test
+- **Solo self-hosters and security learners** auditing their own infra
+
+## Who this isn't for
+
+- **Enterprise SOCs** — no RBAC, SAML, multi-tenant, or Postgres (yet)
+- **Pen testers running one-shot deep enumeration of a single target** — for that, [Tib3rius/AutoRecon](https://github.com/Tib3rius/AutoRecon) and similar CLI tools are better fits. OpenEASD optimises for continuous monitoring across multiple domains over time, not single-target deep dives
+- **Anyone needing to scan domains they don't own or aren't authorised to test** — OpenEASD is intentionally not a "scan-anyone" hosted service. Running it implies you own or have written authorisation for your targets
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
## What

New section between the hero image and Quick start — two short bullet lists explicitly naming the audience and the non-audience. ~12 added lines.

## Why

README's audience signal today is implicit — buried in the hero ("security teams") without naming who. Sophisticated evaluators look for a "Who this is for" block to self-select in ~10 seconds. Its absence reads as "this project doesn't know who it's for" — which erodes trust faster than almost any other README gap in OSS security specifically.

The non-audience list does double duty:
- Helps wrong-fit visitors self-select OUT before they file a "where's RBAC?" issue
- Honestly acknowledges where competitors are better — counterintuitively builds more trust than pretending to do everything

## Hypothesis

Adding this section will (a) reduce time-to-self-select for evaluators; (b) reduce issue noise from wrong-audience users asking for features that contradict our audience choice; (c) signal we have intentional product boundaries rather than feature-sprawl.

## Evidence

**Speculative on the conversion impact** — no A/B test data.

**Data-oriented on the audience content itself** — every line traces to:
- [`docs/DECISIONS.md` D-001](https://github.com/cybersecify/OpenEASD/blob/main/docs/DECISIONS.md#d-001--audience-security-literate-users-not-non-technical-end-users), OR
- The 2026-05-31 ICP expansion (added bug bounty hunters to scope)

The Tib3rius/AutoRecon link is honest acknowledgement — they're genuinely better for one-shot deep enumeration of a single target. Pointing wrong-fit users at the right tool builds trust.

## Per the documentation discipline

Every bullet point is a claim that traces to D-001 or the locked 2026-05-31 ICP expansion. No new audience claims invented here.

## Follow-up needed

D-001 was last updated 2026-05-21 and its "Not targeting" list excludes bug bounty hunters. The 2026-05-31 ICP expansion added them back in scope. Per the DECISIONS.md rule (*"Don't edit a locked decision in place — add a follow-up entry that supersedes it"*), a new D-NNN should be added that supersedes D-001's bug-bounty exclusion. This is tracked separately — not part of this PR's scope.

## Coordination with other open PRs

This PR adds a new section above existing content (between hero image and Quick start). No overlap with:
- PR #70 (Phase listing renumbering)
- PR #71 (Features / Phase listing / Architecture / Tech Stack)

Should merge cleanly alongside both. No rebase risk.

## Test plan

- [x] Renders as two bullet lists in expected layout
- [x] All audience/non-audience lines trace to D-001 or to the 2026-05-31 ICP expansion
- [x] AutoRecon link goes to canonical Tib3rius/AutoRecon
- [x] No other content touched