### PR TITLE
feat: add S3 bucket discovery and public access detection (Fixes #74)

### DIFF
--- a/apps/s3_enum/analyzer.py
+++ b/apps/s3_enum/analyzer.py
@@ -1,0 +1,75 @@
+"""S3 bucket analyzer — parse results and create Finding records."""
+
+import logging
+
+from apps.core.assets.models import Subdomain
+from apps.core.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+# Severity mapping for S3 findings
+SEVERITY_MAP = {
+    "public-list": "high",
+    "public-read": "medium",
+}
+
+
+def analyze(session, records: list[dict]) -> list[Finding]:
+    """
+    Parse S3 bucket results and create Finding records.
+
+    Args:
+        session: The scan session object
+        records: List of S3 bucket records
+
+    Returns:
+        List of Finding model instances
+    """
+    if not records:
+        return []
+
+    objs = []
+
+    for record in records:
+        try:
+            bucket_name = record.get("bucket", "")
+            url = record.get("url", "")
+            access = record.get("access", "unknown")
+            contents = record.get("contents", "")
+
+            # Determine severity
+            severity = SEVERITY_MAP.get(access, "low")
+
+            # Create Finding
+            obj = Finding(
+                session=session,
+                source="s3_enum",
+                check_type="s3_bucket",
+                severity=severity,
+                title=f"Publicly accessible S3 bucket: {bucket_name}",
+                description=(
+                    f"S3 bucket {bucket_name} is publicly accessible.\n\n"
+                    f"Access Level: {access}\n"
+                    f"URL: {url}\n\n"
+                    f"{f'Contents preview: {contents[:200]}...' if contents else ''}\n\n"
+                    f"{'Anyone can list bucket contents.' if access == 'public-list' else 'Bucket exists and is publicly accessible.'}"
+                ),
+                extras={
+                    "bucket": bucket_name,
+                    "url": url,
+                    "access": access,
+                    "contents_preview": contents[:200] if contents else "",
+                },
+            )
+            objs.append(obj)
+
+        except Exception as e:
+            logger.warning(f"Failed to process S3 record: {e}")
+            continue
+
+    logger.info(
+        f"[s3_enum:{session.id}] "
+        f"Analyzed {len(records)} records → {len(objs)} findings"
+    )
+
+    return objs

--- a/apps/s3_enum/apps.py
+++ b/apps/s3_enum/apps.py
@@ -1,0 +1,15 @@
+from django.apps import AppConfig
+
+
+class S3EnumConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.s3_enum"
+    label = "s3_enum"
+    verbose_name = "S3 Bucket Discovery"
+    tool_meta = {
+        "label": "S3 Bucket Discovery",
+        "runner": "apps.s3_enum.scanner.run_s3_enum",
+        "phase": 4.5,
+        "requires": ["naabu"],
+        "produces_findings": True,
+    }

--- a/apps/s3_enum/collector.py
+++ b/apps/s3_enum/collector.py
@@ -1,0 +1,154 @@
+"""S3 bucket discovery — guess bucket names and probe for public access."""
+
+import logging
+import subprocess
+import shutil
+import json
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+# Common S3 bucket name patterns
+BUCKET_PATTERNS = [
+    "{domain}",
+    "{domain}-prod",
+    "{domain}-production",
+    "{domain}-staging",
+    "{domain}-dev",
+    "{domain}-test",
+    "{domain}-backup",
+    "{domain}-backups",
+    "{domain}-assets",
+    "{domain}-static",
+    "{domain}-media",
+    "{domain}-uploads",
+    "{domain}-data",
+    "{domain}-logs",
+    "{domain}-archive",
+    "{name}",
+    "{name}-prod",
+    "{name}-production",
+    "{name}-staging",
+    "{name}-dev",
+    "{name}-test",
+    "{name}-backup",
+    "{name}-backups",
+    "{name}-assets",
+    "{name}-static",
+    "{name}-media",
+    "{name}-uploads",
+    "{name}-data",
+    "{name}-logs",
+    "{name}-archive",
+]
+
+
+def _generate_bucket_names(domain: str) -> list[str]:
+    """Generate potential bucket names from a domain."""
+    names = set()
+
+    # Extract name parts
+    parts = domain.split(".")
+    name = parts[0] if parts else domain
+
+    for pattern in BUCKET_PATTERNS:
+        try:
+            names.add(pattern.format(domain=domain, name=name))
+        except (KeyError, IndexError):
+            continue
+
+    return list(names)
+
+
+def _probe_bucket(bucket_name: str) -> dict | None:
+    """
+    Probe an S3 bucket for public access.
+
+    Returns dict with bucket info if publicly accessible, None otherwise.
+    """
+    try:
+        # Try to list bucket contents (public list)
+        result = subprocess.run(
+            ["aws", "s3", "ls", f"s3://{bucket_name}", "--no-sign-request"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode == 0:
+            # Bucket is publicly listable
+            return {
+                "bucket": bucket_name,
+                "url": f"https://{bucket_name}.s3.amazonaws.com",
+                "access": "public-list",
+                "contents": result.stdout[:500],
+            }
+
+        # Try to head bucket (public read)
+        result = subprocess.run(
+            ["aws", "s3api", "head-bucket", "--bucket", bucket_name, "--no-sign-request"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if result.returncode == 0:
+            # Bucket exists and is publicly accessible
+            return {
+                "bucket": bucket_name,
+                "url": f"https://{bucket_name}.s3.amazonaws.com",
+                "access": "public-read",
+                "contents": "",
+            }
+
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    return None
+
+
+def collect(session, domains: list[str]) -> list[dict]:
+    """
+    Discover publicly accessible S3 buckets for given domains.
+
+    Args:
+        session: The scan session object
+        domains: List of domain names to check
+
+    Returns:
+        List of publicly accessible S3 bucket records
+    """
+    if not domains:
+        return []
+
+    # Check if AWS CLI is available
+    if not shutil.which("aws"):
+        logger.warning("AWS CLI not found, skipping S3 enumeration")
+        return []
+
+    # Generate bucket names for all domains
+    all_bucket_names = set()
+    for domain in domains:
+        all_bucket_names.update(_generate_bucket_names(domain))
+
+    logger.info(
+        f"[s3_enum:{session.id}] "
+        f"Generated {len(all_bucket_names)} potential bucket names "
+        f"from {len(domains)} domains"
+    )
+
+    # Probe each bucket
+    records = []
+    for bucket_name in all_bucket_names:
+        result = _probe_bucket(bucket_name)
+        if result:
+            records.append(result)
+
+    logger.info(
+        f"[s3_enum:{session.id}] "
+        f"Found {len(records)} publicly accessible S3 buckets "
+        f"(from {len(all_bucket_names)} probed)"
+    )
+
+    return records

--- a/apps/s3_enum/scanner.py
+++ b/apps/s3_enum/scanner.py
@@ -1,0 +1,70 @@
+"""S3 bucket scanner — orchestrator: read domains → discover buckets → save findings.
+
+Phase 4.5: Runs after naabu (port scanning) but before service detection.
+Discovers publicly accessible S3 buckets by guessing bucket names.
+"""
+
+import logging
+
+from apps.core.assets.models import Subdomain
+from apps.core.findings.models import Finding
+from .collector import collect
+from .analyzer import analyze
+
+logger = logging.getLogger(__name__)
+
+
+def run_s3_enum(session) -> list[Finding]:
+    """
+    Discover publicly accessible S3 buckets for all domains in the session.
+
+    Guesses bucket names based on domain patterns and probes for public access.
+
+    Args:
+        session: The scan session object
+
+    Returns:
+        List of saved Finding records
+    """
+    # Get all unique domains for this session
+    domains = list(
+        Subdomain.objects.filter(session=session)
+        .values_list("subdomain", flat=True)
+        .distinct()
+    )
+
+    if not domains:
+        logger.info(f"[s3_enum:{session.id}] No domains to check")
+        return []
+
+    logger.info(
+        f"[s3_enum:{session.id}] "
+        f"Starting S3 bucket discovery for {len(domains)} domains"
+    )
+
+    # Collect S3 buckets
+    records = collect(session, domains)
+
+    if not records:
+        logger.info(f"[s3_enum:{session.id}] No public S3 buckets found")
+        return []
+
+    # Analyze and create findings
+    objs = analyze(session, records)
+
+    if objs:
+        # Bulk create
+        Finding.objects.bulk_create(objs, ignore_conflicts=True)
+
+    saved = list(Finding.objects.filter(
+        session=session,
+        source="s3_enum",
+    ))
+
+    logger.info(
+        f"[s3_enum:{session.id}] "
+        f"Found {len(saved)} publicly accessible S3 buckets "
+        f"(from {len(domains)} domains)"
+    )
+
+    return saved


### PR DESCRIPTION
## Summary
Adds S3 bucket discovery and public access detection as Phase 4.5 in the scan pipeline — after naabu (port scanning) but before service detection.

## Changes
- **`apps/s3_enum/collector.py`** — Generates 30+ bucket name patterns per domain, probes each for public-list and public-read access using AWS CLI with `--no-sign-request`
- **`apps/s3_enum/analyzer.py`** — Creates `Finding` records for publicly accessible buckets with severity based on access level
- **`apps/s3_enum/scanner.py`** — Orchestrator that discovers S3 buckets for all domains in a scan session
- **`apps/s3_enum/apps.py`** — Django app config with `tool_meta.phase=4.5`, `requires=["naabu"]`, `produces_findings=True`

## Design Decisions
- **Phase 4.5**: Runs after naabu (port scanning) but before service detection — discovers cloud assets early
- **Unauthenticated**: Uses AWS CLI with `--no-sign-request` — no credentials required
- **Bucket name guessing**: Generates 30+ patterns per domain (e.g., `{domain}-prod`, `{domain}-assets`, `{name}-backup`)
- **Access levels**: Detects public-list (high severity) and public-read (medium severity)
- **Graceful degradation**: If AWS CLI is missing, logs a warning and returns empty

## Dependencies
- AWS CLI (https://aws.amazon.com/cli/) — installed in most environments, no credentials needed for public access probing

## Testing
1. Install AWS CLI
2. Run a scan against a domain with known public S3 buckets
3. Verify bucket findings appear in the findings list
4. Verify each finding includes bucket name, URL, and access level

## Note
This is the first phase of cloud asset enumeration (issue #74). Future phases can add:
- Azure Blob discovery
- GCP Cloud Storage discovery
- Subdomain → cloud CNAME chain detection
- ProjectDiscovery cloudlist integration

## Related Issues
Fixes #74