### PR TITLE
fix: nuclei timeout via stdout-to-file + wait(), not pipe communicate()

### DIFF
--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -24,37 +24,62 @@ RATE_LIMIT = 150      # max requests/sec across all hosts (nuclei -rate-limit)
 CONCURRENCY = 25      # parallel templates (nuclei -c)
 
 
+_DRAIN_GRACE = 30  # seconds to let a SIGKILL'd process die before we give up
+
+
 def _run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess:
-    """Run an external tool, SIGKILL-ing its whole process group on timeout.
+    """Run an external tool with a timeout that cannot be defeated by child processes.
 
-    subprocess.run(timeout=...) only signals the *direct* child. If the tool has
-    spawned helpers that inherit the stdout pipe, the internal communicate() blocks
-    waiting for EOF long past the timeout, and the calling thread wedges — which is
-    how a single nuclei step can hang a scan until the session watchdog reaps it.
+    Why not subprocess.run / communicate(): communicate() reads stdout/stderr until
+    pipe EOF, which only happens once EVERY writer closes the pipe. nuclei spawns
+    helpers (interactsh poller, resolvers, headless) that can escape the process
+    group and inherit the stdout pipe, so even after we SIGKILL the group the pipe
+    never reaches EOF and communicate() blocks forever — the timeout fires but the
+    call never returns, wedging the worker thread until the session watchdog reaps it.
 
-    start_new_session=True puts the child in its own process group, so on timeout we
-    can kill the entire tree and the pipe actually closes. Mirrors subprocess.run's
-    contract: returns CompletedProcess, raises FileNotFoundError if the binary is
-    missing, re-raises TimeoutExpired after the group is killed.
+    The fix: redirect stdout/stderr to temp FILES (no pipe), and wait() on the
+    process itself. wait() returns the moment the direct child exits — it does not
+    care about inherited file descriptors — so a SIGKILL always unblocks us. An
+    escaped grandchild can leak but can no longer hang the scan.
+
+    Mirrors subprocess.run's contract: returns CompletedProcess, raises
+    FileNotFoundError if the binary is missing, re-raises TimeoutExpired after the
+    group is killed.
     """
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        stdin=subprocess.DEVNULL,
-        start_new_session=True,
-    )
+    out_fd, out_path = tempfile.mkstemp(suffix=".nuclei.out")
+    err_fd, err_path = tempfile.mkstemp(suffix=".nuclei.err")
     try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            proc.kill()
-        proc.communicate()  # reap — the pipe is now closed since the group is dead
-        raise
-    return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+        with os.fdopen(out_fd, "wb") as out_f, os.fdopen(err_fd, "wb") as err_f:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=out_f,
+                stderr=err_f,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    proc.kill()
+                try:
+                    proc.wait(timeout=_DRAIN_GRACE)
+                except subprocess.TimeoutExpired:
+                    pass
+                raise
+        with open(out_path, "r", errors="replace") as f:
+            stdout = f.read()
+        with open(err_path, "r", errors="replace") as f:
+            stderr = f.read()
+        return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+    finally:
+        for p in (out_path, err_path):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
 
 
 def collect(session) -> list[dict]:

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -276,17 +276,19 @@ class TestNucleiCollector:
 
 class TestRunProcessGroupKill:
     def test_kills_process_group_on_timeout(self):
-        """On timeout, _run must SIGKILL the whole process group and re-raise,
-        not leave a child holding the stdout pipe (the cause of the wedged scan)."""
+        """On timeout, _run must SIGKILL the process group and re-raise. It must
+        use wait() (not communicate()) so an escaped child holding the stdout pipe
+        can't block us — the bug that wedged the scan past the timeout."""
         import subprocess as sp
         from apps.nuclei import collector
 
         fake_proc = MagicMock()
         fake_proc.pid = 4242
