### PR TITLE
docs: sync README + description to 19 tools + CVE Intel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Use it as a **red teamer** to map external surface fast on targets you're authorised to test. Use it as a **defender** to see what's leaking out of your own infrastructure — subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs — without paying $500-5000/mo for a commercial EASM platform.
 
-OpenEASD wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei` — behind a single web UI with scheduling, alerts, and findings tracking. Eighteen tools across DNS, email, TLS, SSH, ports, CVEs, subdomain takeover, historical URLs, cloud assets, and web hygiene. Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
+OpenEASD wraps the open-source recon tools security teams already use — `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei` — behind a single web UI with scheduling, alerts, and findings tracking. Nineteen tools across DNS, email, TLS, SSH, ports, CVEs, subdomain takeover, historical URLs, cloud assets, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
 
 Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [Cybersecify](https://cybersecify.com) — the same tool we run in engagements and on our own infrastructure.
 
@@ -137,8 +137,9 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline** — 18-tool scan workflow from domain to findings
+- **Automated pipeline** — 19-tool scan workflow from domain to findings
 - **Network attack surface scanning** — CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
+- **CVE prioritisation** — EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows** — Create custom scan configurations, enable/disable tools per workflow
 - **Tool auto-registration** — Add new tools with zero core modification
 - **Live scan progress** — Real-time pipeline status with per-tool step tracking


### PR DESCRIPTION
## What
Bring the repo's public copy in sync with the product:
- README: "Eighteen tools" → "Nineteen tools", "18-tool" → "19-tool", added a **CVE prioritisation (EPSS + CISA KEV)** feature bullet and category.
- GitHub repo description: "18 tools" → "19 tools", added EPSS/KEV.

## Why
The registry reports **19 tools** (CVE Intel / `apps.cve_intel` is in INSTALLED_APPS), and CVE Intel's EPSS + CISA KEV prioritisation was entirely absent from the public copy. Part of a marketing ↔ repo ↔ source-of-truth sync pass.

## Not included
- Screenshot alt-text still says "18 tool steps" — it describes the actual image, which needs regenerating separately.
- Marketing site (`cybersecify.com/openeasd` + sample report) is a separate repo — change-list handed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)