### PR TITLE
fix(ci): skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,14 @@ on:
   push:
     branches: ["main"]
     tags: ["v*"]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Adds `paths-ignore` to both `push` and `pull_request` triggers so CI doesn't run when only `.md` files or `docs/` content changes.

## What's ignored
- `**.md` — any markdown file anywhere in the repo
- `docs/**` — anything under the docs directory

## What still triggers CI
Everything else — Python, frontend, Dockerfile, config, tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)