### PR TITLE
fix: derive Q_TASK_TIMEOUT from tool-cap ceiling (3h->4h)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,9 +16,10 @@ SCHEDULER_ENABLED=True
 
 # Scan timeouts — keep aligned: SCAN_TIMEOUT_MINUTES >= Q_TASK_TIMEOUT (in minutes),
 # and Q_TASK_RETRY > Q_TASK_TIMEOUT. Raise all three together for very large targets.
-# Q_TASK_TIMEOUT=10800        # worker hard-kill per scan task, seconds (default 3h)
-# Q_TASK_RETRY=12000          # broker re-queue window, seconds (must be > Q_TASK_TIMEOUT)
-# SCAN_TIMEOUT_MINUTES=180    # watchdog reap threshold, minutes (must be >= Q_TASK_TIMEOUT)
+# Default 4h is derived from the worst-case sum of per-tool caps (~3.4h ceiling).
+# Q_TASK_TIMEOUT=14400        # worker hard-kill per scan task, seconds (default 4h)
+# Q_TASK_RETRY=15600          # broker re-queue window, seconds (must be > Q_TASK_TIMEOUT)
+# SCAN_TIMEOUT_MINUTES=240    # watchdog reap threshold, minutes (must be >= Q_TASK_TIMEOUT)
 
 # Slack notifications (optional)
 SLACK_WEBHOOK_URL=

--- a/apps/core/scheduler/scheduler.py
+++ b/apps/core/scheduler/scheduler.py
@@ -8,11 +8,11 @@ from django.utils import timezone as django_tz
 logger = logging.getLogger(__name__)
 
 from decouple import config as _config  # noqa: E402
-# Must be >= Q_CLUSTER["timeout"] (3h / 10800s). The watchdog only cleans up the
+# Must be >= Q_CLUSTER["timeout"] (4h / 14400s). The watchdog only cleans up the
 # DB status of scans whose worker died without finalizing; it must not fire while
 # a healthy scan is still legitimately running, or it flips a live scan to
-# "partial" mid-run. Keep this at/above the worker hard-kill (180m).
-SCAN_TIMEOUT_MINUTES = _config("SCAN_TIMEOUT_MINUTES", default=180, cast=int)
+# "partial" mid-run. Keep this at/above the worker hard-kill (240m).
+SCAN_TIMEOUT_MINUTES = _config("SCAN_TIMEOUT_MINUTES", default=240, cast=int)
 
 
 # ---------------------------------------------------------------------------

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -168,7 +168,11 @@ for _dir in [OPENEASD_DATA_DIR, OPENEASD_LOGS_DIR]:
 # The old defaults (timeout 3600 / retry 7200) killed every large scan: a full
 # scan runs past 1h, timeout kills it, then retry re-queues a zombie at exactly
 # 2h. max_attempts:1 is the real "no retries" switch the retry comment claimed.
-Q_TASK_TIMEOUT = config("Q_TASK_TIMEOUT", default=10800, cast=int)   # 3h hard cap per scan task
+# Derived, not guessed: the worst-case sum of per-tool caps (same-phase tools run
+# in parallel) is ~3.4h — dominated by nuclei_network's 1h cap in phase 7. Set the
+# worker hard-kill above that ceiling so "every tool within its cap => scan always
+# completes" is a guarantee, not a hope. 4h leaves ~35m margin over the ceiling.
+Q_TASK_TIMEOUT = config("Q_TASK_TIMEOUT", default=14400, cast=int)   # 4h hard cap per scan task
 Q_TASK_RETRY = config("Q_TASK_RETRY", default=Q_TASK_TIMEOUT + 1200, cast=int)
 # Guard: retry <= timeout causes the broker to re-run a task while it's still
 # running. Force retry strictly above timeout regardless of env misconfiguration.


### PR DESCRIPTION
Follow-up to #157. Makes the worker timeout a *derived* value instead of a guess.

## Why
#157 set `Q_TASK_TIMEOUT` to 3h — but the worst-case sum of per-tool caps (same-phase tools run in parallel) is **~3.4h**, dominated by `nuclei_network`s 1h cap in phase 7. So a scan where every tool maxes out could still be cut by the worker even though each tool stayed inside its own cap. That is the "a random number does not fix it" gap.

## Change
Set the hard-kill above the real ceiling so *every tool within its cap => scan always completes* becomes a guarantee:
- `Q_TASK_TIMEOUT` 10800 -> **14400** (4h, ~35m margin over the ~3.4h ceiling)
- watchdog `SCAN_TIMEOUT_MINUTES` 180 -> **240** (stays >= timeout)
- `retry` follows as timeout+1200 = 15600

Note: amass (30m) and naabu (15m) are already capped via their DB config models — no unbounded tools remain. Existing `test_qcluster_config.py` invariants (retry > timeout, max_attempts:1, watchdog >= timeout) still hold and pass.

Needs the same cluster redeploy as #157.