### PR TITLE
fix: kill nuclei process group on timeout, recompute findings on reap

### DIFF
--- a/apps/core/scheduler/scheduler.py
+++ b/apps/core/scheduler/scheduler.py
@@ -181,7 +181,12 @@ def reap_stuck_scans():
         new_status = "partial" if completed_step else "failed"
         session.status = new_status
         session.end_time = now
-        session.save(update_fields=["status", "end_time"])
+        # _finalize_session never ran (the wedged step held the worker), so
+        # total_findings is still 0 even though completed steps wrote Findings.
+        # Recompute it here so reaped scans show their real count, not 0.
+        from apps.core.scans.pipeline import _count_all_findings
+        session.total_findings = _count_all_findings(session)
+        session.save(update_fields=["status", "end_time", "total_findings"])
 
         if new_status == "partial":
             partial_count += 1

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -10,6 +10,7 @@ Nuclei scans for web vulnerabilities using community templates:
 import json
 import logging
 import os
+import signal
 import subprocess
 import tempfile
 
@@ -17,7 +18,43 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT = 3600  # 1 hour max per scan
+TIMEOUT = 1800        # hard wall-clock cap for the whole nuclei run (30 min)
+REQUEST_TIMEOUT = 5   # seconds per HTTP request (nuclei -timeout)
+RATE_LIMIT = 150      # max requests/sec across all hosts (nuclei -rate-limit)
+CONCURRENCY = 25      # parallel templates (nuclei -c)
+
+
+def _run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess:
+    """Run an external tool, SIGKILL-ing its whole process group on timeout.
+
+    subprocess.run(timeout=...) only signals the *direct* child. If the tool has
+    spawned helpers that inherit the stdout pipe, the internal communicate() blocks
+    waiting for EOF long past the timeout, and the calling thread wedges — which is
+    how a single nuclei step can hang a scan until the session watchdog reaps it.
+
+    start_new_session=True puts the child in its own process group, so on timeout we
+    can kill the entire tree and the pipe actually closes. Mirrors subprocess.run's
+    contract: returns CompletedProcess, raises FileNotFoundError if the binary is
+    missing, re-raises TimeoutExpired after the group is killed.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+        proc.communicate()  # reap — the pipe is now closed since the group is dead
+        raise
+    return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
 
 
 def collect(session) -> list[dict]:
@@ -45,11 +82,20 @@ def collect(session) -> list[dict]:
         f.write("\n".join(targets))
         tmp = f.name
 
-    cmd = [binary, "-list", tmp, "-jsonl", "-silent", "-no-color"]
+    # Bound nuclei explicitly so it finishes well under TIMEOUT instead of relying
+    # on the kill: -timeout caps each request, -rate-limit/-c cap throughput so a
+    # host with many ports (ast.co.rs had 25 IPs / 27 ports) can't stall the run.
+    cmd = [
+        binary, "-list", tmp, "-jsonl", "-silent", "-no-color",
+        "-timeout", str(REQUEST_TIMEOUT),
+        "-retries", "1",
+        "-rate-limit", str(RATE_LIMIT),
+        "-c", str(CONCURRENCY),
+    ]
     logger.info(f"[nuclei:{session.id}] Scanning {len(targets)} web targets")
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT, stdin=subprocess.DEVNULL)
+        result = _run(cmd, TIMEOUT)
     except FileNotFoundError:
         logger.error(f"[nuclei:{session.id}] Binary not found: {binary}")
         return []

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -209,7 +209,7 @@ class TestNucleiCollector:
         mock_result.returncode = 0
         mock_result.stderr = ""
 
-        with patch("apps.nuclei.collector.subprocess.run", return_value=mock_result) as mock_run:
+        with patch("apps.nuclei.collector._run", return_value=mock_result) as mock_run:
             records = collect(sess)
 
         assert mock_run.called
@@ -219,7 +219,7 @@ class TestNucleiCollector:
         from apps.core.scans.models import ScanSession
         sess = ScanSession.objects.create(domain="empty.com", scan_type="full")
 
-        with patch("apps.nuclei.collector.subprocess.run") as mock_run:
+        with patch("apps.nuclei.collector._run") as mock_run:
             records = collect(sess)
 
         assert records == []
@@ -227,7 +227,7 @@ class TestNucleiCollector:
 
     def test_binary_not_found(self):
         sess = self._make_session()
-        with patch("apps.nuclei.collector.subprocess.run",
+        with patch("apps.nuclei.collector._run",
                    side_effect=FileNotFoundError):
             records = collect(sess)
         assert records == []
@@ -235,8 +235,8 @@ class TestNucleiCollector:
     def test_timeout_handled(self):
         import subprocess as sp
         sess = self._make_session()
-        with patch("apps.nuclei.collector.subprocess.run",
-                   side_effect=sp.TimeoutExpired(cmd="nuclei", timeout=3600)):
+        with patch("apps.nuclei.collector._run",
+                   side_effect=sp.TimeoutExpired(cmd="nuclei", timeout=1800)):
             records = collect(sess)
         assert records == []
 
@@ -247,9 +247,71 @@ class TestNucleiCollector:
         mock_result.returncode = 0
         mock_result.stderr = ""
 
-        with patch("apps.nuclei.collector.subprocess.run", return_value=mock_result):
+        with patch("apps.nuclei.collector._run", return_value=mock_result):
             records = collect(sess)
         assert len(records) == 1
+
+    def test_cmd_includes_rate_limiting_flags(self):
+        """nuclei must be invoked with the bounding flags so it can't run unbounded."""
+        sess = self._make_session()
+        captured = {}
+
+        def fake_run(cmd, timeout):
+            captured["cmd"] = cmd
+            captured["timeout"] = timeout
+            return MagicMock(stdout="", returncode=0, stderr="")
+
+        with patch("apps.nuclei.collector._run", side_effect=fake_run):
+            collect(sess)
+
+        cmd = captured["cmd"]
+        for flag in ("-rate-limit", "-c", "-timeout", "-retries"):
+            assert flag in cmd, f"missing {flag}"
+        assert captured["timeout"] == 1800
+
+
+# ---------------------------------------------------------------------------
+# _run — process-group kill on timeout
+# ---------------------------------------------------------------------------
+
+class TestRunProcessGroupKill:
+    def test_kills_process_group_on_timeout(self):
+        """On timeout, _run must SIGKILL the whole process group and re-raise,
+        not leave a child holding the stdout pipe (the cause of the wedged scan)."""
+        import subprocess as sp
+        from apps.nuclei import collector
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 4242
+        # First communicate() (with timeout) raises; second (the reap) returns.
+        fake_proc.communicate.side_effect = [
+            sp.TimeoutExpired(cmd="nuclei", timeout=1),
+            ("", ""),
+        ]
+
+        with patch("apps.nuclei.collector.subprocess.Popen", return_value=fake_proc), \
+             patch("apps.nuclei.collector.os.getpgid", return_value=4242), \
+             patch("apps.nuclei.collector.os.killpg") as mock_killpg:
+            with pytest.raises(sp.TimeoutExpired):
+                collector._run(["nuclei"], timeout=1)
+
+        mock_killpg.assert_called_once()
+        # the reap communicate() must run so the dead group is collected
+        assert fake_proc.communicate.call_count == 2
+
+    def test_returns_completed_process_on_success(self):
+        from apps.nuclei import collector
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 99
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("out", "err")
+
+        with patch("apps.nuclei.collector.subprocess.Popen", return_value=fake_proc):
+            result = collector._run(["nuclei"], timeout=10)
+
+        assert result.returncode == 0
+        assert result.stdout == "out"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -119,6 +119,26 @@ class TestReapStuckScans:
         ds = WorkflowStepResult.objects.get(run=run, tool="domain_security")
         assert ds.status == "completed"
 
