### PR TITLE
fix: renumber scan pipeline phases to sequential integers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,18 +319,18 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 | `apps/subfinder/` | 2 | No | Passive subdomain enumeration |
 | `apps/amass/` | 2 | No | Active subdomain enumeration |
 | `apps/dnsx/` | 3 | No | DNS resolution, public IP filtering |
-| `apps/takeover_check/` | 3.5 | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
-| `apps/naabu/` | 4 | No | Port scanning (top 100 TCP) |
-| `apps/core/service_detection/` | 5 | No | nmap -sV enriches Port.service + is_web |
+| `apps/takeover_check/` | 4 | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
+| `apps/naabu/` | 5 | No | Port scanning (top 100 TCP) |
+| `apps/core/service_detection/` | 6 | No | nmap -sV enriches Port.service + is_web |
 | `apps/nmap/` | 7 | Yes | NSE vulners CVE scan (non-web ports); backport-aware CVE matching (`backports.json` registry) |
 | `apps/tls_checker/` | 7 | Yes | TLS/cert analysis + cipher suite enumeration via `nmap --script ssl-enum-ciphers` (all ports) |
 | `apps/ssh_checker/` | 7 | Yes | SSH config analysis |
 | `apps/nuclei_network/` | 7 | Yes | Network protocol vuln scan (319 templates, non-web) |
 | `apps/httpx/` | 8 | No | Web probing, URL discovery |
-| `apps/historical_urls/` | 8.5 | No | Historical URL discovery via gau + waybackurls (Wayback Machine, OTX, Common Crawl) |
-| `apps/katana/` | 9 | No | Web crawling, endpoint discovery |
-| `apps/nuclei/` | 10 | Yes | Web vuln scan (community templates) |
-| `apps/web_checker/` | 10 | Yes | Security headers, cookies, CORS |
+| `apps/historical_urls/` | 9 | No | Historical URL discovery via gau + waybackurls (Wayback Machine, OTX, Common Crawl) |
+| `apps/katana/` | 10 | No | Web crawling, endpoint discovery |
+| `apps/nuclei/` | 11 | Yes | Web vuln scan (community templates) |
+| `apps/web_checker/` | 11 | Yes | Security headers, cookies, CORS |
 
 ### Tool app structure
 ```
@@ -353,18 +353,18 @@ Phase 1  domain_security    → Finding (DNS/email/RDAP)
 Phase 2  subfinder          → Subdomain (passive enumeration)
 Phase 2  amass              → Subdomain (active enumeration)
 Phase 3  dnsx               → IPAddress (public-only filter)
-Phase 3.5 takeover_check    → Finding (subzy — dangling DNS → unclaimed cloud)
-Phase 4  naabu              → Port (top 100 TCP scan)
-Phase 5  service_detection  → enriches Port.service + Port.is_web
+Phase 4  takeover_check     → Finding (subzy — dangling DNS → unclaimed cloud)
+Phase 5  naabu              → Port (top 100 TCP scan)
+Phase 6  service_detection  → enriches Port.service + Port.is_web
 Phase 7  nmap               → Finding (CVEs on non-web ports, is_web=False)  ┐
 Phase 7  tls_checker        → Finding (cipher/cert/protocol on all ports)    │ parallel
 Phase 7  ssh_checker        → Finding (SSH config on service="ssh" ports)    │
 Phase 7  nuclei_network     → Finding (network protocol vulns, non-web ports)┘
 Phase 8  httpx              → URL (web probing, CDN-aware via SNI)
-Phase 8.5 historical_urls → URL (gau + waybackurls — archived endpoints)
-Phase 9  katana             → URL (web crawling, endpoint discovery)
-Phase 10 nuclei             → Finding (web vulns via templates on URLs)
-Phase 10 web_checker        → Finding (headers, cookies, CORS on URLs)
+Phase 9  historical_urls    → URL (gau + waybackurls — archived endpoints)
+Phase 10 katana             → URL (web crawling, endpoint discovery)
+Phase 11 nuclei             → Finding (web vulns via templates on URLs)
+Phase 11 web_checker        → Finding (headers, cookies, CORS on URLs)
 ```
 
 ### Scan flow
@@ -380,7 +380,7 @@ create_scan_session(domain)          # auto-assigns default workflow
 ### Key design rules
 1. **Tools never import from each other.** Shared data flows through `apps/core/assets/`, `apps/core/web_assets/`, and `apps/core/findings/`.
 2. **Tools self-register.** Add `tool_meta` to AppConfig + add to `INSTALLED_APPS`. No other core files to touch.
