### PR TITLE
feat: add historical URL discovery via gau and waybackurls (Fixes #75)

### DIFF
--- a/apps/historical_urls/analyzer.py
+++ b/apps/historical_urls/analyzer.py
@@ -1,0 +1,94 @@
+"""Historical URL analyzer — parse URLs and create URL records."""
+
+import logging
+from urllib.parse import urlparse
+
+from django.db import transaction
+
+from apps.core.assets.models import Subdomain
+from apps.core.web_assets.models import URL
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_scheme_host_port(url: str) -> tuple[str, str, int]:
+    """Extract scheme, host, and port from a URL."""
+    parsed = urlparse(url)
+    scheme = parsed.scheme or "https"
+    host = parsed.hostname or ""
+
+    # Determine port
+    if parsed.port:
+        port = parsed.port
+    elif scheme == "https":
+        port = 443
+    elif scheme == "http":
+        port = 80
+    else:
+        port = 443
+
+    return scheme, host, port
+
+
+def analyze(session, urls: list[str]) -> list[URL]:
+    """
+    Parse discovered URLs and create URL model instances.
+
+    Links each URL to its corresponding Subdomain record if it exists in the DB.
+
+    Args:
+        session: The scan session object
+        urls: List of URL strings from gau/waybackurls
+
+    Returns:
+        List of URL model instances ready for bulk_create
+    """
+    if not urls:
+        return []
+
+    # Get all subdomains for this session for lookup
+    subdomains = {
+        s.subdomain: s
+        for s in Subdomain.objects.filter(session=session)
+    }
+
+    objs = []
+    seen = set()
+
+    for url_str in urls:
+        try:
+            scheme, host, port = _extract_scheme_host_port(url_str)
+
+            # Skip if we've already seen this URL
+            normalized = f"{scheme}://{host}:{port}{urlparse(url_str).path}"
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+
+            # Find matching subdomain
+            subdomain = subdomains.get(host)
+
+            # Create URL instance
+            obj = URL(
+                session=session,
+                url=url_str,
+                scheme=scheme,
+                host=host,
+                port=port,
+                path=urlparse(url_str).path or "/",
+                source="historical_urls",
+                status_code=None,  # Will be probed later by httpx/katana
+                subdomain=subdomain,
+            )
+            objs.append(obj)
+
+        except Exception as e:
+            logger.warning(f"Failed to parse URL '{url_str}': {e}")
+            continue
+
+    logger.info(
+        f"[historical_urls:{session.id}] "
+        f"Analyzed {len(urls)} URLs → {len(objs)} unique URL records"
+    )
+
+    return objs

--- a/apps/historical_urls/apps.py
+++ b/apps/historical_urls/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+
+class HistoricalUrlsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.historical_urls"
+    label = "historical_urls"
+    verbose_name = "Historical URLs (gau/waybackurls)"
+    tool_meta = {
+        "label": "Historical URLs (gau/waybackurls)",
+        "runner": "apps.historical_urls.scanner.run_historical_urls",
+        "phase": 8.5,
+        "requires": ["httpx"],
+        "produces_findings": False,
+    }

--- a/apps/historical_urls/collector.py
+++ b/apps/historical_urls/collector.py
@@ -1,0 +1,136 @@
+"""Historical URL discovery — runs gau and/or waybackurls against subdomains.
+
+Pulls historical URLs from Wayback Machine, AlienVault OTX, Common Crawl,
+and URLScan.io. Surfaces forgotten endpoints, deprecated APIs, and
+removed-but-still-deployed paths that current crawling misses.
+"""
+
+import logging
+import subprocess
+import shutil
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+# Extensions to skip (images, fonts, media, documents)
+SKIP_EXTENSIONS = {
+    # Images
+    ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".ico", ".webp", ".avif",
+    # Fonts
+    ".woff", ".woff2", ".ttf", ".eot", ".otf",
+    # Media
+    ".mp3", ".mp4", ".avi", ".mov", ".wmv", ".flv", ".webm", ".ogg",
+    # Documents
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+    # Archives
+    ".zip", ".tar", ".gz", ".rar", ".7z",
+    # Other
+    ".css", ".js", ".map",
+}
+
+
+def _run_gau(domain: str) -> list[str]:
+    """Run gau against a domain and return discovered URLs."""
+    binary = getattr(settings, "TOOL_GAU", "gau")
+
+    if not shutil.which(binary):
+        logger.warning(f"gau binary not found at '{binary}', skipping gau")
+        return []
+
+    try:
+        result = subprocess.run(
+            [binary, "--subs", "--threads", "5", domain],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            stdin=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            logger.warning(f"gau failed for {domain}: {result.stderr[:200]}")
+            return []
+
+        urls = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        logger.info(f"gau found {len(urls)} URLs for {domain}")
+        return urls
+
+    except subprocess.TimeoutExpired:
+        logger.warning(f"gau timed out for {domain}")
+        return []
+    except Exception as e:
+        logger.error(f"gau error for {domain}: {e}")
+        return []
+
+
+def _run_waybackurls(domain: str) -> list[str]:
+    """Run waybackurls against a domain and return discovered URLs."""
+    binary = getattr(settings, "TOOL_WAYBACKURLS", "waybackurls")
+
+    if not shutil.which(binary):
+        logger.warning(f"waybackurls binary not found at '{binary}', skipping waybackurls")
+        return []
+
+    try:
+        result = subprocess.run(
+            [binary, "--no-subs", domain],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            stdin=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            logger.warning(f"waybackurls failed for {domain}: {result.stderr[:200]}")
+            return []
+
+        urls = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        logger.info(f"waybackurls found {len(urls)} URLs for {domain}")
+        return urls
+
+    except subprocess.TimeoutExpired:
+        logger.warning(f"waybackurls timed out for {domain}")
+        return []
+    except Exception as e:
+        logger.error(f"waybackurls error for {domain}: {e}")
+        return []
+
+
+def collect(session, domains: list[str]) -> list[str]:
+    """
+    Run gau and waybackurls against a list of domains. Returns deduplicated URLs.
+
+    Args:
+        session: The scan session object
+        domains: List of domain names to query
+
+    Returns:
+        Deduplicated list of discovered URLs
+    """
+    if not domains:
+        return []
+
+    all_urls = set()
+
+    for domain in domains:
+        # Run both tools and merge results
+        gau_urls = _run_gau(domain)
+        wayback_urls = _run_waybackurls(domain)
+
+        all_urls.update(gau_urls)
+        all_urls.update(wayback_urls)
+
+    # Filter out URLs with skip extensions
+    filtered_urls = []
+    for url in all_urls:
+        # Extract path and check extension
+        path = url.split("?")[0].split("#")[0].lower()
+        if any(path.endswith(ext) for ext in SKIP_EXTENSIONS):
+            continue
+        filtered_urls.append(url)
+
+    logger.info(
+        f"[historical_urls:{session.id}] "
+        f"Discovered {len(filtered_urls)} URLs from {len(domains)} domains "
+        f"(filtered from {len(all_urls)} total)"
+    )
+
+    return filtered_urls

--- a/apps/historical_urls/scanner.py
+++ b/apps/historical_urls/scanner.py
@@ -1,0 +1,67 @@
+"""Historical URL scanner — orchestrator: read Subdomains → discover URLs → save.
+
+Phase 8.5: Runs after httpx (Phase 8) and before katana (Phase 9).
+Feeds historical URLs into the same URL table for downstream scanning.
+"""
+
+import logging
+
+from apps.core.assets.models import Subdomain
+from apps.core.web_assets.models import URL
+from .collector import collect
+from .analyzer import analyze
+
+logger = logging.getLogger(__name__)
+
+
+def run_historical_urls(session) -> list[URL]:
+    """
+    Discover historical URLs for all subdomains in the session.
+
+    Runs gau and waybackurls against each subdomain to surface forgotten
+    endpoints, deprecated APIs, and removed-but-still-deployed paths.
+
+    Args:
+        session: The scan session object
+
+    Returns:
+        List of saved URL records
+    """
+    # Get all unique subdomains for this session
+    subdomains = list(
+        Subdomain.objects.filter(session=session)
+        .values_list("subdomain", flat=True)
+        .distinct()
+    )
+
+    if not subdomains:
+        logger.info(f"[historical_urls:{session.id}] No subdomains to query")
+        return []
+
+    logger.info(
+        f"[historical_urls:{session.id}] "
+        f"Starting historical URL discovery for {len(subdomains)} subdomains"
+    )
+
+    # Collect historical URLs from gau and waybackurls
+    urls = collect(session, subdomains)
+
+    if not urls:
+        logger.info(f"[historical_urls:{session.id}] No historical URLs found")
+        return []
+
+    # Analyze and create URL records
+    objs = analyze(session, urls)
+
+    if objs:
+        # Bulk create, ignoring duplicates (same URL in same session)
+        URL.objects.bulk_create(objs, ignore_conflicts=True)
+
+    saved = list(URL.objects.filter(session=session, source="historical_urls"))
+    logger.info(
+        f"[historical_urls:{session.id}] "
+        f"Saved {len(saved)} historical URLs "
+        f"(from {len(subdomains)} subdomains)"
+    )
+
+    return saved


### PR DESCRIPTION
## Summary
Adds historical URL discovery using `gau` and `waybackurls` as Phase 8.5 in the scan pipeline — between httpx (Phase 8) and katana (Phase 9).

## Changes
- **`apps/historical_urls/collector.py`** — Runs `gau` and `waybackurls` against discovered subdomains, filters out static assets (images, fonts, media, documents)
- **`apps/historical_urls/analyzer.py`** — Parses URLs, deduplicates, extracts scheme/host/port, links to existing Subdomain records
- **`apps/historical_urls/scanner.py`** — Orchestrator that feeds discovered URLs into the existing `URL` table for downstream scanning
- **`apps/historical_urls/apps.py`** — Django app config with `tool_meta.phase=8.5`, `requires=["httpx"]`, `produces_findings=False`

## Design Decisions
- **Phase 8.5**: Runs after httpx (probes live web) but before katana (live crawling) — historical URLs get verified by both downstream tools
- **Both tools**: Runs both `gau` and `waybackurls` and merges results for maximum coverage
- **Static asset filtering**: Skips images, fonts, media, documents, archives, CSS/JS to reduce noise
- **Graceful degradation**: If either binary is missing, logs a warning and continues with the other tool
- **Deduplication**: Normalizes URLs by scheme/host/port/path to avoid duplicates

## Dependencies
- `gau` binary (https://github.com/lc/gau) — 5K+ stars, Go binary, no auth required
- `waybackurls` binary (https://github.com/tomnomnom/waybackurls) — 3K+ stars, Go binary, no auth required

## Testing
1. Install `gau` and `waybackurls` binaries
2. Run a scan against a domain with historical presence
3. Verify URLs appear in the URL table with `source="historical_urls"`
4. Verify katana/nuclei scan the discovered URLs in subsequent phases

## Related Issues
Fixes #75