### PR TITLE
chore(github): add no-bounty + recognition + first-time-CI notes to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,12 @@ body:
         **Security issue?** Please use private reporting instead — see
         [SECURITY.md](https://github.com/cybersecify/OpenEASD/blob/main/SECURITY.md).
 
+        **About this project:** OpenEASD is MIT-licensed open source
+        maintained by CyberSecify (Rathnakara G N + Ashok S Kamat).
+        We don't pay for bug reports or run a bug bounty program —
+        community reports are welcomed and credited in CHANGELOG /
+        commit attribution / Discussions.
+
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,6 +12,12 @@ body:
         For "add tool X", consider opening a "New tool proposal" issue instead
         — it's a different kind of conversation.
 
+        **About this project:** OpenEASD is MIT-licensed open source
+        maintained by CyberSecify (Rathnakara G N + Ashok S Kamat).
+        Feature requests don't carry bounties — but if you'd like to
+        ship the feature yourself, contributors are credited in
+        CHANGELOG / commit attribution / Discussions.
+
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_tool.yml
+++ b/.github/ISSUE_TEMPLATE/new_tool.yml
@@ -14,6 +14,12 @@ body:
         This template is for proposing — code can come in the same PR, or
         we can discuss the design first if it's not obvious.
 
+        **About this project:** OpenEASD is MIT-licensed open source
+        maintained by CyberSecify (Rathnakara G N + Ashok S Kamat).
+        We don't pay for PRs — community contributors are credited in
+        CHANGELOG / commit attribution / Discussions, and (when
+        applicable) co-credited in conference talks and publications.
+
   - type: input
     id: tool-name
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,10 @@ common things reviewers will check first. See CONTRIBUTING.md if
 anything's unclear.
 -->
 
+> **First time contributing?** CI won't run automatically on PRs from new accounts — that's our anti-spam gate, not unresponsiveness. A maintainer will approve it within a few hours, up to 2 business days depending on load.
+
+> **About contributions:** OpenEASD is MIT-licensed open source maintained by CyberSecify (Rathnakara G N + Ashok S Kamat). Community contributions are welcomed — they make the project move faster and amplify what we can give back to the security community. We don't pay for PRs or run a bug bounty program; contributions are recognised through public CHANGELOG credit, commit attribution, GitHub Discussion shout-outs, and (where applicable) conference / publication co-credit. See [SECURITY.md](https://github.com/cybersecify/OpenEASD/blob/main/SECURITY.md) for the no-bounty note and [CONTRIBUTING.md](https://github.com/cybersecify/OpenEASD/blob/main/CONTRIBUTING.md) for what we look for in a PR.
+
 ## What this changes
 
 <!-- 1-3 sentences. The "why" matters more than the "what" — the diff


### PR DESCRIPTION
## What

Adds three reusable notes across the PR template and the three issue templates (`bug_report.yml`, `feature_request.yml`, `new_tool.yml`):

1. **First-time-contributor CI explanation** (PR template only) — names the GitHub-Actions "require approval for first-time contributors" gate as anti-spam, not reviewer unresponsiveness, with realistic timing ("a few hours, up to 2 business days depending on load").
2. **Maintainer + funding-model statement** (all four templates) — clarifies that OpenEASD is MIT-licensed open source maintained by Cybersecify, and that there's no bug bounty / no per-PR payment.
3. **Positive recognition framing** (all four templates) — names the actual reward path (CHANGELOG credit, commit attribution, Discussion shout-outs, conference / publication co-credit) so "no bounty" doesn't read as "you get nothing."

## Why

| Note | Triggered by | Goal |
|---|---|---|
| CI gate explanation | First-time-contributor approval setting enabled today | Stop first-timers silently bailing while CI shows "waiting for approval" |
| No-bounty statement | Bot-scam PR #78 claiming a non-existent $5,000 bounty | Pre-empt future fake-bounty PRs / issues at the template level |
| Recognition framing | "What's in it for contributors?" — direct user question | Make the real reward path explicit on day one |

## Maintainer framing — locked policy

*"OpenEASD is maintained by Cybersecify with or without external contributions; community help amplifies what we can give back, not a dependency."*

This is the honest description — not "community-maintained" (which would imply distributed maintainership we don't have), not closed either.

## Sponsors decision

Explicitly **deferred** in this PR. No `.github/FUNDING.yml` added. Review scheduled for 2026-07-01 with named triggers (real infra cost, ≥3 monthly external contributors, or inbound "how do I support this?" inquiry). If none fire by then, push the review out another month. The reasoning: with near-zero infra cost and ~zero monthly contributors, a Sponsors button would be a vanity badge with no honest use-of-funds story.

## Pairs with

- PR #79 — `.github/CODEOWNERS` (auto-routes review to the right maintainer)
- Branch protection rules — configured today via `gh api` (require 1 approving review, no force-push, dismiss stale reviews, conversation resolution)
- "Require approval for first-time contributors" — enabled today on Actions

## Test plan

- [x] PR template renders correctly in GitHub's preview (markdown blockquotes display, links resolve)
- [x] All three issue templates still pass YAML validation (extending an existing `type: markdown` block, no schema change)
- [x] Wording reviewed for accuracy: "maintained by Cybersecify," not "community-maintained"
- [x] No CI/code changes — pure template content