-3. **Port.is_web** classifies ports. Set by `service_detection` (Phase 5) based on nmap -sV service name. Used by nmap to skip web ports (`is_web=False` only). tls_checker probes all ports — including HTTPS (port 443).
+3. **Port.is_web** classifies ports. Set by `service_detection` (Phase 6) based on nmap -sV service name. Used by nmap to skip web ports (`is_web=False` only). tls_checker probes all ports — including HTTPS (port 443).
 4. **dnsx filters to public IPs only.** Private/loopback/link-local/AWS metadata IPs dropped.
 5. **httpx feeds subdomain:port pairs, not IP:port pairs.** Cloudflare/CDN-fronted services need SNI matching.
 6. **nmap only scans non-web ports** (`Port.objects.filter(is_web=False)`).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline** — 15-tool scan workflow from domain to findings
+- **Automated pipeline** — 16-tool scan workflow from domain to findings
 - **Network attack surface scanning** — CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **Dynamic workflows** — Create custom scan configurations, enable/disable tools per workflow
 - **Tool auto-registration** — Add new tools with zero core modification
@@ -65,22 +65,22 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 ## Scan Pipeline
 
 ```
-Phase 1   Domain Security    - DNS, email (SPF/DMARC/DKIM), RDAP checks
-Phase 2   Subfinder          - Passive subdomain enumeration
-Phase 2   Amass              - Active subdomain enumeration
-Phase 3   DNSx               - DNS resolution, public IP filtering
-Phase 3.5 Takeover Check     - Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud)
-Phase 4   Naabu              - TCP port scanning (top 100)
-Phase 5   Service Detection  - Classify ports as web/non-web via nmap -sV (auto)
-Phase 7   Nmap               - CVE scanning via NSE vulners (non-web ports)
-Phase 7   TLS Checker        - Certificate, cipher, and protocol analysis
-Phase 7   SSH Checker        - SSH configuration audit
-Phase 7   Nuclei Network     - Service-aware nuclei network templates against non-web ports
-Phase 8   httpx              - Web probing, URL discovery
-Phase 8.5 Historical URLs    - Archived URL discovery via gau + waybackurls
-Phase 9   Katana             - Deep URL crawl on top of httpx (asset producer)
-Phase 10  Nuclei             - Web vulnerability scanning (community templates)
-Phase 10  Web Checker        - Security headers, cookies, CORS analysis
+Phase 1  Domain Security   - DNS, email (SPF/DMARC/DKIM), RDAP checks
+Phase 2  Subfinder         - Passive subdomain enumeration
+Phase 2  Amass             - Active subdomain enumeration
+Phase 3  DNSx              - DNS resolution, public IP filtering
+Phase 4  Takeover Check    - Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud)
+Phase 5  Naabu             - TCP port scanning (top 100)
+Phase 6  Service Detection - Classify ports as web/non-web via nmap -sV (auto)
+Phase 7  Nmap              - CVE scanning via NSE vulners (non-web ports)
+Phase 7  TLS Checker       - Certificate, cipher, and protocol analysis
+Phase 7  SSH Checker       - SSH configuration audit
+Phase 7  Nuclei Network    - Service-aware nuclei network templates against non-web ports
+Phase 8  httpx             - Web probing, URL discovery
+Phase 9  Historical URLs   - Archived URL discovery via gau + waybackurls
+Phase 10 Katana            - Deep URL crawl on top of httpx (asset producer)
+Phase 11 Nuclei            - Web vulnerability scanning (community templates)
+Phase 11 Web Checker       - Security headers, cookies, CORS analysis
 ```
 
 ## Architecture

