### PR TITLE
fix: raise worker memory limit 1Gi->4Gi to stop nuclei OOM-kill

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -119,13 +119,19 @@ spec:
             capabilities:
               add:
                 - NET_RAW   # required for nmap and naabu port scanning
+          # nuclei loads ~10k community templates into memory at scan time,
+          # which spikes well past 1Gi. At the old 1Gi limit the kernel
+          # OOM-killed the worker mid-scan (exit 137) — proc.wait() never
+          # returned, so the scan orphaned "running" until the 240m watchdog
+          # reaped it as partial. Raised to 4Gi (node has ~52Gi free) so the
+          # template load fits and full scans complete.
           resources:
             requests:
               cpu: "500m"
-              memory: "512Mi"
+              memory: "1Gi"
             limits:
               cpu: "2000m"
-              memory: "1Gi"
+              memory: "4Gi"
 
       volumes:
         - name: data


### PR DESCRIPTION
## What
Raise the `worker` container memory limit `1Gi → 4Gi` (request `512Mi → 1Gi`) in `k8s/deployment.yaml`.

## Why
Root cause of the ast.co.rs full-scan hang. nuclei loads ~10k community templates into memory at scan time, spiking past 1Gi. The kernel OOM-killed the worker mid-scan (`reason: OOMKilled`, exit 137), so `proc.wait()` never returned and the scan orphaned "running" until the 240m watchdog reaped it as partial.

Three prior fixes (#148 process-group kill, #156 file-based wait, #162 baked templates) all treated it as an I/O hang and missed the real cause. Confirmed by running nuclei directly on the node — every run died with exit 137, and the worker pod had 4 OOMKilled restarts.

## Risk
Low. Node has ~52Gi free; idle worker uses ~93Mi. Single-value limit bump, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)