### PR TITLE
fix: align Django-Q2 scan timers so full scans complete

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@ SCAN_DAILY_HOUR=2
 SCAN_DAILY_MINUTE=0
 SCHEDULER_ENABLED=True
 
+# Scan timeouts — keep aligned: SCAN_TIMEOUT_MINUTES >= Q_TASK_TIMEOUT (in minutes),
+# and Q_TASK_RETRY > Q_TASK_TIMEOUT. Raise all three together for very large targets.
+# Q_TASK_TIMEOUT=10800        # worker hard-kill per scan task, seconds (default 3h)
+# Q_TASK_RETRY=12000          # broker re-queue window, seconds (must be > Q_TASK_TIMEOUT)
+# SCAN_TIMEOUT_MINUTES=180    # watchdog reap threshold, minutes (must be >= Q_TASK_TIMEOUT)
+
 # Slack notifications (optional)
 SLACK_WEBHOOK_URL=
 ALERT_SEVERITY_THRESHOLD=high

--- a/apps/core/scheduler/scheduler.py
+++ b/apps/core/scheduler/scheduler.py
@@ -8,7 +8,11 @@ from django.utils import timezone as django_tz
 logger = logging.getLogger(__name__)
 
 from decouple import config as _config  # noqa: E402
-SCAN_TIMEOUT_MINUTES = _config("SCAN_TIMEOUT_MINUTES", default=90, cast=int)
+# Must be >= Q_CLUSTER["timeout"] (3h / 10800s). The watchdog only cleans up the
+# DB status of scans whose worker died without finalizing; it must not fire while
+# a healthy scan is still legitimately running, or it flips a live scan to
+# "partial" mid-run. Keep this at/above the worker hard-kill (180m).
+SCAN_TIMEOUT_MINUTES = _config("SCAN_TIMEOUT_MINUTES", default=180, cast=int)
 
 
 # ---------------------------------------------------------------------------

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -156,12 +156,32 @@ for _dir in [OPENEASD_DATA_DIR, OPENEASD_LOGS_DIR]:
     _dir.mkdir(parents=True, exist_ok=True)
 
 # Django-Q2 task queue — ORM broker uses the existing Django DB (SQLite)
+#
+# Timer alignment (all three must agree or scans die mid-run):
+#   timeout  — worker hard-kill; MUST exceed a real full scan's wall-clock.
+#   retry    — re-queue window; MUST be > timeout or the broker re-runs a task
+#              that is still executing. max_attempts:1 makes this moot but the
+#              constraint is enforced anyway.
+#   watchdog — reap_stuck_scans (SCAN_TIMEOUT_MINUTES) must be >= timeout so it
+#              only reaps genuinely orphaned scans (dead worker), never a healthy
+#              long-running one.
+# The old defaults (timeout 3600 / retry 7200) killed every large scan: a full
+# scan runs past 1h, timeout kills it, then retry re-queues a zombie at exactly
+# 2h. max_attempts:1 is the real "no retries" switch the retry comment claimed.
+Q_TASK_TIMEOUT = config("Q_TASK_TIMEOUT", default=10800, cast=int)   # 3h hard cap per scan task
+Q_TASK_RETRY = config("Q_TASK_RETRY", default=Q_TASK_TIMEOUT + 1200, cast=int)
+# Guard: retry <= timeout causes the broker to re-run a task while it's still
+# running. Force retry strictly above timeout regardless of env misconfiguration.
+if Q_TASK_RETRY <= Q_TASK_TIMEOUT:
+    Q_TASK_RETRY = Q_TASK_TIMEOUT + 1200
+
 Q_CLUSTER = {
     "name": "openeasd",
     "workers": 1,       # SQLite is single-writer; >1 workers causes race conditions on task pickup
     "orm": "default",   # uses Django DB — no Redis needed
-    "timeout": 3600,    # 1 hour — accommodates long full scans
-    "retry": 7200,      # must be > timeout; effectively disables retries for our use case
+    "timeout": Q_TASK_TIMEOUT,
+    "retry": Q_TASK_RETRY,
+    "max_attempts": 1,  # a killed scan is dead, not retried — never re-queue it
     "catch_up": False,  # skip missed tasks on worker restart
 }
 

--- a/tests/unit/test_qcluster_config.py
+++ b/tests/unit/test_qcluster_config.py
@@ -1,0 +1,37 @@
+"""Regression tests for the Django-Q2 scan-timeout invariants.
+
+The original production bug was pure config drift: timeout 3600 / retry 7200 with
+no max_attempts, so every full scan that ran past 1h was killed and then a zombie
+was re-queued at exactly 2h. These tests lock the three timers into agreement so
+the bug cannot silently reappear.
+"""
+
+from django.conf import settings
+
+from apps.core.scheduler.scheduler import SCAN_TIMEOUT_MINUTES
+
+
+def test_retry_strictly_greater_than_timeout():
+    """retry <= timeout makes the broker re-run a task while it's still running."""
+    q = settings.Q_CLUSTER
+    assert q["retry"] > q["timeout"]
+
+
+def test_max_attempts_disables_requeue():
+    """max_attempts:1 is the real 'no retries' switch — a killed scan is dead."""
+    assert settings.Q_CLUSTER.get("max_attempts") == 1
+
+
+def test_watchdog_at_or_above_worker_timeout():
+    """The watchdog must not reap a scan whose worker is still legitimately running.
+
+    SCAN_TIMEOUT_MINUTES (minutes) must be >= the worker hard-kill (seconds/60),
+    or reap_stuck_scans flips a healthy long scan to 'partial' mid-run.
+    """
+    timeout_minutes = settings.Q_CLUSTER["timeout"] / 60
+    assert SCAN_TIMEOUT_MINUTES >= timeout_minutes
+
+
+def test_single_writer_worker():
+    """SQLite is single-writer — more than one worker races on task pickup."""
+    assert settings.Q_CLUSTER["workers"] == 1


### PR DESCRIPTION
The root cause behind ast.co.rs (and every large scan) failing at exactly 2h.

## Bug
`Q_CLUSTER` had `timeout: 3600` (1h) and `retry: 7200` (2h) with no `max_attempts`. A full scan runs past 1h, so the worker was hard-killed mid-scan, then the broker re-queued a zombie task at exactly 2h. The `retry` comment claimed it "disables retries" — but Django-Q2 disables re-queue via `max_attempts`, not `retry`.

## Fix — align the three timers that must agree
| Timer | Was | Now |
|---|---|---|
| `timeout` (worker kill) | 3600s / 1h | **10800s / 3h** (`Q_TASK_TIMEOUT`) |
| `retry` (re-queue window) | 7200s | **timeout+1200**, guarded `> timeout` (`Q_TASK_RETRY`) |
| `max_attempts` | — | **1** (real no-requeue switch) |
| watchdog `SCAN_TIMEOUT_MINUTES` | 90m | **180m** (must be `>= timeout`) |

The watchdog now sits at/above the worker hard-kill, so `reap_stuck_scans` only reaps genuinely orphaned scans (dead worker), never a healthy long-running one. All three knobs are env-tunable and documented in `.env.example`.

## Tests
`tests/unit/test_qcluster_config.py` locks the invariants (retry > timeout, max_attempts:1, watchdog >= timeout) so this config drift cannot silently reappear. Existing scheduler tests pass (they read `SCAN_TIMEOUT_MINUTES` dynamically).

Needs a cluster redeploy to take effect.