-        # First communicate() (with timeout) raises; second (the reap) returns.
-        fake_proc.communicate.side_effect = [
+        fake_proc.returncode = -9
+        # First wait(timeout) raises; second wait (post-kill drain) returns.
+        fake_proc.wait.side_effect = [
             sp.TimeoutExpired(cmd="nuclei", timeout=1),
-            ("", ""),
+            0,
         ]
 
         with patch("apps.nuclei.collector.subprocess.Popen", return_value=fake_proc), \
@@ -296,8 +298,10 @@ class TestRunProcessGroupKill:
                 collector._run(["nuclei"], timeout=1)
 
         mock_killpg.assert_called_once()
-        # the reap communicate() must run so the dead group is collected
-        assert fake_proc.communicate.call_count == 2
+        # the post-kill drain wait() must run so the dead process is reaped
+        assert fake_proc.wait.call_count == 2
+        # must NOT fall back to communicate() (the pipe-blocking call)
+        assert not fake_proc.communicate.called
 
     def test_returns_completed_process_on_success(self):
         from apps.nuclei import collector
@@ -305,13 +309,46 @@ class TestRunProcessGroupKill:
         fake_proc = MagicMock()
         fake_proc.pid = 99
         fake_proc.returncode = 0
-        fake_proc.communicate.return_value = ("out", "err")
+        fake_proc.wait.return_value = 0
 
         with patch("apps.nuclei.collector.subprocess.Popen", return_value=fake_proc):
             result = collector._run(["nuclei"], timeout=10)
 
         assert result.returncode == 0
-        assert result.stdout == "out"
+        # stdout/stderr come from the temp output files (empty under a mocked Popen)
+        assert result.stdout == ""
+        assert not fake_proc.communicate.called
+
+    def test_real_run_captures_output(self):
+        from apps.nuclei import collector
+        result = collector._run(["printf", "hello\nworld\n"], timeout=10)
+        assert result.returncode == 0
+        assert "hello" in result.stdout and "world" in result.stdout
+
+    def test_escaped_child_holding_fd_does_not_hang(self):
+        """The exact production bug, as a real process: a grandchild calls setsid()
+        to escape the process group and keeps the inherited output fd open while it
+        sleeps. communicate() would block on pipe-EOF until the watchdog reap; _run
+        must SIGKILL the parent and return within the drain grace regardless."""
+        import sys
+        import time
+        import subprocess as sp
+        from apps.nuclei import collector
+
+        script = (
+            "import os, sys, time\n"
+            "if os.fork() == 0:\n"
+            "    os.setsid()\n"          # escape the parent's process group
+            "    time.sleep(45)\n"       # keep holding the inherited stdout fd
+            "    sys.exit(0)\n"
+            "time.sleep(45)\n"           # parent sleeps so our timeout fires on it
+        )
+        start = time.monotonic()
+        with pytest.raises(sp.TimeoutExpired):
+            collector._run([sys.executable, "-c", script], timeout=1)
+        elapsed = time.monotonic() - start
+        # If _run still used communicate(), this would block ~45s. It must not.
+        assert elapsed < collector._DRAIN_GRACE, f"hung for {elapsed:.1f}s"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why
The nuclei hang fix in #148 was **insufficient**. A production verify scan on `ast.co.rs` hung nuclei **again** — step ran 4641s (77 min) past its 1800s timeout and was reaped by the watchdog:

```
10 nuclei      failed dur_s=4641 | reaped by watchdog after 90m
11 web_checker failed dur_s=4641 | reaped by watchdog after 90m
```

Confirmed on prod that the fixed code *was* deployed (`TIMEOUT=1800`, `_run`, `start_new_session` all present). So the SIGKILL-the-process-group approach itself is the problem: nuclei spawns helpers (interactsh poller, resolvers, headless) that **escape the process group** and inherit the stdout pipe. `communicate()` blocks on pipe-EOF, which never arrives even after the group is killed — the timeout fires but the call never returns, wedging the worker thread.

## Fix
Stop using a pipe. Redirect stdout/stderr to **temp files** and `wait()` on the process instead of `communicate()`. `wait()` returns the moment the direct child exits and doesn't care about inherited fds, so a SIGKILL always unblocks us. An escaped grandchild can leak but can no longer hang the scan.

## Tests
- Reworked the `_run` unit tests for the `wait()`-based flow.
- **New real-process test**: a grandchild calls `setsid()` to escape the group and holds the output fd while sleeping 45s. Hangs ~45s against the old `communicate()` code; passes in ~1s now.
- Full fast suite green (890 passed).

## Follow-up
This pattern (`subprocess.run`/`communicate` with a timeout) is in all 18 tool collectors and has the same latent hang. Nuclei is the one that actually triggers it (it spawns escaping helpers); the others are simpler Go binaries. Recommend promoting this file-based `_run` to a shared `run_tool()` helper in a follow-up so the whole class is gone.