### PR TITLE
fix(docs): post-#87 doc sync — test table, counts, jwt description, screenshot alt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -473,7 +473,8 @@ GET  /api/insights/                       — trends, top hosts, asset growth, K
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_service_detection.py` | 16 | XML parsing, Port enrichment, is_web |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
+| `tests/unit/test_takeover_check.py` | 35 | collector (binary missing, bad JSON, happy path), analyzer (vulnerable/non-vulnerable, FK link, dedup, extra field), scanner (no subdomains, persist + return) |
 | `tests/integration/test_scan_flow.py` | 13 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 71 | Smoke tests for all 35 API endpoints (auth + payload shape) |
 
-**Total: ~760 tests** (~719 fast + 41 slow domain_security)
+**Total: ~836 tests** (~795 fast + 41 slow domain_security)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ OpenEASD wraps the open-source recon tools security teams already use — `subfi
 
 Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [CyberSecify](https://cybersecify.com) — the same tool we run in engagements and on our own infrastructure.
 
-![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 14 tool steps tracked live](docs/screenshots/scan-detail-live.png)
+![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 15 tool steps tracked live](docs/screenshots/scan-detail-live.png)
 
 ## Who this is for
 
@@ -341,7 +341,7 @@ uv run pytest tests/
 - **paramiko** — SSH protocol inspection
 - **cryptography** — X.509 certificate analysis
 - **xhtml2pdf** — PDF report generation
-- **django-ninja-jwt** — JWT auth for the Ninja API (wraps `djangorestframework-simplejwt`); access + refresh tokens, blacklist on logout
+- **django-ninja-jwt** — JWT auth for the Ninja API (built on PyJWT); access + refresh tokens, blacklist on logout
 
 **Frontend:**
 - **React 19 + Vite 8** — SPA with hot module replacement


### PR DESCRIPTION
## Summary

Post-merge doc cleanup after #87 (subdomain takeover via subzy):

- **CLAUDE.md** — add `test_takeover_check.py` (35 tests) to tests table; update total from ~760 to ~836 (~795 fast + 41 slow)
- **README.md** — fix screenshot alt text "14 tool steps" → "15 tool steps"
- **README.md** — fix `django-ninja-jwt` description: removes incorrect "wraps djangorestframework-simplejwt" (that package isn't installed); correct description is "built on PyJWT"