### PR TITLE
feat: add phase_group to tool_meta for all 17 tools

### DIFF
--- a/apps/alterx/apps.py
+++ b/apps/alterx/apps.py
@@ -10,6 +10,7 @@ class AlterxConfig(AppConfig):
         "label": "Alterx (Subdomain Permutation)",
         "runner": "apps.alterx.scanner.run_alterx",
         "phase": 2,
+        "phase_group": "Surface Enumeration",
         "requires": ["subfinder"],
         "produces_findings": False,
     }

--- a/apps/amass/apps.py
+++ b/apps/amass/apps.py
@@ -10,6 +10,7 @@ class AmassConfig(AppConfig):
         "label": "Amass",
         "runner": "apps.amass.scanner.run_amass",
         "phase": 2,
+        "phase_group": "Surface Enumeration",
         "requires": [],
         "produces_findings": False,
     }

--- a/apps/core/service_detection/apps.py
+++ b/apps/core/service_detection/apps.py
@@ -9,6 +9,7 @@ class ServiceDetectionConfig(AppConfig):
         "label": "Service Detection",
         "runner": "apps.core.service_detection.detector.detect_services",
         "phase": 6,
+        "phase_group": "Port Discovery",
         "requires": ["naabu"],
         "produces_findings": False,
         "core": True,  # always runs, hidden from workflow UI

--- a/apps/core/workflows/registry.py
+++ b/apps/core/workflows/registry.py
@@ -42,6 +42,7 @@ def _discover_tools():
             "label": meta.get("label", app_config.verbose_name or tool_name),
             "runner": meta["runner"],
             "phase": meta.get("phase", 99),
+            "phase_group": meta.get("phase_group", ""),
             "requires": meta.get("requires", []),
             "produces_findings": meta.get("produces_findings", False),
             "core": meta.get("core", False),
@@ -85,6 +86,11 @@ def get_tool_requires() -> dict[str, list[str]]:
 def get_tool_produces_findings() -> dict[str, bool]:
     """Dynamic map: tool_name → whether the tool writes to the Finding table."""
     return {name: info["produces_findings"] for name, info in get_registry().items()}
+
+
+def get_tool_phase_groups() -> dict[str, str]:
+    """Dynamic map: tool_name → phase_group label."""
+    return {name: info["phase_group"] for name, info in get_registry().items()}
 
 
 def get_source_choices() -> list[tuple[str, str]]:

--- a/apps/dnsx/apps.py
+++ b/apps/dnsx/apps.py
@@ -10,6 +10,7 @@ class DnsxConfig(AppConfig):
         "label": "DNSx (Resolve)",
         "runner": "apps.dnsx.scanner.run_dnsx",
         "phase": 3,
+        "phase_group": "Surface Enumeration",
         "requires": ["subfinder"],
         "produces_findings": False,
     }

--- a/apps/domain_security/apps.py
+++ b/apps/domain_security/apps.py
@@ -10,6 +10,7 @@ class DomainSecurityConfig(AppConfig):
         "label": "Domain Security",
         "runner": "apps.domain_security.scanner.run_domain_security",
         "phase": 1,
+        "phase_group": "Domain Intelligence",
         "requires": [],
         "produces_findings": True,
     }

--- a/apps/historical_urls/apps.py
+++ b/apps/historical_urls/apps.py
@@ -10,6 +10,7 @@ class HistoricalUrlsConfig(AppConfig):
         "label": "Historical URLs (gau + waybackurls)",
         "runner": "apps.historical_urls.scanner.run_historical_urls",
         "phase": 9,
+        "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": False,
     }

--- a/apps/httpx/apps.py
+++ b/apps/httpx/apps.py
@@ -10,6 +10,7 @@ class HttpxConfig(AppConfig):
         "label": "HTTPx (Web Probe)",
         "runner": "apps.httpx.scanner.run_httpx",
         "phase": 8,
+        "phase_group": "Web Exposure",
         "requires": ["naabu"],
         "produces_findings": False,
     }

--- a/apps/katana/apps.py
+++ b/apps/katana/apps.py
@@ -10,6 +10,7 @@ class KatanaConfig(AppConfig):
         "label": "Katana",
         "runner": "apps.katana.scanner.run_katana",
         "phase": 10,
