### PR TITLE
fix(docs): correct scan pipeline phase numbers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,22 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 ## Scan Pipeline
 
 ```
-Phase 1  Domain Security    - DNS, email (SPF/DMARC/DKIM), RDAP checks
-Phase 2  Subfinder          - Passive subdomain enumeration
-Phase 2  Amass              - Active subdomain enumeration
-Phase 3  DNSx               - DNS resolution, public IP filtering
-Phase 3.5 Takeover Check    - Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud)
-Phase 4  Naabu              - TCP port scanning (top 100)
-Phase 5  Service Detection  - Classify ports as web/non-web via nmap -sV (auto)
-Phase 6  Nmap               - CVE scanning via NSE vulners (non-web ports)
-Phase 6  TLS Checker        - Certificate, cipher, and protocol analysis
-Phase 6  SSH Checker        - SSH configuration audit
-Phase 6  Nuclei Network     - Service-aware nuclei network templates against non-web ports
-Phase 7  httpx              - Web probing, URL discovery
-Phase 8  Katana             - Deep URL crawl on top of httpx (asset producer)
-Phase 8  Nuclei             - Web vulnerability scanning (community templates)
-Phase 8  Web Checker        - Security headers, cookies, CORS analysis
+Phase 1   Domain Security    - DNS, email (SPF/DMARC/DKIM), RDAP checks
+Phase 2   Subfinder          - Passive subdomain enumeration
+Phase 2   Amass              - Active subdomain enumeration
+Phase 3   DNSx               - DNS resolution, public IP filtering
+Phase 3.5 Takeover Check     - Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud)
+Phase 4   Naabu              - TCP port scanning (top 100)
+Phase 5   Service Detection  - Classify ports as web/non-web via nmap -sV (auto)
+Phase 7   Nmap               - CVE scanning via NSE vulners (non-web ports)
+Phase 7   TLS Checker        - Certificate, cipher, and protocol analysis
+Phase 7   SSH Checker        - SSH configuration audit
+Phase 7   Nuclei Network     - Service-aware nuclei network templates against non-web ports
+Phase 8   httpx              - Web probing, URL discovery
+Phase 8.5 Historical URLs    - Archived URL discovery via gau + waybackurls
+Phase 9   Katana             - Deep URL crawl on top of httpx (asset producer)
+Phase 10  Nuclei             - Web vulnerability scanning (community templates)
+Phase 10  Web Checker        - Security headers, cookies, CORS analysis
 ```
 
 ## Architecture


### PR DESCRIPTION
## What

Fixes stale phase numbers in the README Scan Pipeline section. The numbers had drifted from the actual `tool_meta` phase assignments over several merges.

| Tool | Before | After |
|---|---|---|
| Nmap, TLS Checker, SSH Checker, Nuclei Network | Phase 6 | Phase 7 |
| httpx | Phase 7 | Phase 8 |
| Historical URLs | missing | Phase 8.5 |
| Katana | Phase 8 | Phase 9 |
| Nuclei, Web Checker | Phase 8 | Phase 10 |

CLAUDE.md and AppConfig `tool_meta` values are the source of truth — this brings README into sync.

## Test Plan
- [ ] README phase numbers match `tool_meta` in each `apps/*/apps.py`