### PR TITLE
fix: bake nuclei templates into image (fixes scan hang #161)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,10 @@ ENV PATH="/usr/local/bin:${PATH}"
 # hangs for hours. Baking makes them present at every start; the collector runs
 # nuclei with -disable-update-check so no runtime fetch is ever attempted.
 # Refreshed whenever the image is rebuilt.
-RUN nuclei -update-templates -disable-update-check \
+# NOTE: do NOT add -disable-update-check here — it suppresses the install itself
+# (nuclei exits 0 but writes nothing), so the templates dir is never created and
+# the test -d gate fails. The flag belongs only in the scan-time collector cmd.
+RUN nuclei -update-templates \
     && test -d /root/nuclei-templates
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,15 @@ COPY --from=subzy-builder /subzy /usr/local/bin/subzy
 COPY --from=history-builder /history-tools/ /usr/local/bin/
 ENV PATH="/usr/local/bin:${PATH}"
 
+# Bake nuclei templates into the image. Without this, the first scan on any
+# fresh container (every pod restart — the template dir is on the ephemeral
+# FS, not a PVC) downloads the whole template repo from GitHub mid-scan and
+# hangs for hours. Baking makes them present at every start; the collector runs
+# nuclei with -disable-update-check so no runtime fetch is ever attempted.
+# Refreshed whenever the image is rebuilt.
+RUN nuclei -update-templates -disable-update-check \
+    && test -d /root/nuclei-templates
+
 WORKDIR /app
 
 # Create virtualenv

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -112,6 +112,11 @@ def collect(session) -> list[dict]:
     # host with many ports (ast.co.rs had 25 IPs / 27 ports) can't stall the run.
     cmd = [
         binary, "-list", tmp, "-jsonl", "-silent", "-no-color",
+        # Never touch the network for templates/version at scan time. Templates
+        # are baked into the image; a fresh pod with no templates would otherwise
+        # download the whole repo from GitHub mid-scan and hang for hours (the
+        # process wedged past its own 30-min cap on the ast.co.rs prod scan).
+        "-disable-update-check",
         "-timeout", str(REQUEST_TIMEOUT),
         "-retries", "1",
         "-rate-limit", str(RATE_LIMIT),

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -269,6 +269,25 @@ class TestNucleiCollector:
             assert flag in cmd, f"missing {flag}"
         assert captured["timeout"] == 1800
 
+    def test_cmd_disables_runtime_template_update(self):
+        """nuclei must never download/update templates at scan time.
+
+        Templates are baked into the image; a runtime fetch from GitHub on a
+        fresh pod hangs for hours mid-scan. -disable-update-check stops nuclei
+        from doing any template/version update check when it runs.
+        """
+        sess = self._make_session()
+        captured = {}
+
+        def fake_run(cmd, timeout):
+            captured["cmd"] = cmd
+            return MagicMock(stdout="", returncode=0, stderr="")
+
+        with patch("apps.nuclei.collector._run", side_effect=fake_run):
+            collect(sess)
+
+        assert "-disable-update-check" in captured["cmd"]
+
 
 # ---------------------------------------------------------------------------
 # _run — process-group kill on timeout


### PR DESCRIPTION
Fixes #161 — the true root cause behind ast.co.rs full scans never completing.

## Root cause (reproduced on prod, systematic-debugging)
nuclei templates are **never baked into the image** — the Dockerfile installs only the binary. The template dir `/root/nuclei-templates` sits on the **ephemeral container FS** (only `/app/data` + `/app/logs` are PVCs), so the **first nuclei scan on every fresh pod downloads the whole template repo from GitHub mid-scan** and hangs.

Evidence: on session 19 (fresh pod after a redeploy), nuclei ran **236.8 min on 17 URLs** and was still installing templates when the watchdog killed it — 0 findings. Reproduced directly in the worker: with templates absent, nuclei stalls at `nuclei-templates are not installed, installing...`; once present, it is instant.

## Fix — eliminate all template network activity at scan time
- **Dockerfile:** `RUN nuclei -update-templates` at build → templates baked into the image, present at every container start, refreshed on rebuild.
- **collector.py:** add `-disable-update-check` → nuclei never checks for / downloads templates or version updates during a scan.

## Tests
`test_cmd_disables_runtime_template_update` added; full `test_nuclei.py` suite (31) passes.

## Note
This is separate from the Q_CLUSTER timeout fix (#157/#158, already deployed). That correctly stopped the 2h zombie and let the scan run to 4h; this removes the actual thing that was consuming those hours. Needs an image rebuild + redeploy to take effect.