### PR TITLE
chore(docs): add CODE_OF_CONDUCT.md (Contributor Covenant by reference)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+OpenEASD adopts version 2.1 of the **Contributor Covenant** as its code of
+conduct. The canonical, full text is published at:
+
+> **https://www.contributor-covenant.org/version/2/1/code_of_conduct/**
+
+The short version: contributors, users, and maintainers are expected to
+interact respectfully and in good faith. Disagreement on technical
+direction is welcome and encouraged; personal attacks, harassment, and
+bad-faith behaviour are not.
+
+## Scope
+
+This Code applies to all project surfaces — the GitHub repo (issues,
+pull requests, discussions), any project-affiliated channels, and any
+public spaces when an individual is representing the project.
+
+## Reporting
+
+If you experience or witness behaviour that violates this Code, report
+it to the maintainers through one of the channels below. We treat
+reports as confidential.
+
+- **Preferred:** open a private report at
+  [github.com/cybersecify/OpenEASD/security/advisories/new](https://github.com/cybersecify/OpenEASD/security/advisories/new)
+  (the same private channel we use for security issues — it's the
+  fastest route to the maintainers and stays out of the public timeline).
+- **Email fallback:** **contact@cybersecify.com** with
+  `[OpenEASD CoC]` in the subject line.
+
+Reports are read by the maintainers: **Rathnakara G N** and
+**Ashok S Kamat** of Cybersecify.
+
+## Enforcement
+
+Maintainers may, at their discretion, take any action they consider
+appropriate in response to a violation — including warning the
+participant, removing comments/commits/PRs, or banning the participant
+from project surfaces. The Contributor Covenant's
+[Enforcement Guidelines](https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines)
+serve as the reference framework for the severity and proportionality
+of any response.


### PR DESCRIPTION
## What

Adds `CODE_OF_CONDUCT.md` that adopts Contributor Covenant 2.1 by reference (links to the canonical version on contributor-covenant.org rather than embedding the full text).

Reporting channel reuses the SECURITY.md pattern — GitHub Private Vulnerability Reporting preferred, `contact@cybersecify.com` fallback.

## Why

GitHub Insights → Community Standards flagged this as the last missing item (7/9 → 8/9 after this lands). Link-based adoption is the standard pattern at PD-scale OSS repos — no benefit to maintaining our own copy of widely-recognised text.

## Test plan

- [x] File renders correctly on GitHub
- [x] All links resolve (contributor-covenant.org/version/2/1, GitHub PVR, mailto)
- [x] Reporting contact matches SECURITY.md (`contact@cybersecify.com`)