### PR TITLE
feat: add subdomain takeover detection via subzy (Fixes #76)

### DIFF
--- a/apps/takeover_check/analyzer.py
+++ b/apps/takeover_check/analyzer.py
@@ -1,0 +1,91 @@
+"""Subdomain takeover analyzer — parse subzy results and create Finding records."""
+
+import logging
+
+from apps.core.assets.models import Subdomain
+from apps.core.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+# Severity mapping for takeover vulnerabilities
+SEVERITY = "high"
+
+
+def analyze(session, records: list[dict]) -> list[Finding]:
+    """
+    Parse subzy results and create Finding records.
+
+    Args:
+        session: The scan session object
+        records: List of subzy result records
+
+    Returns:
+        List of Finding model instances
+    """
+    if not records:
+        return []
+
+    # Get subdomains for this session
+    subdomains = {
+        s.subdomain: s
+        for s in Subdomain.objects.filter(session=session)
+    }
+
+    objs = []
+
+    for record in records:
+        try:
+            subdomain_str = record.get("subdomain", "")
+            if not subdomain_str:
+                continue
+
+            # Find matching subdomain record
+            subdomain = subdomains.get(subdomain_str)
+            if not subdomain:
+                continue
+
+            # Extract details
+            platform = record.get("platform", "unknown")
+            cname = record.get("cname", "")
+            status_code = record.get("status_code", "")
+            vulnerable = record.get("vulnerable", False)
+
+            if not vulnerable:
+                continue
+
+            # Create Finding
+            obj = Finding(
+                session=session,
+                subdomain=subdomain,
+                source="takeover_check",
+                check_type="subdomain_takeover",
+                severity=SEVERITY,
+                title=f"Subdomain takeover vulnerability: {subdomain_str}",
+                description=(
+                    f"Subdomain {subdomain_str} is vulnerable to takeover.\n\n"
+                    f"Platform: {platform}\n"
+                    f"CNAME: {cname}\n"
+                    f"HTTP Status: {status_code}\n\n"
+                    f"The subdomain points to an unclaimed {platform} resource. "
+                    f"An attacker could register this resource and serve content "
+                    f"as {subdomain_str}."
+                ),
+                extras={
+                    "platform": platform,
+                    "cname": cname,
+                    "status_code": status_code,
+                    "subdomain": subdomain_str,
+                },
+            )
+            objs.append(obj)
+
+        except Exception as e:
+            logger.warning(f"Failed to process subzy record: {e}")
+            continue
+
+    logger.info(
+        f"[takeover_check:{session.id}] "
+        f"Analyzed {len(records)} records → {len(objs)} findings"
+    )
+
+    return objs

--- a/apps/takeover_check/apps.py
+++ b/apps/takeover_check/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+
+class TakeoverCheckConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.takeover_check"
+    label = "takeover_check"
+    verbose_name = "Subdomain Takeover Check"
+    tool_meta = {
+        "label": "Subdomain Takeover Check",
+        "runner": "apps.takeover_check.scanner.run_takeover_check",
+        "phase": 3.5,
+        "requires": ["dnsx"],
+        "produces_findings": True,
+    }

--- a/apps/takeover_check/collector.py
+++ b/apps/takeover_check/collector.py
@@ -1,0 +1,89 @@
+"""Subdomain takeover detection — wraps subzy to detect dangling DNS records."""
+
+import json
+import logging
+import subprocess
+import shutil
+import tempfile
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def collect(session, subdomains: list[str]) -> list[dict]:
+    """
+    Run subzy against a list of subdomains to detect takeover vulnerabilities.
+
+    Args:
+        session: The scan session object
+        subdomains: List of subdomain strings to check
+
+    Returns:
+        List of takeover vulnerability records
+    """
+    if not subdomains:
+        return []
+
+    binary = getattr(settings, "TOOL_SUBZY", "subzy")
+
+    if not shutil.which(binary):
+        logger.warning(f"subzy binary not found at '{binary}'")
+        return []
+
+    # Write subdomains to temp file
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("\n".join(subdomains))
+        tmp = f.name
+
+    try:
+        # Run subzy
+        cmd = [
+            binary,
+            "run",
+            "--targets", tmp,
+            "--hide_fails",
+            "--timeout", "30",
+            "--json",
+        ]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=len(subdomains) * 60,  # 60s per subdomain max
+            stdin=subprocess.DEVNULL,
+        )
+
+        if result.returncode != 0:
+            logger.warning(f"subzy failed: {result.stderr[:300]}")
+            return []
+
+        # Parse JSON output
+        records = []
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+                records.append(record)
+            except json.JSONDecodeError:
+                continue
+
+        logger.info(f"subzy found {len(records)} potential takeovers")
+        return records
+
+    except subprocess.TimeoutExpired:
+        logger.warning("subzy timed out")
+        return []
+    except Exception as e:
+        logger.error(f"subzy error: {e}")
+        return []
+    finally:
+        # Clean up temp file
+        try:
+            import os
+            os.unlink(tmp)
+        except OSError:
+            pass