--- a/apps/core/service_detection/apps.py
+++ b/apps/core/service_detection/apps.py
@@ -8,7 +8,7 @@ class ServiceDetectionConfig(AppConfig):
     tool_meta = {
         "label": "Service Detection",
         "runner": "apps.core.service_detection.detector.detect_services",
-        "phase": 5,
+        "phase": 6,
         "requires": ["naabu"],
         "produces_findings": False,
         "core": True,  # always runs, hidden from workflow UI

--- a/apps/historical_urls/apps.py
+++ b/apps/historical_urls/apps.py
@@ -9,7 +9,7 @@ class HistoricalUrlsConfig(AppConfig):
     tool_meta = {
         "label": "Historical URLs (gau + waybackurls)",
         "runner": "apps.historical_urls.scanner.run_historical_urls",
-        "phase": 8.5,
+        "phase": 9,
         "requires": ["httpx"],
         "produces_findings": False,
     }

--- a/apps/katana/apps.py
+++ b/apps/katana/apps.py
@@ -9,7 +9,7 @@ class KatanaConfig(AppConfig):
     tool_meta = {
         "label": "Katana",
         "runner": "apps.katana.scanner.run_katana",
-        "phase": 9,
+        "phase": 10,
         "requires": ["httpx"],
         "produces_findings": False,
     }

--- a/apps/naabu/apps.py
+++ b/apps/naabu/apps.py
@@ -9,7 +9,7 @@ class NaabuConfig(AppConfig):
     tool_meta = {
         "label": "Naabu (Port Scan)",
         "runner": "apps.naabu.scanner.run_naabu",
-        "phase": 4,
+        "phase": 5,
         "requires": ["dnsx"],
         "produces_findings": False,
     }

--- a/apps/nuclei/apps.py
+++ b/apps/nuclei/apps.py
@@ -9,7 +9,7 @@ class NucleiConfig(AppConfig):
     tool_meta = {
         "label": "Nuclei (Web Vuln Scan)",
         "runner": "apps.nuclei.scanner.run_nuclei",
-        "phase": 10,
+        "phase": 11,
         "requires": ["httpx"],
         "produces_findings": True,
     }

--- a/apps/takeover_check/apps.py
+++ b/apps/takeover_check/apps.py
@@ -8,7 +8,7 @@ class TakeoverCheckConfig(AppConfig):
     tool_meta = {
         "label": "Subdomain Takeover Check (subzy)",
         "runner": "apps.takeover_check.scanner.run_takeover_check",
-        "phase": 3.5,
+        "phase": 4,
         "requires": ["subfinder"],
         "produces_findings": True,
     }

--- a/apps/web_checker/apps.py
+++ b/apps/web_checker/apps.py
@@ -8,7 +8,7 @@ class WebCheckerConfig(AppConfig):
     tool_meta = {
         "label": "Web Checker",
         "runner": "apps.web_checker.scanner.run_web_check",
-        "phase": 10,
+        "phase": 11,
         "requires": ["httpx"],
         "produces_findings": True,
     }

--- a/tests/unit/test_pipeline_phases.py
+++ b/tests/unit/test_pipeline_phases.py
@@ -2,14 +2,14 @@
 
 
 def test_phase_order():
-    """Non-web tools (7) must run before httpx (8) and web tools (10)."""
+    """Non-web tools (7) must run before httpx (8) and web tools (11)."""
     from apps.core.workflows.registry import get_tool_phases
     phases = get_tool_phases()
 
     assert phases["httpx"] == 8,           f"httpx: expected 8, got {phases['httpx']}"
     assert phases["nuclei_network"] == 7,  f"nuclei_network: expected 7, got {phases['nuclei_network']}"
-    assert phases["nuclei"] == 10,         f"nuclei: expected 10, got {phases['nuclei']}"
-    assert phases["web_checker"] == 10,    f"web_checker: expected 10, got {phases['web_checker']}"
+    assert phases["nuclei"] == 11,         f"nuclei: expected 11, got {phases['nuclei']}"
+    assert phases["web_checker"] == 11,    f"web_checker: expected 11, got {phases['web_checker']}"
 
     # Non-web tools must all be before httpx
     assert phases["nmap"] < phases["httpx"],          "nmap must run before httpx"


### PR DESCRIPTION
## What

Removes fractional phases (3.5, 8.5) and gaps (5→7) from the pipeline. All 16 tools now sit on sequential integers 1–11.

| Tool | Before | After |
|---|---|---|
| takeover_check | 3.5 | 4 |
| naabu | 4 | 5 |
| service_detection | 5 | 6 |
| nmap / tls_checker / ssh_checker / nuclei_network | 7 | 7 (unchanged) |
| httpx | 8 | 8 (unchanged) |
| historical_urls | 8.5 | 9 |
| katana | 9 | 10 |
| nuclei / web_checker | 10 | 11 |

Updated: `apps/*/apps.py` tool_meta, `CLAUDE.md`, `README.md`, `tests/unit/test_pipeline_phases.py`.

## Test Plan
- [x] 838 tests pass
- [x] `uv run manage.py check` clean