### PR TITLE
fix: k8s imagePullPolicy Always + Recreate strategy

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -9,6 +9,12 @@ spec:
   # SQLite (RWO PVC) — single replica required.
   # To scale horizontally, migrate to PostgreSQL.
   replicas: 1
+  # Recreate (not RollingUpdate): the single RWO data PVC can only be mounted by
+  # one pod at a time, so a rolling update deadlocks — the new pod stays Pending
+  # on the volume while the old pod refuses to terminate. Recreate tears the old
+  # pod down first, then starts the new one.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: openeasd
@@ -20,6 +26,11 @@ spec:
       initContainers:
         - name: init
           image: ghcr.io/cybersecify/openeasd:latest
+          # Always re-pull: the :latest tag is mutable, so a deploy that doesn't
+          # change the tag string must still fetch the new digest. Without this,
+          # k8s defaults to IfNotPresent semantics against the cached image and
+          # silently keeps running the old build.
+          imagePullPolicy: Always
           command: ["./docker-entrypoint.sh", "true"]
           envFrom:
             - configMapRef:
@@ -35,6 +46,7 @@ spec:
       containers:
         - name: web
           image: ghcr.io/cybersecify/openeasd:latest
+          imagePullPolicy: Always
           command:
             - gunicorn
             - openeasd.wsgi:application
@@ -88,6 +100,7 @@ spec:
 
         - name: worker
           image: ghcr.io/cybersecify/openeasd:latest
+          imagePullPolicy: Always
           command:
             - python
             - manage.py


### PR DESCRIPTION
## Why
Today's prod deploy of the nuclei fix exposed two latent k8s issues:

1. **Stale image silently kept running.** The deployment references the mutable `:latest` tag with default `IfNotPresent` behaviour, so the node reused its cached image and never pulled the new digest. We had to `microk8s ctr image pull` + pin the deployment to `@sha256:...` by hand to get the new build live.
2. **Rolling-update deadlock.** With `replicas: 1` and a single **RWO** data PVC, a rolling update can't schedule the new pod (volume already mounted by the old pod), so it hangs on "1 old replicas are pending termination" until manually scaled to 0.

## What
- `imagePullPolicy: Always` on all three containers (`init`, `web`, `worker`) → `:latest` actually re-pulls on every deploy.
- `strategy: Recreate` → the old pod is torn down (releasing the RWO volume) before the new pod starts, so `rollout restart` no longer deadlocks.

No behaviour change to the app; deploy-mechanics only.

## Apply to the live deployment
After merge, on the cluster:
```bash
microk8s kubectl apply -k k8s/
```
(Or `kubectl patch` the two fields.) With `Always` in place, future deploys are just `rollout restart` — no more manual `ctr pull` + digest pin.