### PR TITLE
fix: suppress CodeQL alerts on intentional verify=False scanner calls

### DIFF
--- a/apps/core/service_detection/detector.py
+++ b/apps/core/service_detection/detector.py
@@ -93,7 +93,7 @@ def _probe_http(host: str, port: int, scheme: str) -> bool:
         requests.head(
             f"{scheme}://{host}:{port}",
             timeout=PROBE_TIMEOUT,
-            verify=False,  # nosec B501 — intentional: probing target hosts with self-signed certs
+            verify=False,  # nosec B501  # lgtm[py/request-without-cert-validation]  intentional: probing target hosts with self-signed certs
             allow_redirects=False,
             headers={"User-Agent": "openeasd-service-probe/1.0"},
         )

--- a/apps/web_checker/collector.py
+++ b/apps/web_checker/collector.py
@@ -123,7 +123,7 @@ def collect(session) -> list[dict]:
                     "User-Agent": USER_AGENT,
                     "Origin": _CORS_TEST_ORIGIN,
                 },
-                verify=False,  # nosec B501 — intentional: scanning target hosts that may have self-signed certs
+                verify=False,  # nosec B501  # lgtm[py/request-without-cert-validation]  intentional: scanning target hosts that may have self-signed certs
                 allow_redirects=True,
             )
 


### PR DESCRIPTION
## Summary

Closes 2 HIGH-severity CodeQL alerts (#17, #18) as false positives. The flagged \`verify=False\` calls are deliberate scanner behaviour:
- \`apps/core/service_detection/detector.py:93\` (HEAD probe for service identification)
- \`apps/web_checker/collector.py:119\` (security-header collection)

Both already had \`# nosec B501\` with explanatory comments, but CodeQL does not honour bandit's suppression syntax. This PR adds \`# lgtm[py/request-without-cert-validation]\` next to them so CodeQL re-scan clears the alerts.

## Why these are not security bugs

OpenEASD scans target hosts as an external attacker would. Most of those hosts have self-signed, expired, or otherwise broken certs (that is literally what TLS posture detection is about). If the scanner required valid certs, it could not reach most targets and the whole tool would be useless. The current behaviour is correct and intentional.

## Companion action (separate from this PR)

I will also dismiss 4 \`py/incomplete-url-substring-sanitization\` CodeQL alerts (#44, #45, #46, #47) via the GitHub API. Those fire on test fixtures using \`example.com\` and \`api.example.com\` and are pure false positives. No code change needed for that piece.

## Test plan

- [ ] CI green
- [ ] CodeQL re-scan on this branch shows alerts #17 and #18 as dismissed / fixed