### PR TITLE
feat: add-and-scan-once for new domains from the Start Scan page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+
+- **Self-serve add-and-scan-once from the Start Scan page.**
+  - **What:** `/scans/start` now lets you enter a brand-new domain and run a
+    one-off scan without opening Django admin. A new `POST /api/domains/{pk}/authorize/`
+    endpoint records a `DomainAuthorization` (auth_type `owner`, the logged-in user,
+    today's date) after a required "I have authority to scan this domain" attestation.
+  - **Why:** Authorization could previously be granted only through Django admin, so
+    the intended "add a domain and scan it" flow could not be completed in the UI.
+  - **Hypothesis:** (user-driven) operators need to scan newly-supplied domains on
+    demand without an admin round-trip; a lightweight on-the-record attestation keeps
+    the consent gate for the public Docker build while removing the admin friction.
+  - **Evidence:** (user-driven) reported directly — "I want to add domains and scan
+    them once via UI; it's not happening." The gate is deliberately retained because
+    the same image ships as the public GitHub Docker download, where it is the user's
+    responsibility to confirm they have authority.
+  - Does not touch the scheduler or `SCHEDULED_SCANS_ENABLED`; automatic scanning
+    remains disabled on the managed deployment.
+
 ### Housekeeping
 
 - **Docs drift + version sync** — Rebuilt the CLAUDE.md test-count table against the actual suite (dropped two removed files, added 13 missing ones, corrected stale counts → **970 tests, 929 fast + 41 slow**), added the undocumented API routes (`/api/notifications/*`, `domains/<pk>/monitoring/`, `scans/<uuid>/subscan/`, `scans/urls/`, `workflows/<pk>/rename/`), reverted `pyproject.toml` `1.0.0` → `0.9.0` to match the latest tag + CHANGELOG (it had been bumped ahead of a release that hasn't been cut), and gitignored `.DS_Store`. **Why:** a claims-trace audit found the counts and endpoint list had drifted from the code; keeping the version ahead of the tag invites shipping a mislabelled build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -461,6 +461,7 @@ POST /api/domains/                        — add domain
 POST /api/domains/<pk>/toggle/            — activate/deactivate
 POST /api/domains/<pk>/delete/            — delete domain + all scan data
 POST /api/domains/<pk>/monitoring/        — set/clear per-domain monitoring interval
+POST /api/domains/<pk>/authorize/         — grant DomainAuthorization (attestation required)
 GET  /api/scans/                          — paginated scan list (?domain=&status=&page=)
 POST /api/scans/start/                    — start/schedule scan
 GET  /api/scans/<uuid>/                   — full scan detail (assets + findings)
@@ -536,6 +537,6 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 84 | Smoke tests for all API endpoints (auth + payload shape) |
+| `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 970 tests** (929 fast + 41 slow domain_security)
+**Total: 975 tests** (934 fast + 41 slow domain_security)

--- a/apps/core/domains/api.py
+++ b/apps/core/domains/api.py
@@ -6,12 +6,13 @@ import re
 from django.db import transaction
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 
 from ninja import Router, Schema, Status
 from ninja.errors import HttpError
 
 from ninja_jwt.authentication import JWTAuth
-from apps.core.domains.models import Domain
+from apps.core.domains.models import Domain, DomainAuthorization
 from apps.core.findings.models import Finding
 from apps.core.insights.builder import rebuild_finding_type_summaries
 from apps.core.insights.models import ScanSummary
@@ -131,6 +132,44 @@ def toggle_domain(request, pk: int):
     domain.save()
     from apps.core.scheduler.scheduler import sync_domain_monitoring_jobs
     sync_domain_monitoring_jobs()
+    _enrich_domains([domain])
+    return _serialize_domain(domain)
+
+
+class AuthorizeIn(Schema):
+    attestation: bool = False
+    auth_type: str = "owner"
+
+
+@router.post("/{pk}/authorize/")
+def authorize_domain(request, pk: int, data: AuthorizeIn):
+    """Grant a DomainAuthorization record so the domain becomes scannable.
+
+    Requires an explicit `attestation` that the caller has authority to scan
+    the domain. Idempotent: if already authorized, returns the existing record.
+    """
+    domain = get_object_or_404(
+        Domain.objects.select_related("authorization"), pk=pk
+    )
+
+    if getattr(domain, "authorization", None) is not None:
+        _enrich_domains([domain])
+        return _serialize_domain(domain)
+
+    if not data.attestation:
+        raise HttpError(400, "Authorization attestation is required")
+
+    valid_types = {choice[0] for choice in DomainAuthorization.AUTH_TYPES}
+    auth_type = data.auth_type if data.auth_type in valid_types else "owner"
+
+    DomainAuthorization.objects.create(
+        domain=domain,
+        auth_type=auth_type,
+        authorized_at=timezone.localdate(),
+        authorized_by=request.auth.username,
+    )
+
+    domain = Domain.objects.select_related("authorization").get(pk=pk)
     _enrich_domains([domain])
     return _serialize_domain(domain)
 

--- a/frontend/src/pages/ScanStartPage.jsx
+++ b/frontend/src/pages/ScanStartPage.jsx
@@ -7,6 +7,9 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { apiPost, apiGet } from '../api/client.js';
 
+// Mirrors the API's RFC 1123 hostname check (apps/core/domains/api.py)
+const HOSTNAME_RE = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+
 export default function ScanStartPage() {
   const navigate = useNavigate();
   const params     = new URLSearchParams(window.location.search);
@@ -31,6 +34,9 @@ export default function ScanStartPage() {
   const [schedTime,  setSchedTime] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error,      setError]     = useState(null);
+  const [newDomainMode, setNewDomainMode] = useState(false);
+  const [newDomain,     setNewDomain]     = useState('');
+  const [attested,      setAttested]      = useState(false);
 
   useEffect(() => {
     if (defaultWf && !workflowId) setWorkflow(String(defaultWf.id));
@@ -38,10 +44,32 @@ export default function ScanStartPage() {
 
   async function handleSubmit(e) {
     e.preventDefault();
-    if (!domain) { setError('Select a domain.'); return; }
+    const target = newDomainMode ? newDomain.trim().toLowerCase() : domain;
+    if (!target) {
+      setError(newDomainMode ? 'Enter a domain.' : 'Select a domain.');
+      return;
+    }
+    if (newDomainMode) {
+      if (!HOSTNAME_RE.test(target)) { setError('Enter a valid domain name.'); return; }
+      if (!attested) {
+        setError('Please confirm you have authority to scan this domain.');
+        return;
+      }
+    }
     setError(null); setSubmitting(true);
     try {
-      const body = { domain, schedule_type: scheduled ? 'once' : 'now' };
+      if (newDomainMode) {
+        let created;
+        try {
+          created = await apiPost('/domains/', { name: target });
+        } catch (err) {
+          // Domain already exists — reuse the one from the loaded list.
+          if (err.status === 400) created = domains.find(d => d.name === target);
+          if (!created) throw err;
+        }
+        await apiPost(`/domains/${created.id}/authorize/`, { attestation: true });
+      }
+      const body = { domain: target, schedule_type: scheduled ? 'once' : 'now' };
       if (workflowId) body.workflow_id = Number(workflowId);
       if (scheduled && schedTime) body.scheduled_at = schedTime;
       await apiPost('/scans/start/', body);
@@ -65,13 +93,44 @@ export default function ScanStartPage() {
             <CardContent className="p-6">
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
-                  <label className="block text-xs text-dim mb-1 font-medium">Domain *</label>
-                  <select value={domain} onChange={e => setDomain(e.target.value)} required className="field">
-                    <option value="">— select domain —</option>
-                    {domains.filter(d => d.is_active && d.authorization).map(d => (
-                      <option key={d.id} value={d.name}>{d.name}</option>
-                    ))}
-                  </select>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="block text-xs text-dim font-medium">Domain *</label>
+                    <button
+                      type="button"
+                      className="text-xs text-brand hover:underline"
+                      onClick={() => { setNewDomainMode(m => !m); setError(null); }}
+                    >
+                      {newDomainMode ? 'Pick existing domain' : '＋ Scan a new domain'}
+                    </button>
+                  </div>
+                  {newDomainMode ? (
+                    <>
+                      <input
+                        type="text"
+                        value={newDomain}
+                        onChange={e => setNewDomain(e.target.value)}
+                        placeholder="example.com"
+                        className="field"
+                        autoFocus
+                      />
+                      <label className="mt-2 flex items-start gap-2 text-sm text-body cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={attested}
+                          onChange={e => setAttested(e.target.checked)}
+                          className="accent-brand mt-0.5"
+                        />
+                        <span>I confirm I have authority to scan this domain (I own it or have written permission).</span>
+                      </label>
+                    </>
+                  ) : (
+                    <select value={domain} onChange={e => setDomain(e.target.value)} className="field">
+                      <option value="">— select domain —</option>
+                      {domains.filter(d => d.is_active && d.authorization).map(d => (
+                        <option key={d.id} value={d.name}>{d.name}</option>
+                      ))}
+                    </select>
+                  )}
                 </div>
                 <div>
                   <label className="block text-xs text-dim mb-1 font-medium">Workflow</label>
@@ -94,7 +153,10 @@ export default function ScanStartPage() {
                 )}
                 {error && <p className="text-red-400 text-sm">{error}</p>}
                 <div className="flex gap-3 pt-1">
-                  <Button type="submit" disabled={submitting}>
+                  <Button
+                    type="submit"
+                    disabled={submitting || (newDomainMode && (!newDomain.trim() || !attested))}
+                  >
                     {submitting ? 'Starting…' : scheduled ? 'Schedule Scan' : 'Start Scan Now'}
                   </Button>
                   <Button type="button" variant="outline" onClick={() => navigate('/scans')}>Cancel</Button>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -295,6 +295,53 @@ class TestDomainsToggle:
         assert post_json(auth_client, "/api/domains/99999/toggle/", {}).status_code == 404
 
 
+class TestDomainsAuthorize:
+    def test_creates_authorization_record(self, auth_client, domain):
+        from apps.core.domains.models import DomainAuthorization
+        res = post_json(
+            auth_client, f"/api/domains/{domain.pk}/authorize/", {"attestation": True}
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["authorization"] is not None
+        assert body["authorization"]["auth_type"] == "owner"
+        auth = DomainAuthorization.objects.get(domain=domain)
+        assert auth.authorized_by == "apitest"  # from the `user` fixture
+
+    def test_attestation_required(self, auth_client, domain):
+        from apps.core.domains.models import DomainAuthorization
+        res = post_json(
+            auth_client, f"/api/domains/{domain.pk}/authorize/", {"attestation": False}
+        )
+        assert res.status_code == 400
+        assert not DomainAuthorization.objects.filter(domain=domain).exists()
+
+    def test_idempotent_when_already_authorized(self, auth_client, domain):
+        from apps.core.domains.models import DomainAuthorization
+        from django.utils import timezone
+        DomainAuthorization.objects.create(
+            domain=domain, auth_type="owner",
+            authorized_at=timezone.localdate(), authorized_by="someone",
+        )
+        # Second call (even without attestation) returns 200, does not duplicate.
+        res = post_json(
+            auth_client, f"/api/domains/{domain.pk}/authorize/", {"attestation": False}
+        )
+        assert res.status_code == 200
+        assert DomainAuthorization.objects.filter(domain=domain).count() == 1
+        assert DomainAuthorization.objects.get(domain=domain).authorized_by == "someone"
+
+    def test_not_found(self, auth_client):
+        assert post_json(
+            auth_client, "/api/domains/99999/authorize/", {"attestation": True}
+        ).status_code == 404
+
+    def test_requires_auth(self, client, domain):
+        assert post_json(
+            client, f"/api/domains/{domain.pk}/authorize/", {"attestation": True}
+        ).status_code == 401
+
+
 class TestDomainsDelete:
     def test_deletes_domain(self, auth_client, domain):
         res = post_json(auth_client, f"/api/domains/{domain.pk}/delete/", {})


### PR DESCRIPTION
Lets an operator add a new domain and run a one-off scan entirely from `/scans/start`.

- New `POST /api/domains/{pk}/authorize/` grants a `DomainAuthorization` after a required "I have authority to scan this domain" attestation (auth_type=owner, logged-in user, today).
- Start Scan page gains a "Scan a new domain" mode that chains create → authorize → start. Typing an already-added domain falls through to authorize + scan it.
- Existing dropdown flow for already-authorized domains is unchanged.
- Does not touch the scheduler / `SCHEDULED_SCANS_ENABLED` — auto-scan stays disabled on the managed deployment.
- Tests: 5 new endpoint tests (attestation required, idempotent, 404, auth). Full fast suite: 934 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)