+    def test_partial_reap_recomputes_total_findings(self, db):
+        """A reaped partial scan must report the findings its completed steps
+        wrote, not 0 — _finalize_session never ran to tally them."""
+        from apps.core.findings.models import Finding
+        session = self._make_session("running", SCAN_TIMEOUT_MINUTES + 1, "count.example.com")
+        self._attach_run(session, completed_tools=["nmap"], in_flight_tools=["nuclei"])
+        for i in range(3):
+            Finding.objects.create(
+                session=session, source="nmap", target=f"1.2.3.4:{i}",
+                check_type="cve", severity="high",
+                title=f"CVE-2024-000{i}", description="desc",
+            )
+        # Sanity: tally not yet run.
+        assert session.total_findings == 0
+
+        assert reap_stuck_scans() == 1
+        session.refresh_from_db()
+        assert session.status == "partial"
+        assert session.total_findings == 3
+
     def test_failed_when_no_step_completed(self, db):
         """Stuck scan with a run but no completed steps -> failed (not partial)."""
         session = self._make_session("running", SCAN_TIMEOUT_MINUTES + 1, "f.example.com")


### PR DESCRIPTION
## Why
A scan (`ast.co.rs`, session `c93a01fd`) failed because the **nuclei** step hung. `subprocess.run(timeout=)` only signals the direct child, so a helper nuclei spawned held the stdout pipe open and `communicate()` blocked far past the 1h timeout. nuclei shares phase 11 with `web_checker`, so it runs in a `ThreadPoolExecutor` whose `shutdown(wait=True)` then wedged until the session watchdog reaped the scan — leaving 37 findings written but `total_findings=0` (because `_finalize_session` never ran).

## What
- **`apps/nuclei/collector.py`** — run nuclei via `Popen(start_new_session=True)` and `os.killpg(..., SIGKILL)` on timeout so the whole process tree dies and the pipe closes (the thread always returns). Bound nuclei with `-timeout/-retries/-rate-limit/-c`; lower `TIMEOUT` 3600 → 1800.
- **`apps/core/scheduler/scheduler.py`** — `reap_stuck_scans` now recomputes `total_findings`, so a reaped/partial scan shows its real count instead of 0.

## Tests
- New: process-group SIGKILL on timeout, success path, nuclei bounding flags present, reap recomputes `total_findings`.
- Full fast suite green (892 passed), `manage.py check` clean, bandit clean.

## Follow-up (not in this PR)
The `Popen`-with-process-group-kill pattern should become a shared `run_tool()` helper used by all 18 collectors — every one has the same latent hang. Scoped this PR to the tool that actually bit.