+        "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": False,
     }

--- a/apps/naabu/apps.py
+++ b/apps/naabu/apps.py
@@ -10,6 +10,7 @@ class NaabuConfig(AppConfig):
         "label": "Naabu (Port Scan)",
         "runner": "apps.naabu.scanner.run_naabu",
         "phase": 5,
+        "phase_group": "Port Discovery",
         "requires": ["dnsx"],
         "produces_findings": False,
     }

--- a/apps/nmap/apps.py
+++ b/apps/nmap/apps.py
@@ -10,6 +10,7 @@ class NmapConfig(AppConfig):
         "label": "Nmap (NSE Vuln Scan)",
         "runner": "apps.nmap.scanner.run_nmap",
         "phase": 7,
+        "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
     }

--- a/apps/nuclei/apps.py
+++ b/apps/nuclei/apps.py
@@ -10,6 +10,7 @@ class NucleiConfig(AppConfig):
         "label": "Nuclei (Web Vuln Scan)",
         "runner": "apps.nuclei.scanner.run_nuclei",
         "phase": 11,
+        "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": True,
     }

--- a/apps/nuclei_network/apps.py
+++ b/apps/nuclei_network/apps.py
@@ -9,6 +9,7 @@ class NucleiNetworkConfig(AppConfig):
         "label": "Nuclei (Network Scan)",
         "runner": "apps.nuclei_network.scanner.run_nuclei_network",
         "phase": 7,
+        "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
     }

--- a/apps/ssh_checker/apps.py
+++ b/apps/ssh_checker/apps.py
@@ -9,6 +9,7 @@ class SshCheckerConfig(AppConfig):
         "label": "SSH Checker",
         "runner": "apps.ssh_checker.scanner.run_ssh_check",
         "phase": 7,
+        "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
     }

--- a/apps/subfinder/apps.py
+++ b/apps/subfinder/apps.py
@@ -10,6 +10,7 @@ class SubfinderConfig(AppConfig):
         "label": "Subfinder",
         "runner": "apps.subfinder.scanner.run_subfinder",
         "phase": 2,
+        "phase_group": "Surface Enumeration",
         "requires": [],
         "produces_findings": False,
     }

--- a/apps/takeover_check/apps.py
+++ b/apps/takeover_check/apps.py
@@ -9,6 +9,7 @@ class TakeoverCheckConfig(AppConfig):
         "label": "Subdomain Takeover Check (subzy)",
         "runner": "apps.takeover_check.scanner.run_takeover_check",
         "phase": 4,
+        "phase_group": "Surface Enumeration",
         "requires": ["subfinder"],
         "produces_findings": True,
     }

--- a/apps/tls_checker/apps.py
+++ b/apps/tls_checker/apps.py
@@ -9,6 +9,7 @@ class TlsCheckerConfig(AppConfig):
         "label": "TLS Checker",
         "runner": "apps.tls_checker.scanner.run_tls_check",
         "phase": 7,
+        "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
     }

--- a/apps/web_checker/apps.py
+++ b/apps/web_checker/apps.py
@@ -9,6 +9,7 @@ class WebCheckerConfig(AppConfig):
         "label": "Web Checker",
         "runner": "apps.web_checker.scanner.run_web_check",
         "phase": 11,
+        "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": True,
     }


### PR DESCRIPTION
## Summary

- Adds `phase_group` field to `tool_meta` in all 17 tool `apps.py` files
- Updates the registry to store and expose it via `get_tool_phase_groups()`
- Five groups aligned with the EASD mental model:

| Group | Tools |
|-------|-------|
| Domain Intelligence | domain_security |
| Surface Enumeration | subfinder, amass, alterx, dnsx, takeover_check |
| Port Discovery | naabu, service_detection |
| Network Exposure | nmap, tls_checker, ssh_checker, nuclei_network |
| Web Exposure | httpx, historical_urls, katana, nuclei, web_checker |

## Test plan

- [ ] `uv run manage.py check` — 0 issues
- [ ] `uv run pytest tests/ --ignore=tests/unit/test_domain_security.py -q` — 855 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)