--- a/apps/takeover_check/scanner.py
+++ b/apps/takeover_check/scanner.py
@@ -1,0 +1,71 @@
+"""Subdomain takeover scanner — orchestrator: read Subdomains → detect takeovers → save findings.
+
+Phase 3.5: Runs after dnsx (needs CNAME records) but before port scanning.
+Detects dangling DNS records pointing to unclaimed cloud resources.
+"""
+
+import logging
+
+from apps.core.assets.models import Subdomain
+from apps.core.findings.models import Finding
+from .collector import collect
+from .analyzer import analyze
+
+logger = logging.getLogger(__name__)
+
+
+def run_takeover_check(session) -> list[Finding]:
+    """
+    Check all subdomains for takeover vulnerabilities.
+
+    Runs subzy against discovered subdomains to detect dangling DNS records
+    pointing to unclaimed cloud resources (S3, Heroku, GitHub Pages, etc.).
+
+    Args:
+        session: The scan session object
+
+    Returns:
+        List of saved Finding records
+    """
+    # Get all unique subdomains for this session
+    subdomains = list(
+        Subdomain.objects.filter(session=session)
+        .values_list("subdomain", flat=True)
+        .distinct()
+    )
+
+    if not subdomains:
+        logger.info(f"[takeover_check:{session.id}] No subdomains to check")
+        return []
+
+    logger.info(
+        f"[takeover_check:{session.id}] "
+        f"Starting takeover detection for {len(subdomains)} subdomains"
+    )
+
+    # Collect takeover vulnerabilities
+    records = collect(session, subdomains)
+
+    if not records:
+        logger.info(f"[takeover_check:{session.id}] No takeovers detected")
+        return []
+
+    # Analyze and create findings
+    objs = analyze(session, records)
+
+    if objs:
+        # Bulk create
+        Finding.objects.bulk_create(objs, ignore_conflicts=True)
+
+    saved = list(Finding.objects.filter(
+        session=session,
+        source="takeover_check",
+    ))
+
+    logger.info(
+        f"[takeover_check:{session.id}] "
+        f"Found {len(saved)} takeover vulnerabilities "
+        f"(from {len(subdomains)} subdomains)"
+    )
+
+    return saved


### PR DESCRIPTION
## Summary
Adds subdomain takeover detection using `subzy` as Phase 3.5 in the scan pipeline — after dnsx (CNAME resolution) but before port scanning.

## Changes
- **`apps/takeover_check/collector.py`** — Runs `subzy` against subdomains to detect dangling DNS records pointing to unclaimed cloud resources
- **`apps/takeover_check/analyzer.py`** — Creates high-severity `Finding` records with platform name, CNAME, and HTTP status
- **`apps/takeover_check/scanner.py`** — Orchestrator that checks all subdomains for takeover vulnerabilities
- **`apps/takeover_check/apps.py`** — Django app config with `tool_meta.phase=3.5`, `requires=["dnsx"]`, `produces_findings=True`

## Design Decisions
- **Phase 3.5**: Runs after dnsx (needs CNAME records) but before port scanning — only needs DNS + HTTP signals
- **Option A (subzy wrap)**: Fastest to ship, leverages subzy's built-in platform pattern database covering 80+ platforms
- **Produces findings**: Each detected takeover is a `severity=high` Finding with platform details
- **Graceful degradation**: If subzy binary is missing, logs a warning and returns empty

## Dependencies
- `subzy` binary (https://github.com/LukaSikic/subzy) — 1.5K+ stars, Go binary, maintained

## Testing
1. Install `subzy` binary
2. Run a scan against a domain with known dangling DNS records
3. Verify takeover findings appear in the findings list
4. Verify each finding includes platform name, CNAME, and HTTP status

## Related Issues
Fixes #76