### PR TITLE
feat: add gowitness screenshot capture for visual reconnaissance (Fixes #77)

### DIFF
--- a/apps/gowitness/analyzer.py
+++ b/apps/gowitness/analyzer.py
@@ -1,0 +1,102 @@
+"""Gowitness analyzer — store screenshot metadata and link to URLs."""
+
+import logging
+import os
+import hashlib
+
+from django.db import models
+
+from apps.core.web_assets.models import URL
+
+logger = logging.getLogger(__name__)
+
+
+class URLScreenshot(models.Model):
+    """Screenshot metadata linked to a URL."""
+
+    url = models.ForeignKey(
+        URL,
+        on_delete=models.CASCADE,
+        related_name="screenshots",
+    )
+    screenshot_path = models.CharField(max_length=500)
+    http_status = models.IntegerField(null=True, blank=True)
+    page_title = models.CharField(max_length=500, blank=True)
+    captured_at = models.DateTimeField(auto_now_add=True)
+    file_size = models.IntegerField(default=0)
+
+    class Meta:
+        unique_together = ["url", "screenshot_path"]
+
+    def __str__(self):
+        return f"Screenshot for {self.url.url}"
+
+
+def analyze(session, records: list[dict], output_dir: str) -> list[URLScreenshot]:
+    """
+    Parse gowitness results and create URLScreenshot records.
+
+    Args:
+        session: The scan session object
+        records: List of gowitness result records
+        output_dir: Directory containing screenshot files
+
+    Returns:
+        List of URLScreenshot model instances
+    """
+    if not records:
+        return []
+
+    # Get URLs for this session
+    urls = {
+        url.url: url
+        for url in URL.objects.filter(session=session)
+    }
+
+    objs = []
+
+    for record in records:
+        try:
+            url_str = record.get("url", "")
+            if not url_str:
+                continue
+
+            # Find matching URL record
+            url_obj = urls.get(url_str)
+            if not url_obj:
+                continue
+
+            # Get screenshot file path
+            screenshot_file = record.get("screenshot", "")
+            if not screenshot_file:
+                continue
+
+            # Construct full path
+            screenshot_path = os.path.join(output_dir, screenshot_file)
+            if not os.path.exists(screenshot_path):
+                logger.warning(f"Screenshot file not found: {screenshot_path}")
+                continue
+
+            # Get file size
+            file_size = os.path.getsize(screenshot_path)
+
+            # Create URLScreenshot instance
+            obj = URLScreenshot(
+                url=url_obj,
+                screenshot_path=screenshot_path,
+                http_status=record.get("status-code"),
+                page_title=record.get("title", ""),
+                file_size=file_size,
+            )
+            objs.append(obj)
+
+        except Exception as e:
+            logger.warning(f"Failed to process gowitness record: {e}")
+            continue
+
+    logger.info(
+        f"[gowitness:{session.id}] "
+        f"Analyzed {len(records)} records → {len(objs)} screenshot records"
+    )
+
+    return objs

--- a/apps/gowitness/apps.py
+++ b/apps/gowitness/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+
+class GowitnessConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.gowitness"
+    label = "gowitness"
+    verbose_name = "Gowitness (Screenshots)"
+    tool_meta = {
+        "label": "Gowitness (Screenshots)",
+        "runner": "apps.gowitness.scanner.run_gowitness",
+        "phase": 10,
+        "requires": ["httpx"],
+        "produces_findings": False,
+    }

--- a/apps/gowitness/collector.py
+++ b/apps/gowitness/collector.py
@@ -1,0 +1,92 @@
+"""Gowitness screenshot capture — takes screenshots of URLs using headless Chromium."""
+
+import json
+import logging
+import os
+import subprocess
+import shutil
+import tempfile
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def collect(session, urls: list[str], output_dir: str) -> list[dict]:
+    """
+    Run gowitness against a list of URLs and capture screenshots.
+
+    Args:
+        session: The scan session object
+        urls: List of URL strings to screenshot
+        output_dir: Directory to store screenshots and metadata
+
+    Returns:
+        List of screenshot metadata records
+    """
+    if not urls:
+        return []
+
+    binary = getattr(settings, "TOOL_GOWITNESS", "gowitness")
+
+    if not shutil.which(binary):
+        logger.warning(f"gowitness binary not found at '{binary}'")
+        return []
+
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Write URLs to temp file
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("\n".join(urls))
+        tmp = f.name
+
+    try:
+        # Run gowitness
+        cmd = [
+            binary,
+            "file",
+            "-f", tmp,
+            "-P", output_dir,
+            "--json-file", os.path.join(output_dir, "results.json"),
+            "--timeout", "30",
+            "--delay", "2",
+            "--no-stdout",
+        ]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=len(urls) * 60,  # 60s per URL max
+            stdin=subprocess.DEVNULL,
+        )
+
+        if result.returncode != 0:
+            logger.warning(f"gowitness failed: {result.stderr[:300]}")
+            return []
+
+        # Parse results
+        results_file = os.path.join(output_dir, "results.json")
+        if not os.path.exists(results_file):
+            logger.warning("gowitness results.json not found")
+            return []
+
+        with open(results_file, "r") as f:
+            records = json.load(f)
+
+        logger.info(f"gowitness captured {len(records)} screenshots")
+        return records
+
+    except subprocess.TimeoutExpired:
+        logger.warning("gowitness timed out")
+        return []
+    except Exception as e:
+        logger.error(f"gowitness error: {e}")
+        return []
+    finally:
+        # Clean up temp file
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass

