### PR TITLE
chore(github): add CODEOWNERS for automatic PR review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,42 @@
+# CODEOWNERS — auto-requests review from the right maintainer per path.
+# Order matters: later rules override earlier ones.
+# Reference: https://docs.github.com/articles/about-code-owners
+
+# Default reviewer for anything not matched below.
+*                                @rathnakaragn
+
+# ---------------------------------------------------------------------------
+# Code surfaces (technical — Rathnakar)
+# ---------------------------------------------------------------------------
+/apps/                           @rathnakaragn
+/openeasd/                       @rathnakaragn
+/tests/                          @rathnakaragn
+/frontend/src/                   @rathnakaragn
+
+# CI and tool configuration
+/.github/workflows/              @rathnakaragn
+/Dockerfile                      @rathnakaragn
+/docker-entrypoint.sh            @rathnakaragn
+/pyproject.toml                  @rathnakaragn
+/uv.lock                         @rathnakaragn
+/frontend/package.json           @rathnakaragn
+/frontend/package-lock.json      @rathnakaragn
+
+# ---------------------------------------------------------------------------
+# Strategy + community surfaces (shared — Rathnakar + Ashok)
+# ---------------------------------------------------------------------------
+/.github/ISSUE_TEMPLATE/         @rathnakaragn @ashok-kamat
+/.github/PULL_REQUEST_TEMPLATE.md @rathnakaragn @ashok-kamat
+/.github/CODEOWNERS              @rathnakaragn @ashok-kamat
+/.github/FUNDING.yml             @rathnakaragn @ashok-kamat
+/.github/dependabot.yml          @rathnakaragn
+/docs/                           @rathnakaragn @ashok-kamat
+/README.md                       @rathnakaragn @ashok-kamat
+/CHANGELOG.md                    @rathnakaragn @ashok-kamat
+/CONTRIBUTING.md                 @rathnakaragn @ashok-kamat
+/CLAUDE.md                       @rathnakaragn @ashok-kamat
+/PRD.md                          @rathnakaragn @ashok-kamat
+/LICENSE                         @rathnakaragn @ashok-kamat
+
+# Security (technical-leaning — Rathnakar primary, Ashok co-reviewer)
+/SECURITY.md                     @rathnakaragn @ashok-kamat


### PR DESCRIPTION
## What

New `.github/CODEOWNERS` file. GitHub auto-assigns reviewers based on path patterns whenever a PR touches matching files.

## Routing follows the locked role division

| Surface | Auto-assigned reviewer(s) |
|---|---|
| Code, CI, tool config, dependencies | @rathnakaragn alone |
| Issue/PR templates, docs, README, CHANGELOG, CLAUDE.md, PRD.md, LICENSE | @rathnakaragn + @ashok-kamat (co-reviewers) |
| SECURITY.md | @rathnakaragn + @ashok-kamat |
| Default (anything unmatched) | @rathnakaragn |

## Why

Before this file, PRs sit until someone happens to notice them. Reviews can silently skip the right person if nobody pings manually. CODEOWNERS auto-pings the correct reviewer the moment a PR opens.

## Pairs with

Branch protection rules (configured earlier today via `gh api`) require **1 approving review before merge**. CODEOWNERS makes that 1 approving review automatically route to the right person.

## Test plan

- [x] File validates against GitHub's CODEOWNERS syntax (`@rathnakaragn` and `@ashok-kamat` are both valid GitHub handles in the org)
- [x] Path patterns cover all major directories (`/apps/`, `/openeasd/`, `/tests/`, `/frontend/`, `/.github/`, `/docs/`) plus top-level docs
- [x] No code changes, no behavior changes outside the GitHub review-routing layer