### PR TITLE
fix(contributing): correct "four-file pattern" → "five-file pattern"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,10 @@ and `scanner.py` (thin orchestrator: `collect → analyze → save`). Add
 it — the tool shows up in the workflow editor and runs in pipeline order.
 
 Look at `apps/web_checker/` or `apps/ssh_checker/` for working examples
-of the four-file pattern. `apps/subfinder/` is a good asset-producing
-example (`produces_findings: False`).
+of the five-file pattern (`apps.py`, `models.py`, `collector.py`,
+`analyzer.py`, `scanner.py` — plus the standard `__init__.py` Python
+package marker). `apps/subfinder/` is a good asset-producing example
+(`produces_findings: False`).
 
 ## Other ways to help
 


### PR DESCRIPTION
## What
CONTRIBUTING.md called the new-tool plugin pattern "four-file" but the file list immediately above names **five** Python modules. Corrected to "five-file pattern" with the modules named explicitly, plus a note that `__init__.py` is the standard Python package marker.

## Why
The drift caused review confusion on PR #80 — an LLM reviewer reading "four-file pattern" flagged `__init__.py` as an extra file that shouldn't have been included. The actual five-module count matches CLAUDE.md.

## Test plan
- [x] Verified `apps/web_checker/`, `apps/ssh_checker/`, `apps/subfinder/` each have 5 Python modules + `__init__.py`
- [x] No code change