### PR TITLE
fix: keep real ALLOWED_HOSTS in secret so apply -k can't break prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kubectl apply -k k8s/` can no longer take the site offline by clobbering `ALLOWED_HOSTS`** — The committed `configmap.yaml` held the deployment's real serving hostname in `ALLOWED_HOSTS`/`CSRF_TRUSTED_ORIGINS`. Two problems: it leaked a private hostname into the public repo, and because the configmap is part of the kustomize base, running the documented `kubectl apply -k k8s/` deploy step would overwrite the live host with whatever the file said — so scrubbing it to a placeholder turned a routine re-apply into an outage (Django `400`s every request whose `Host` isn't in `ALLOWED_HOSTS`). Fix: move the real `ALLOWED_HOSTS`/`CSRF_TRUSTED_ORIGINS` into `openeasd-secret`, which is applied out-of-band and is deliberately **not** listed in `kustomization.yaml`, so `apply -k` never touches it. `configmap.yaml` now carries placeholders only, and the deployment's `envFrom` already lists `secretRef` after `configMapRef` (last source wins), so the secret's values override the placeholders at runtime. **Why:** the deploy path documented in CLAUDE.md must be safe to run at any time; a config re-apply should never be able to knock the live host offline, and the real hostname should never be in the repo. **Evidence:** verified against the live cluster — the rendered `kubectl kustomize k8s/` output manages only configmap/service/pvc/deployment (no Secret), the secret now durably holds the real host, and the deployment `envFrom` order makes the secret win over the configmap placeholder.
+
 ## [v0.9.0] — 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,19 +189,28 @@ container: worker      → python manage.py qcluster  (NET_RAW capability for nm
 **Files:**
 ```
 k8s/
-  configmap.yaml        — env vars (ALLOWED_HOSTS, CSRF_TRUSTED_ORIGINS, etc.)
-  secret.yaml           — SECRET_KEY template (fill in before applying)
+  configmap.yaml        — non-secret env vars; ALLOWED_HOSTS/CSRF are PLACEHOLDERS only
+  secret.yaml           — template for SECRET_KEY + real ALLOWED_HOSTS/CSRF (apply out-of-band)
   pvc.yaml              — openeasd-data (10Gi) + openeasd-logs (2Gi), RWO
   deployment.yaml       — single pod with init + web + worker containers
   service.yaml          — ClusterIP, port 80 → 8000
   ingress.yaml          — nginx Ingress; TLS annotations ready to uncomment
-  kustomization.yaml    — kubectl apply -k k8s/
+  kustomization.yaml    — kubectl apply -k k8s/ (does NOT include secret.yaml)
 ```
 
 **Key constraints:**
 - `replicas: 1` required — SQLite RWO PVC allows single-node access only
 - Only `worker` container gets `NET_RAW`; `web` does not need it
 - `GET /health/` — unauthenticated endpoint used by K8s readiness/liveness probes
+- **Real `ALLOWED_HOSTS`/`CSRF_TRUSTED_ORIGINS` live in `openeasd-secret`, never in
+  the committed configmap.** `configmap.yaml` carries only placeholders; the real
+  hostname is set in the secret, which is applied out-of-band and is intentionally
+  omitted from the kustomize base. Because the deployment's `envFrom` lists
+  `secretRef` after `configMapRef` (last source wins), the secret's values override
+  the configmap placeholders at runtime. This is deliberate: it keeps the real host
+  out of the public repo AND makes `kubectl apply -k k8s/` safe — a re-apply can
+  never clobber `ALLOWED_HOSTS` back to the placeholder and 400 the live host.
+  Set them when creating the secret (see `k8s/secret.yaml` and `kustomization.yaml`).
 
 **Update running deployment:**
 ```bash

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -4,7 +4,17 @@ metadata:
   name: openeasd-config
   namespace: default
 data:
-  # Replace openeasd.example.com with the hostname you serve OpenEASD on.
+  # ALLOWED_HOSTS / CSRF_TRUSTED_ORIGINS below are PLACEHOLDERS only. Set the real
+  # production hostname in openeasd-secret (see secret.yaml), NOT in this file.
+  #
+  # Why: the secret is applied out-of-band and is deliberately NOT part of the
+  # kustomize base (kustomization.yaml lists only configmap/pvc/deployment/service),
+  # so `kubectl apply -k k8s/` can never overwrite it. The deployment's envFrom
+  # lists secretRef AFTER configMapRef, and the last envFrom source wins — so the
+  # secret's ALLOWED_HOSTS/CSRF_TRUSTED_ORIGINS override these placeholders at
+  # runtime. Committing the real host here would leak it into the public repo AND
+  # let a routine `apply -k` clobber it back to the placeholder, 400-ing every
+  # request on the real host. Leave these as-is.
   ALLOWED_HOSTS: "openeasd.example.com,openeasd.local,localhost"
   CSRF_TRUSTED_ORIGINS: "https://openeasd.example.com,http://openeasd.local"
   DEBUG: "False"

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -12,6 +12,13 @@ resources:
 # ingress.yaml is omitted — Caddy on the host terminates TLS and proxies to the
 # NodePort (service.yaml). Re-add the ingress + a controller (e.g. nginx-ingress)
 # if you want in-cluster ingress instead.
-# Apply secret.yaml separately with a real SECRET_KEY (do not commit real values):
+# secret.yaml is intentionally NOT listed above — it is applied separately with
+# real values that must never be committed, and keeping it out of the base means
+# `kubectl apply -k k8s/` can never overwrite it. The secret holds SECRET_KEY AND
+# the real ALLOWED_HOSTS / CSRF_TRUSTED_ORIGINS (configmap.yaml carries only
+# placeholders; secretRef overrides configMapRef in the deployment envFrom). Apply
+# it out-of-band, e.g.:
 #   kubectl create secret generic openeasd-secret -n default \
-#     --from-literal=SECRET_KEY="$(openssl rand -hex 32)"
+#     --from-literal=SECRET_KEY="$(openssl rand -hex 32)" \
+#     --from-literal=ALLOWED_HOSTS="your.host,localhost" \
+#     --from-literal=CSRF_TRUSTED_ORIGINS="https://your.host"

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,6 +1,13 @@
 # TEMPLATE — do not commit real values.
 # Generate SECRET_KEY: openssl rand -hex 32 | base64
 # Then apply: kubectl apply -f k8s/secret.yaml
+#
+# This Secret is applied OUT-OF-BAND and is intentionally NOT listed in
+# kustomization.yaml, so `kubectl apply -k k8s/` never touches it. That makes it
+# the durable home for values that must survive a re-apply and must NOT live in
+# the public repo — chiefly ALLOWED_HOSTS / CSRF_TRUSTED_ORIGINS. The deployment's
+# envFrom lists secretRef AFTER configMapRef, so the values set here override the
+# placeholders in configmap.yaml at runtime (last envFrom source wins).
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +16,11 @@ metadata:
 type: Opaque
 stringData:
   SECRET_KEY: "REPLACE_WITH_OPENSSL_RAND_HEX_32"
+  # Real production hostname lives HERE, not in configmap.yaml. Set both to the
+  # host(s) you serve OpenEASD on. Without these the pod falls back to the
+  # configmap placeholders and Django 400s every request on the real host.
+  ALLOWED_HOSTS: "REPLACE_WITH_YOUR_HOST,localhost"
+  CSRF_TRUSTED_ORIGINS: "https://REPLACE_WITH_YOUR_HOST"
   # Optional — uncomment to enable alert notifications
   # SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/..."
   # MS_TEAMS_WEBHOOK_URL: "https://..."


### PR DESCRIPTION
## What
Move the real `ALLOWED_HOSTS` / `CSRF_TRUSTED_ORIGINS` out of the committed `configmap.yaml` (placeholders only now) and into `openeasd-secret`, which is applied out-of-band and is **not** part of the kustomize base. Docs (CLAUDE.md, secret/configmap/kustomization comments) updated to match.

## Why
`configmap.yaml` is in the kustomize base, so the documented `kubectl apply -k k8s/` deploy step overwrites the live `ALLOWED_HOSTS` with whatever the file holds. Now that the file is a placeholder (`openeasd.example.com`), a routine re-apply would 400 every request on the real host — an outage. The real hostname also should never live in the public repo. Putting the real values in the secret (not in the base) makes `apply -k` safe: it can never touch the secret, and the deployment's `envFrom` lists `secretRef` after `configMapRef`, so the secret's values override the configmap placeholders at runtime (last source wins).

## How verified (against the live cluster, read-only + one additive change)
- Confirmed the deployment `envFrom` order is `configMapRef` then `secretRef` → secret wins.
- Added the real `ALLOWED_HOSTS`/`CSRF_TRUSTED_ORIGINS` to `openeasd-secret` (additive patch, no pod restart) so the durable source is in place before the repo change lands.
- Rendered `kubectl kustomize k8s/` on the cluster: the manifests `apply -k` would manage are ConfigMap / Service / 2×PVC / Deployment only — **no Secret** — proving `apply -k` can never clobber the real host.
- No real hostname appears in any committed file (`git grep` clean).

## Note (separate, pre-existing prod issue — not caused by this change)
While verifying I found the production node is at **100% disk** (DiskPressure taint), which is independently evicting pods and blocking replacements. That is unrelated to this footgun and out of scope here; flagging for operator follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)