### PR TITLE
feat(readme): rewrite hero — dual-audience (red team + defender) + Built by

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@
 [![Docker Image](https://img.shields.io/badge/ghcr.io%2Fcybersecify%2Fopeneasd-latest-2496ed?logo=docker&logoColor=white)](https://github.com/cybersecify/OpenEASD/pkgs/container/openeasd)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-**See your domain like an attacker does.** OpenEASD is a self-hosted scanner that wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `dnsx`, `naabu`, `httpx`, `nuclei`, `nmap` — behind a single web UI with scheduling, alerts, and findings tracking. Free, MIT-licensed, one `docker run`. Results stay on your machine.
+**See what attackers see. Use it before they do.**
 
-It surfaces the **lowest hanging fruits** — what someone scanning your perimeter sees first. Eleven attack vectors across DNS, email, TLS, SSH, ports, CVEs, and web hygiene.
+Use it as a **red teamer** to map external surface fast on a target you're engaged with. Use it as a **defender** to see what's leaking out of your own infrastructure — subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs — without paying $500-5000/mo for a commercial EASM platform.
+
+OpenEASD wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `dnsx`, `naabu`, `httpx`, `nuclei`, `nmap` — behind a single web UI with scheduling, alerts, and findings tracking. Eleven attack vectors across DNS, email, TLS, SSH, ports, CVEs, and web hygiene. Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
+
+Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [CyberSecify](https://cybersecify.com) — the same tool we run in engagements and on our own infrastructure.
 
 ![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 14 tool steps tracked live](docs/screenshots/scan-detail-live.png)
 


### PR DESCRIPTION
## What

Replaces the single-line hero with a four-paragraph hero:

```
**See what attackers see. Use it before they do.**

Use it as a **red teamer** to map external surface fast on a target you're engaged with.
Use it as a **defender** to see what's leaking out of your own infrastructure —
subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs — without
paying $500-5000/mo for a commercial EASM platform.

OpenEASD wraps the open-source recon tools security teams already use —
`subfinder`, `amass`, `dnsx`, `naabu`, `httpx`, `nuclei`, `nmap` — behind a
single web UI with scheduling, alerts, and findings tracking. Eleven attack
vectors across DNS, email, TLS, SSH, ports, CVEs, and web hygiene.
Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.

Built by Rathnakara G N and Ashok S Kamat of Cybersecify — the same tool
we run in engagements and on our own infrastructure.
```

## Why

| Change | Why |
|---|---|
| Punchier opener (See / Use parallel) | Action verb (Use) makes it agentic — not just passive visibility. Two sub-10-word sentences land fast |
| Explicit dual-audience body (red teamer + defender) | Old hero only surfaced the defender framing implicitly via "your domain". OpenEASD has two real user lanes — both should see themselves immediately |
| $500-5000/mo comparison | Makes the defender value concrete. Anyone evaluating SaaS EASM knows the price tag instantly |
| Built-by line above the fold | Currently buried in an "Author" section at line 353 of a 354-line README. Brand-build only works if visible. LinkedIn + Cybersecify links let visitors verify in one click |
| "Same tool we run in engagements and on our own infrastructure" | Credibility signal — authors use it themselves. Standard OSS-with-commercial-arm pattern, visible without being salesy |

## Pairs with

PR #84 (templates) — same dual framing: "maintained by Cybersecify (Rathnakara G N + Ashok S Kamat)" appears in every PR + issue creation flow. README and templates now tell the same story.

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [x] LinkedIn URLs match the existing "Author" section (line 353) — same `https://www.linkedin.com/in/<handle>/` format
- [x] No claim drift from code: dangling CNAMEs / missing TLS / known CVEs all map to existing tool outputs (dnsx + tls_checker + nmap + nuclei) — not adding any new claims that don't trace to source
- [x] Hero length still scannable in 10 seconds (4 short paragraphs, not a wall of text)
