### PR TITLE
fix(docker): add git to runtime stage for cloud_enum install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.12 python3.12-venv python3-pip \
-    curl ca-certificates \
+    curl ca-certificates git \
     nmap \
     # xhtml2pdf / pycairo / svglib build deps
     build-essential libffi-dev libssl-dev libxml2 libxslt1.1 \


### PR DESCRIPTION
## Summary
- Adds `git` to the `apt-get install` in the Dockerfile runtime stage
- Required because `uv pip install git+https://github.com/initstring/cloud_enum.git` calls the git binary to clone the repo
- CI was failing on the Docker build job with: `Git executable not found`

## Test plan
- [ ] Docker Build CI job passes