### PR TITLE
fix: stop subscans polluting latest-session views + reject non-http archived URLs

### DIFF
--- a/apps/core/queries.py
+++ b/apps/core/queries.py
@@ -10,11 +10,19 @@ def latest_session_ids(domains=None):
     has real findings (steps that ran before the watchdog reap), so it should
     surface in dashboards and findings views.
 
+    Subscans are excluded: they copy the parent's assets but run only a subset
+    of tools and produce their own subset of findings. A subscan always has the
+    highest id for its domain, so without this filter it would masquerade as the
+    domain's "latest session" and collapse dashboards/findings/insights down to
+    just the re-run tool's output until the next full scan.
+
     If *domains* is ``None``, returns for all domains.
     """
     from apps.core.scans.models import ScanSession
 
-    qs = ScanSession.objects.filter(status__in=["completed", "partial"])
+    qs = ScanSession.objects.filter(status__in=["completed", "partial"]).exclude(
+        scan_type="subscan"
+    )
     if domains is not None:
         qs = qs.filter(domain__in=domains)
     rows = qs.values("domain").annotate(latest_id=Max("id"))

--- a/apps/core/scans/pipeline.py
+++ b/apps/core/scans/pipeline.py
@@ -36,12 +36,15 @@ logger = logging.getLogger(__name__)
 def _detect_deltas(session):
     # Exclude subscans: they only run a subset of tools, so using one as the
     # baseline would produce spurious "new finding" deltas on the next full scan.
+    # Filter on scan_type (immutable) rather than parent_session, which is
+    # SET_NULL and would promote a subscan to a baseline once its parent is
+    # deleted.
     previous = (
         ScanSession.objects.filter(
             domain=session.domain, status__in=["completed", "partial"]
         )
         .exclude(id=session.id)
-        .filter(parent_session__isnull=True)
+        .exclude(scan_type="subscan")
         .order_by("-start_time")
         .first()
     )
@@ -92,6 +95,14 @@ def _finalize_session(session):
     session.end_time = django_tz.now()
     session.save(update_fields=["total_findings", "status", "end_time"])
     logger.info(f"[scan:{session_id}] Completed — {total} findings")
+
+    # Subscans run only a subset of tools against copied parent assets. Delta
+    # detection, insights, and alerts all assume a full scan's finding set — a
+    # subscan's subset would diff against the last full scan (spurious "removed"
+    # deltas) and re-fire alerts the parent already sent. Skip them for subscans.
+    if session.scan_type == "subscan":
+        logger.info(f"[scan:{session_id}] Subscan — skipping deltas, insights, and alerts")
+        return
 
     _detect_deltas(session)
 
@@ -329,6 +340,15 @@ def create_subscan_session(parent_uuid: str, tools: list[str], triggered_by: str
 def run_scan(session_id: int):
     """Execute a scan session via its attached workflow, then finalise."""
     session = ScanSession.objects.select_related("workflow", "parent_session").get(id=session_id)
+    # A queued task may be picked up after the session was already cancelled
+    # (stop issued while pending) or reaped by the watchdog (marked failed while
+    # sitting in a deep queue). Flipping such a session back to "running" would
+    # resurrect it — re-executing a cancelled scan, or running a second copy
+    # alongside the replacement the reap allowed to start. Only pending sessions
+    # are meant to run.
+    if session.status != "pending":
+        logger.info(f"[scan:{session_id}] Session status is '{session.status}', not 'pending' — skipping run")
+        return
     session.status = "running"
     session.save(update_fields=["status"])
     logger.info(f"[scan:{session_id}] Starting {'subscan' if session.parent_session_id else 'scan'} for {session.domain}")

--- a/apps/historical_urls/analyzer.py
+++ b/apps/historical_urls/analyzer.py
@@ -24,6 +24,13 @@ _NOISE_EXTENSIONS = frozenset([
 
 _DEFAULT_PORTS = {"http": 80, "https": 443}
 
+# Only http(s) URLs are kept. Archive sources (Wayback/OTX/Common Crawl) are
+# third-party-influenceable and can return non-navigable schemes such as
+# ``javascript:`` or ``data:``; storing those risks rendering them as clickable
+# links in the UI (→ XSS / token theft). gau/waybackurls emit essentially only
+# http(s), so this drops no legitimate endpoints.
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
 
 def _is_noise(url: str) -> bool:
     """Return True if the URL points at a non-interesting static asset."""
@@ -72,9 +79,9 @@ def analyze(session, raw_urls: list[str]) -> list[URL]:
             parsed = urlparse(url_str)
         except ValueError:
             continue
-        scheme = parsed.scheme
+        scheme = parsed.scheme.lower()
         host = parsed.hostname or ""
-        if not host or not scheme:
+        if scheme not in _ALLOWED_SCHEMES or not host:
             continue
 
         seen.add(url_str)

--- a/frontend/src/pages/ScanDetailPage.jsx
+++ b/frontend/src/pages/ScanDetailPage.jsx
@@ -148,6 +148,11 @@ const SCHEME_CLS = {
   http:  'bg-yellow-900/40 text-yellow-400 border border-yellow-800',
 };
 
+// Discovered URLs can originate from third-party archive sources; only link out
+// to genuine http(s) URLs so a hostile scheme (javascript:, data:) can't render
+// as a clickable link. Anything else is shown as inert text.
+const SAFE_URL = /^https?:\/\//i;
+
 function StatCard({ label, value, danger }) {
   return (
     <div className={`border rounded-lg px-4 py-3 text-center ${danger ? 'border-red-800 bg-red-900/10' : 'border-rim bg-card'}`}>
@@ -403,7 +408,9 @@ export default function ScanDetailPage() {
                             </span>
                           </TableCell>
                           <TableCell className="px-4 py-3 font-mono text-brand text-xs max-w-xs truncate">
-                            <a href={u.url} target="_blank" rel="noopener noreferrer" className="hover:underline">{u.url}</a>
+                            {SAFE_URL.test(u.url)
+                              ? <a href={u.url} target="_blank" rel="noopener noreferrer" className="hover:underline">{u.url}</a>
+                              : <span className="text-dim" title="Non-navigable URL scheme — not linked">{u.url}</span>}
                           </TableCell>
                           <TableCell className={`px-4 py-3 font-mono font-semibold ${statusColor(u.status_code)}`}>
                             {u.status_code || '—'}

--- a/tests/unit/test_historical_urls.py
+++ b/tests/unit/test_historical_urls.py
@@ -231,6 +231,27 @@ class TestAnalyze:
         objs = analyze(sess, ["example.com/path"])
         assert objs == []
 
+    def test_rejects_javascript_scheme(self):
+        sess = self._session()
+        objs = analyze(sess, ["javascript://example.com/%0aalert(1)"])
+        assert objs == []
+
+    def test_rejects_data_scheme(self):
+        sess = self._session()
+        objs = analyze(sess, ["data://example.com/text/html,<script>alert(1)</script>"])
+        assert objs == []
+
+    def test_rejects_ftp_scheme(self):
+        sess = self._session()
+        objs = analyze(sess, ["ftp://example.com/file"])
+        assert objs == []
+
+    def test_accepts_uppercase_http_scheme(self):
+        sess = self._session()
+        objs = analyze(sess, ["HTTPS://example.com/admin"])
+        assert len(objs) == 1
+        assert objs[0].scheme == "https"
+
 
 # ---------------------------------------------------------------------------
 # Scanner

--- a/tests/unit/test_scans.py
+++ b/tests/unit/test_scans.py
@@ -176,6 +176,125 @@ class TestDetectDeltas:
         _detect_deltas(s)
         assert ScanDelta.objects.filter(session=s).count() == 0
 
+    def test_subscan_not_used_as_baseline(self, db):
+        """A subscan between two full scans must not become the delta baseline."""
+        from apps.core.scans.models import ScanSession, ScanDelta
+        from apps.core.findings.models import Finding
+        from apps.core.scans.pipeline import _detect_deltas
+        from django.utils import timezone
+
+        full1 = ScanSession.objects.create(domain="b.com", scan_type="full", status="completed", end_time=timezone.now())
+        Finding.objects.create(session=full1, source="web_checker", target="b.com", check_type="hdr", severity="low", title="Missing HSTS")
+        # A subscan (subset of tools) runs later — highest id, but not a valid baseline.
+        sub = ScanSession.objects.create(domain="b.com", scan_type="subscan", status="completed", end_time=timezone.now())
+        Finding.objects.create(session=sub, source="tls_checker", target="b.com:443", check_type="cipher", severity="medium", title="Weak cipher")
+        full2 = ScanSession.objects.create(domain="b.com", scan_type="full", status="completed", end_time=timezone.now())
+        Finding.objects.create(session=full2, source="web_checker", target="b.com", check_type="hdr", severity="low", title="Missing HSTS")
+
+        _detect_deltas(full2)
+
+        # Baseline is full1, so the unchanged HSTS finding yields no deltas — the
+        # subscan's TLS finding must not appear as a spurious "removed".
+        assert ScanDelta.objects.filter(session=full2).count() == 0
+
+
+@pytest.mark.django_db
+class TestFinalizeSubscan:
+    def test_finalize_skips_deltas_insights_alerts_for_subscan(self, db):
+        from unittest.mock import patch
+        from apps.core.scans.models import ScanSession
+        from apps.core.scans.pipeline import _finalize_session
+        from django.utils import timezone
+
+        parent = ScanSession.objects.create(domain="s.com", scan_type="full", status="completed", end_time=timezone.now())
+        sub = ScanSession.objects.create(domain="s.com", scan_type="subscan", status="running", parent_session=parent)
+
+        with patch("apps.core.scans.pipeline._detect_deltas") as m_delta, \
+             patch("apps.core.insights.builder.build_insights") as m_insights, \
+             patch("apps.core.scans.pipeline._dispatch_alerts") as m_alerts:
+            _finalize_session(sub)
+
+        sub.refresh_from_db()
+        assert sub.status == "completed"
+        m_delta.assert_not_called()
+        m_insights.assert_not_called()
+        m_alerts.assert_not_called()
+
+    def test_finalize_runs_deltas_insights_alerts_for_full_scan(self, db):
+        from unittest.mock import patch
+        from apps.core.scans.models import ScanSession
+        from apps.core.scans.pipeline import _finalize_session
+        from django.utils import timezone
+
+        s = ScanSession.objects.create(domain="f.com", scan_type="full", status="running", end_time=timezone.now())
+
+        with patch("apps.core.scans.pipeline._detect_deltas") as m_delta, \
+             patch("apps.core.insights.builder.build_insights") as m_insights, \
+             patch("apps.core.scans.pipeline._dispatch_alerts") as m_alerts:
+            _finalize_session(s)
+
+        m_delta.assert_called_once()
+        m_insights.assert_called_once()
+        m_alerts.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestRunScanPendingGuard:
+    def test_cancelled_session_is_not_resurrected(self, db):
+        """A stop issued while pending must not be overwritten by the queued task."""
+        from unittest.mock import patch
+        from apps.core.scans.models import ScanSession
+        from apps.core.scans.pipeline import run_scan
+
+        s = ScanSession.objects.create(domain="c.com", scan_type="full", status="cancelled")
+        with patch("apps.core.scans.pipeline._run_via_workflow") as m_run:
+            run_scan(s.id)
+
+        s.refresh_from_db()
+        assert s.status == "cancelled"
+        m_run.assert_not_called()
+
+    def test_failed_session_is_not_resurrected(self, db):
+        from unittest.mock import patch
+        from apps.core.scans.models import ScanSession
+        from apps.core.scans.pipeline import run_scan
+
+        s = ScanSession.objects.create(domain="d.com", scan_type="full", status="failed")
+        with patch("apps.core.scans.pipeline._run_via_workflow") as m_run:
+            run_scan(s.id)
+
+        s.refresh_from_db()
+        assert s.status == "failed"
+        m_run.assert_not_called()
+
+    def test_pending_session_runs(self, db):
+        from unittest.mock import patch
+        from apps.core.scans.models import ScanSession
+        from apps.core.scans.pipeline import run_scan
+
+        s = ScanSession.objects.create(domain="p.com", scan_type="full", status="pending")
+        with patch("apps.core.scans.pipeline._run_via_workflow") as m_run, \
+             patch("apps.core.scans.pipeline._seed_apex_into_assets"), \
+             patch("apps.core.scans.pipeline._finalize_session"):
+            run_scan(s.id)
+
+        m_run.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestLatestSessionIdsExcludesSubscans:
+    def test_subscan_excluded_from_latest(self, db):
+        from apps.core.scans.models import ScanSession
+        from apps.core.queries import latest_session_ids
+        from django.utils import timezone
+
+        full = ScanSession.objects.create(domain="x.com", scan_type="full", status="completed", end_time=timezone.now())
+        # Subscan has the higher id but must not be treated as the domain's latest.
+        ScanSession.objects.create(domain="x.com", scan_type="subscan", status="completed", end_time=timezone.now())
+
+        ids = latest_session_ids(["x.com"])
+        assert ids == [full.id]
+
 
 # ---------------------------------------------------------------------------
 # Model tests


### PR DESCRIPTION
Fixes four correctness/security issues surfaced by a full-project review.

## Subscan correctness (the core cluster)
A subscan copies its parent's assets but runs only a tool subset and produces its own subset of findings — yet it's marked `completed` and always has the highest `id` for its domain. Several places assumed "latest session id per domain = the domain's current state," which subscans broke:

- **`latest_session_ids()` now excludes subscans** (`apps/core/queries.py`). Previously a `tls_checker`-only subscan became the domain's "latest session," collapsing the dashboard, the default `/api/scans/findings/` view, domain enrichment, and insights down to just the re-run tool's output until the next full scan.
- **`_finalize_session()` short-circuits deltas/insights/alerts for subscans** (`apps/core/scans/pipeline.py`). Their subset of findings was diffed against the last full scan (mass of spurious `removed` deltas feeding `ScanSummary.removed_exposures`) and re-fired Slack/Teams alerts the parent already sent.
- **`_detect_deltas()` selects its baseline via the immutable `scan_type` field** instead of the `SET_NULL` `parent_session` FK, so deleting a parent scan can no longer promote a subscan to a delta baseline.

## Pending-scan resurrection race
- **`run_scan()` aborts if the session is no longer `pending`** (`apps/core/scans/pipeline.py`). A queued Django-Q task previously flipped `status` to `running` unconditionally, which (a) silently re-ran a scan that was cancelled while pending — `stop` was lost — and (b) after the watchdog reaped a long-queued scan as `failed`, could run a **second concurrent scan** of the same domain when the original task finally executed.

## XSS hardening on archived URLs
- **http(s) scheme allowlist** in `apps/historical_urls/analyzer.py` and the URL table in `frontend/src/pages/ScanDetailPage.jsx`. Historical-URL sources (Wayback/OTX/Common Crawl via gau/waybackurls) are third-party-influenceable and could return `javascript:`/`data:` URLs that passed the noise filter, were stored, and rendered as clickable `<a href>` links. With JWTs in `localStorage`, one click is token theft. Non-http(s) URLs are now dropped at ingestion and rendered as inert text in the UI.

## Tests
Adds 11 tests: analyzer scheme rejection (`javascript:`/`data:`/`ftp:`/uppercase), delta baseline ignoring subscans, `_finalize_session` skip-vs-run behavior, `run_scan` pending guard (cancelled/failed/pending), and `latest_session_ids` subscan exclusion.

Full fast suite: **945 passed** (934 baseline + 11 new). `manage.py check` clean, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)