### PR TITLE
fix(docs): consistent Cybersecify brand casing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
         [SECURITY.md](https://github.com/cybersecify/OpenEASD/blob/main/SECURITY.md).
 
         **About this project:** OpenEASD is MIT-licensed open source
-        maintained by CyberSecify (Rathnakara G N + Ashok S Kamat).
+        maintained by Cybersecify (Rathnakara G N + Ashok S Kamat).
         We don't pay for bug reports or run a bug bounty program —
         community reports are welcomed and credited in CHANGELOG /
         commit attribution / Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,7 @@ body:
         — it's a different kind of conversation.
 
         **About this project:** OpenEASD is MIT-licensed open source
-        maintained by CyberSecify (Rathnakara G N + Ashok S Kamat).
+        maintained by Cybersecify (Rathnakara G N + Ashok S Kamat).
         Feature requests don't carry bounties — but if you'd like to
         ship the feature yourself, contributors are credited in
         CHANGELOG / commit attribution / Discussions.

--- a/.github/ISSUE_TEMPLATE/new_tool.yml
+++ b/.github/ISSUE_TEMPLATE/new_tool.yml
@@ -15,7 +15,7 @@ body:
         we can discuss the design first if it's not obvious.
 
         **About this project:** OpenEASD is MIT-licensed open source
-        maintained by CyberSecify (Rathnakara G N + Ashok S Kamat).
+        maintained by Cybersecify (Rathnakara G N + Ashok S Kamat).
         We don't pay for PRs — community contributors are credited in
         CHANGELOG / commit attribution / Discussions, and (when
         applicable) co-credited in conference talks and publications.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ anything's unclear.
 
 > **First time contributing?** CI won't run automatically on PRs from new accounts — that's our anti-spam gate, not unresponsiveness. A maintainer will approve it within a few hours, up to 2 business days depending on load.
 
-> **About contributions:** OpenEASD is MIT-licensed open source maintained by CyberSecify (Rathnakara G N + Ashok S Kamat). Community contributions are welcomed — they make the project move faster and amplify what we can give back to the security community. We don't pay for PRs or run a bug bounty program; contributions are recognised through public CHANGELOG credit, commit attribution, GitHub Discussion shout-outs, and (where applicable) conference / publication co-credit. See [SECURITY.md](https://github.com/cybersecify/OpenEASD/blob/main/SECURITY.md) for the no-bounty note and [CONTRIBUTING.md](https://github.com/cybersecify/OpenEASD/blob/main/CONTRIBUTING.md) for what we look for in a PR.
+> **About contributions:** OpenEASD is MIT-licensed open source maintained by Cybersecify (Rathnakara G N + Ashok S Kamat). Community contributions are welcomed — they make the project move faster and amplify what we can give back to the security community. We don't pay for PRs or run a bug bounty program; contributions are recognised through public CHANGELOG credit, commit attribution, GitHub Discussion shout-outs, and (where applicable) conference / publication co-credit. See [SECURITY.md](https://github.com/cybersecify/OpenEASD/blob/main/SECURITY.md) for the no-bounty note and [CONTRIBUTING.md](https://github.com/cybersecify/OpenEASD/blob/main/CONTRIBUTING.md) for what we look for in a PR.
 
 ## What this changes
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Rathnakara G N (https://www.linkedin.com/in/rathnakaragn/) and Ashok S Kamat (https://www.linkedin.com/in/ashokskamat/) / CyberSecify
+Copyright (c) 2026 Rathnakara G N (https://www.linkedin.com/in/rathnakaragn/) and Ashok S Kamat (https://www.linkedin.com/in/ashokskamat/) / Cybersecify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use it as a **red teamer** to map external surface fast on a target you're engag
 
 OpenEASD wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `dnsx`, `subzy`, `naabu`, `httpx`, `nuclei`, `nmap` — behind a single web UI with scheduling, alerts, and findings tracking. Twelve attack vectors across DNS, email, TLS, SSH, ports, CVEs, subdomain takeover, and web hygiene. Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
 
-Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [CyberSecify](https://cybersecify.com) — the same tool we run in engagements and on our own infrastructure.
+Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [Cybersecify](https://cybersecify.com) — the same tool we run in engagements and on our own infrastructure.
 
 ![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 15 tool steps tracked live](docs/screenshots/scan-detail-live.png)
 
@@ -355,4 +355,4 @@ MIT License - see [LICENSE](LICENSE)
 
 ## Author
 
-[Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) / [CyberSecify](https://cybersecify.com)
+[Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) / [Cybersecify](https://cybersecify.com)


### PR DESCRIPTION
## What

Sweep across LICENSE, README (hero + author footer), PR template, and 3 issue templates. The brand is **Cybersecify** (lowercase 's') — not "CyberSecify". Repo org slug (`cybersecify`) and domain (`cybersecify.com`) were already correct.

8 occurrences across 6 files. No code or behavior change.

## Why

Brand consistency. Multiple surfaces had drifted to "CyberSecify" since the locked brand wording was relaxed by an earlier session.

## Test plan

- [x] `grep -rn "CyberSecify"` on tracked files returns 0 occurrences post-sweep
- [x] `grep -rn "Cybersecify"` confirms presence in all 6 files