--- a/apps/gowitness/scanner.py
+++ b/apps/gowitness/scanner.py
@@ -1,0 +1,76 @@
+"""Gowitness scanner — orchestrator: read URLs → capture screenshots → save metadata.
+
+Phase 10: Runs after httpx + katana, before nuclei web vuln scan.
+Captures screenshots of all discovered URLs for visual triage.
+"""
+
+import logging
+import os
+
+from django.conf import settings
+
+from apps.core.web_assets.models import URL
+from .collector import collect
+from .analyzer import analyze, URLScreenshot
+
+logger = logging.getLogger(__name__)
+
+
+def run_gowitness(session) -> list[URLScreenshot]:
+    """
+    Capture screenshots for all URLs in the session.
+
+    Runs gowitness against discovered URLs to create visual artifacts
+    for triage and demo purposes.
+
+    Args:
+        session: The scan session object
+
+    Returns:
+        List of saved URLScreenshot records
+    """
+    # Get all URLs for this session
+    urls = list(
+        URL.objects.filter(session=session)
+        .values_list("url", flat=True)
+        .distinct()
+    )
+
+    if not urls:
+        logger.info(f"[gowitness:{session.id}] No URLs to screenshot")
+        return []
+
+    # Create output directory
+    data_dir = getattr(settings, "DATA_DIR", "data")
+    output_dir = os.path.join(data_dir, "screenshots", str(session.id))
+    os.makedirs(output_dir, exist_ok=True)
+
+    logger.info(
+        f"[gowitness:{session.id}] "
+        f"Starting screenshot capture for {len(urls)} URLs"
+    )
+
+    # Collect screenshots
+    records = collect(session, urls, output_dir)
+
+    if not records:
+        logger.info(f"[gowitness:{session.id}] No screenshots captured")
+        return []
+
+    # Analyze and create records
+    objs = analyze(session, records, output_dir)
+
+    if objs:
+        # Bulk create
+        URLScreenshot.objects.bulk_create(objs, ignore_conflicts=True)
+
+    saved = list(URLScreenshot.objects.filter(url__session=session))
+    total_size = sum(s.file_size for s in saved)
+
+    logger.info(
+        f"[gowitness:{session.id}] "
+        f"Saved {len(saved)} screenshots "
+        f"({total_size / 1024 / 1024:.1f} MB total)"
+    )
+
+    return saved


### PR DESCRIPTION
## Summary
Adds gowitness screenshot capture for visual reconnaissance of discovered URLs — Phase 10 in the scan pipeline.

## Changes
- **`apps/gowitness/collector.py`** — Runs `gowitness` against URLs, captures screenshots as PNG files, outputs JSON manifest with metadata
- **`apps/gowitness/analyzer.py`** — Stores screenshot metadata in `URLScreenshot` model linked to `URL` records
- **`apps/gowitness/scanner.py`** — Orchestrator that captures screenshots for all URLs in a scan session
- **`apps/gowitness/apps.py`** — Django app config with `tool_meta.phase=10`, `requires=["httpx"]`, `produces_findings=False`

## Design Decisions
- **Phase 10**: Runs after httpx + katana (URL discovery) but before nuclei (vuln scanning) — screenshots capture the final URL set
- **Storage**: Screenshots stored in `data/screenshots/<session_id>/` with metadata in `URLScreenshot` model
- **Graceful degradation**: If gowitness binary is missing, logs a warning and returns empty
- **File size tracking**: Stores file size for storage management

## Dependencies
- `gowitness` binary (https://github.com/sensepost/gowitness) — 4.5K+ stars, Go binary, uses headless Chromium

## Testing
1. Install `gowitness` binary
2. Run a scan against a domain
3. Verify screenshots appear in `data/screenshots/<session_id>/`
4. Verify `URLScreenshot` records are created with correct metadata

## Note
Frontend "Screenshots" tab with thumbnail grid and click-to-zoom modal requires a separate React component. This PR implements the backend only.

## Related Issues
Fixes #77