### PR TITLE
fix(docs): correct tool count 17 to 18 in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ apps/<tool>/
 ## Scan pipeline
 
 All scans run through the **dynamic workflow system**. The default "Full Scan"
-workflow executes all 17 tools in phase order. Custom workflows can include
+workflow executes all 18 tools in phase order. Custom workflows can include
 any subset of tools.
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 Use it as a **red teamer** to map external surface fast on targets you're authorised to test. Use it as a **defender** to see what's leaking out of your own infrastructure — subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs — without paying $500-5000/mo for a commercial EASM platform.
 
-OpenEASD wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `naabu`, `httpx`, `gau`, `waybackurls`, `nuclei`, `nmap` — behind a single web UI with scheduling, alerts, and findings tracking. Seventeen tools across DNS, email, TLS, SSH, ports, CVEs, subdomain takeover, historical URLs, and web hygiene. Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
+OpenEASD wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei` — behind a single web UI with scheduling, alerts, and findings tracking. Eighteen tools across DNS, email, TLS, SSH, ports, CVEs, subdomain takeover, historical URLs, cloud assets, and web hygiene. Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
 
 Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [Cybersecify](https://cybersecify.com) — the same tool we run in engagements and on our own infrastructure.
 
-![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 17 tool steps tracked live](docs/screenshots/scan-detail-live.png)
+![OpenEASD scan in progress against nmap.org — 11 subdomains, 22 IPs, 6 ports, 3 critical findings already, all 18 tool steps tracked live](docs/screenshots/scan-detail-live.png)
 
 ## Who this is for
 
@@ -138,7 +138,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline** — 17-tool scan workflow from domain to findings
+- **Automated pipeline** — 18-tool scan workflow from domain to findings
 - **Network attack surface scanning** — CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **Dynamic workflows** — Create custom scan configurations, enable/disable tools per workflow
 - **Tool auto-registration** — Add new tools with zero core modification


### PR DESCRIPTION
## What

Update tool count from 17 to 18 in:
- README.md hero ("Eighteen tools", added cloud_enum + katana to named list, added cloud assets to vector list)
- README.md hero image alt text ("all 18 tool steps tracked live")
- README.md feature bullet ("18-tool scan workflow")
- CLAUDE.md scan pipeline section ("executes all 18 tools in phase order")

## Why

The repo has had 18 tool_meta-registered apps since cloud_assets shipped in v0.7.1, but README and CLAUDE.md narrative kept citing 17. CLAUDE.md had internal drift: the tool-apps table correctly listed 18 but the narrative said 17.

Verified count:
\`\`\`
grep -rln "tool_meta = {" apps/ | grep -v "registry.py" | wc -l
\`\`\`
returns 18 on current main.

CHANGELOG v0.7 entry citing "all 17 tools" left as-is — historically accurate at that release.

## Scope

- README.md (3 lines)
- CLAUDE.md (1 line)
- No behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)