### PR TITLE
fix: add fork workflow, fix dev setup port, and improve PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,13 @@ anything's unclear.
 
 > **About contributions:** OpenEASD is MIT-licensed open source maintained by Cybersecify (Rathnakara G N + Ashok S Kamat). Community contributions are welcomed — they make the project move faster and amplify what we can give back to the security community. We don't pay for PRs or run a bug bounty program; contributions are recognised through public CHANGELOG credit, commit attribution, GitHub Discussion shout-outs, and (where applicable) conference / publication co-credit. See [SECURITY.md](https://github.com/cybersecify/OpenEASD/blob/main/SECURITY.md) for the no-bounty note and [CONTRIBUTING.md](https://github.com/cybersecify/OpenEASD/blob/main/CONTRIBUTING.md) for what we look for in a PR.
 
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / new tool
+- [ ] Refactor (no behavior change)
+- [ ] Docs / tests only
+
 ## What this changes
 
 <!-- 1-3 sentences. The "why" matters more than the "what" — the diff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ See `tests/unit/test_ssh_checker.py` (33 tests) or
   agree on direction before you write.
 - **Frontend tweaks.** React 19 + Vite 8 + Tailwind + shadcn/ui in
   `frontend/`. Run `npm run dev` against a Django backend on `:8000`.
-- **Tests.** We're at ~760 tests excluding slow DNS; raising that
+- **Tests.** We're at ~910 tests excluding slow DNS; raising that
   number always helps. `tests/unit/test_<thing>.py` matches the app it
   tests.
 
@@ -155,6 +155,36 @@ See `tests/unit/test_ssh_checker.py` (33 tests) or
 - `apps/core/workflows/registry.py` — the auto-registration plumbing.
 - `apps/core/findings/models.py` — the unified Finding model every
   tool writes to.
+
+## Fork and contribute
+
+OpenEASD uses a fork-based workflow for external contributors — you won't
+have write access to the main repo, so work happens in your fork.
+
+```bash
+# 1. Fork the repo on GitHub (click "Fork" top-right)
+
+# 2. Clone your fork
+git clone https://github.com/<your-username>/OpenEASD.git
+cd OpenEASD
+
+# 3. Add the upstream remote so you can stay in sync
+git remote add upstream https://github.com/cybersecify/OpenEASD.git
+
+# 4. Before starting work, sync your fork's main with upstream
+git fetch upstream
+git checkout main
+git merge upstream/main
+
+# 5. Create a branch
+git checkout -b feat/my-feature   # or fix/my-fix
+
+# 6. Push to your fork and open a PR against cybersecify/OpenEASD main
+git push origin feat/my-feature
+```
+
+Maintainers with write access can branch directly on the main repo — same
+branch naming rules apply.
 
 ## Development setup
 
@@ -168,11 +198,18 @@ cd frontend && npm install && cd ..
 # Run migrations
 uv run manage.py migrate
 
-# Terminal 1 — Django + Django-Q2 worker
-uv run python main.py
+# Quickest: starts Django (:8001) + Vite dev server + qcluster worker together
+make dev
 
-# Terminal 2 — Vite dev server (proxies /api/ to Django on port 8000)
+# Or manually in three terminals:
+# Terminal 1 — Django
+uv run manage.py runserver 8001
+
+# Terminal 2 — Vite dev server (proxies /api/ to Django at :8001)
 cd frontend && npm run dev
+
+# Terminal 3 — Background worker (required for scans to execute)
+uv run manage.py qcluster
 ```
 
 App runs at `http://localhost:5173` in dev. Default login on a fresh DB


### PR DESCRIPTION
## Summary

- Add fork-and-contribute section to CONTRIBUTING.md for external contributors (fork → upstream remote → branch → PR flow)
- Update dev setup to lead with `make dev` at the correct port (8001) instead of the old `main.py` / port 8000 path
- Fix stale test count (760 → ~910)
- Add Type of change checkboxes to PR template

## Test plan

- [ ] Review CONTRIBUTING.md renders correctly on GitHub
- [ ] Review PR template appears correctly when opening a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)