### PR TITLE
fix: close scheduler consent-gate gaps for recurring/one-time scans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,8 +241,8 @@ Don't enable the `ingress` addon if the host already runs Caddy on :80/:443 — 
 ### Scheduler
 - Daily scan runs at `SCAN_DAILY_HOUR:SCAN_DAILY_MINUTE` (uses `TIME_ZONE` in settings, default 02:00)
 - Configured via env vars: `SCAN_DAILY_HOUR`, `SCAN_DAILY_MINUTE`
-- **Auto-scan consent gate:** `daily_scan` and per-domain monitoring only scan domains with a `DomainAuthorization` record (`is_active=True, authorization__isnull=False`); `run_monitoring_scan` re-checks at run time. The scheduler cannot bypass the authorization gate the manual API/UI already enforce.
-- **`SCHEDULED_SCANS_ENABLED`** (env, default `True`) is the master switch for unattended scanning. When `False`, `setup_core_schedules()` registers only the hygiene jobs (watchdog + token purge) and removes any existing `daily_scan`/`monitor_*` schedules on startup — this is how a deployment is made durably manual-only (set in `k8s/configmap.yaml`). Manual/API scans are unaffected.
+- **Auto-scan consent gate:** every unattended entry point — `daily_scan`, per-domain monitoring (`run_monitoring_scan`), and user-created recurring/one-time jobs (`run_scheduled_scan`) — re-checks at run time that the domain is active and has a `DomainAuthorization` record (`is_active=True, authorization__isnull=False`) before scanning. The scheduler cannot bypass the authorization gate the manual API/UI already enforce, and a schedule whose domain was later revoked or deleted no-ops instead of scanning.
+- **`SCHEDULED_SCANS_ENABLED`** (env, default `True`) is the master switch for unattended scanning. When `False`, `setup_core_schedules()` registers only the hygiene jobs (watchdog + token purge) and removes every existing unattended-scan schedule — `daily_scan`, `monitor_*`, `recurring_*`, and `once_*` — on startup, so no schedule of any kind can fire. This is how a deployment is made durably manual-only (set in `k8s/configmap.yaml`). Manual/API scans are unaffected.
 - Schedule history visible in Django admin under "Django Q" → "Scheduled tasks"
 - Scheduler code lives in `apps/core/scheduler/scheduler.py`
 - `setup_core_schedules()` called from `apps/core/scheduler/apps.py` → `SchedulerConfig.ready()`
@@ -525,7 +525,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_qcluster_config.py` | 4 | Django-Q cluster config |
 | `tests/unit/test_reports.py` | 26 | CSV export content/structure, PDF export (mocked pisa), min_severity filter |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
-| `tests/unit/test_scheduler.py` | 28 | reap_stuck_scans, token purge, daily_scan, authorization gate, `SCHEDULED_SCANS_ENABLED` switch |
+| `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, run_scheduled_scan + monitoring authorization gates, `SCHEDULED_SCANS_ENABLED` switch |
 | `tests/unit/test_service_detection.py` | 64 | XML parsing, Port enrichment, is_web |
 | `tests/unit/test_ssh_checker.py` | 34 | SSH probe, host key, kex/cipher/MAC, auth, collector |
 | `tests/unit/test_subfinder.py` | 10 | JSON parser, dedup, hostname normalization |
@@ -537,6 +537,6 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
+| `tests/test_api_endpoints.py` | 90 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 975 tests** (934 fast + 41 slow domain_security)
+**Total: 981 tests** (940 fast + 41 slow domain_security)

--- a/apps/core/domains/api.py
+++ b/apps/core/domains/api.py
@@ -193,6 +193,16 @@ def delete_domain(request, pk: int):
     rebuild_finding_type_summaries()
     from apps.core.scheduler.scheduler import sync_domain_monitoring_jobs
     sync_domain_monitoring_jobs()
+
+    # Remove the domain's recurring/one-time scan schedules. sync_domain_monitoring_jobs
+    # only reaps monitor_* jobs; a leftover recurring_<domain> would keep firing
+    # unattended for a domain that no longer exists (its authorization was
+    # cascade-deleted, so run_scheduled_scan's gate now no-ops it — but the dead
+    # schedule row and its noise should not linger).
+    from django_q.models import Schedule
+    Schedule.objects.filter(name=f"recurring_{domain_name}").delete()
+    Schedule.objects.filter(name__startswith=f"once_{domain_name}_").delete()
+
     return {"deleted": domain_name}
 
 

--- a/apps/core/scheduler/scheduler.py
+++ b/apps/core/scheduler/scheduler.py
@@ -35,10 +35,12 @@ def setup_core_schedules():
     """Register/update the fixed system schedules in Django-Q2.
 
     System-hygiene schedules (stuck-scan watchdog, token purge) always run.
-    The unattended-scan schedules (daily scan + per-domain monitoring) are
-    registered only when SCHEDULED_SCANS_ENABLED is True; when False they are
-    actively removed, so flipping the flag on a running deployment takes effect
-    on the next startup even if the schedules were created by an earlier boot.
+    Every unattended-scan schedule (daily scan, per-domain monitoring, and
+    user-created recurring/one-time jobs) is registered/kept only when
+    SCHEDULED_SCANS_ENABLED is True; when False they are all actively removed,
+    so flipping the flag on a running deployment takes effect on the next
+    startup even if the schedules were created by an earlier boot. This is what
+    makes the switch a durable, complete "manual-only" mode.
     """
     from django.conf import settings
     from django_q.models import Schedule
@@ -67,6 +69,11 @@ def setup_core_schedules():
     if not settings.SCHEDULED_SCANS_ENABLED:
         removed = Schedule.objects.filter(name="daily_scan").delete()[0]
         removed += Schedule.objects.filter(name__startswith="monitor_").delete()[0]
+        # User-created recurring/one-time jobs are unattended scans too — remove
+        # them as well, or the switch wouldn't actually make the deployment
+        # manual-only (they would keep firing run_scheduled_scan).
+        removed += Schedule.objects.filter(name__startswith="recurring_").delete()[0]
+        removed += Schedule.objects.filter(name__startswith="once_").delete()[0]
         logger.info(
             "[scheduler] SCHEDULED_SCANS_ENABLED=False — manual-only mode; "
             f"removed {removed} auto-scan schedule(s). Hygiene schedules registered."
@@ -167,9 +174,26 @@ def run_monitoring_scan(domain: str):
 
 
 def run_scheduled_scan(domain: str, triggered_by: str = "scheduled"):
-    """Top-level callable for Django-Q2 one-time and recurring scan jobs."""
+    """Top-level callable for Django-Q2 one-time and recurring scan jobs.
+
+    Re-checks consent at run time, mirroring daily_scan/run_monitoring_scan.
+    A user-created recurring/one-time schedule is authorization-checked only
+    when created (scans/api.start_scan); without this gate it would keep
+    scanning a domain whose authorization was later revoked, that was
+    deactivated, or that was deleted (a deleted domain has no row, so the
+    active+authorized filter skips it). Gated on both is_active and
+    authorization to match the daily_scan guarantee.
+    """
+    from apps.core.domains.models import Domain
     from apps.core.scans.pipeline import create_scan_session
     from apps.core.scans.tasks import run_scan_task
+
+    is_scannable = Domain.objects.filter(
+        name=domain, is_active=True, authorization__isnull=False
+    ).exists()
+    if not is_scannable:
+        logger.warning(f"[scheduled_scan] Skipping {domain} — not an active, authorized domain")
+        return
 
     session = create_scan_session(domain, triggered_by=triggered_by)
     if session is None:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -351,6 +351,26 @@ class TestDomainsDelete:
     def test_requires_auth(self, client, domain):
         assert post_json(client, f"/api/domains/{domain.pk}/delete/", {}).status_code == 401
 
+    def test_removes_recurring_and_once_schedules(self, auth_client, domain):
+        """Deleting a domain must not leave its scan schedules firing unattended."""
+        from django_q.models import Schedule
+
+        Schedule.objects.create(
+            name=f"recurring_{domain.name}",
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.CRON, cron="0 2 * * *", repeats=-1,
+        )
+        Schedule.objects.create(
+            name=f"once_{domain.name}_" + "a" * 32,
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.ONCE, repeats=1,
+        )
+
+        res = post_json(auth_client, f"/api/domains/{domain.pk}/delete/", {})
+        assert res.status_code == 200
+        assert not Schedule.objects.filter(name=f"recurring_{domain.name}").exists()
+        assert not Schedule.objects.filter(name__startswith=f"once_{domain.name}_").exists()
+
 
 # ---------------------------------------------------------------------------
 # Scans

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -372,6 +372,65 @@ class TestRunMonitoringScanAuthorization:
 
 
 # ---------------------------------------------------------------------------
+# run_scheduled_scan consent gate (recurring / one-time jobs)
+# ---------------------------------------------------------------------------
+
+class TestRunScheduledScanConsentGate:
+    def test_runs_for_active_authorized_domain(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        _authorize(Domain.objects.create(name="sched-ok.example.com", is_active=True))
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            fake_session = MagicMock()
+            fake_session.id = 1
+            mock_create.return_value = fake_session
+            run_scheduled_scan("sched-ok.example.com", "recurring")
+
+        mock_create.assert_called_once()
+        mock_task.assert_called_once()
+
+    def test_skips_unauthorized_domain(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        Domain.objects.create(name="sched-noauth.example.com", is_active=True)  # no auth
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            run_scheduled_scan("sched-noauth.example.com", "recurring")
+
+        mock_create.assert_not_called()
+        mock_task.assert_not_called()
+
+    def test_skips_inactive_domain(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        _authorize(Domain.objects.create(name="sched-inactive.example.com", is_active=False))
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            run_scheduled_scan("sched-inactive.example.com", "recurring")
+
+        mock_create.assert_not_called()
+        mock_task.assert_not_called()
+
+    def test_skips_deleted_domain(self, db):
+        """A recurring schedule left behind by a deleted domain must not scan."""
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            run_scheduled_scan("gone.example.com", "recurring")  # no Domain row at all
+
+        mock_create.assert_not_called()
+        mock_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # setup_core_schedules master switch (SCHEDULED_SCANS_ENABLED)
 # ---------------------------------------------------------------------------
 
@@ -420,3 +479,25 @@ class TestSetupCoreSchedules:
 
         assert not Schedule.objects.filter(name="daily_scan").exists()
         assert not Schedule.objects.filter(name__startswith="monitor_").exists()
+
+    def test_disabled_removes_recurring_and_once_schedules(self, db, settings):
+        """Manual-only mode must also drop user-created recurring/one-time jobs."""
+        from django_q.models import Schedule
+        from apps.core.scheduler.scheduler import setup_core_schedules
+
+        Schedule.objects.create(
+            name="recurring_example.com",
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.CRON, cron="0 2 * * *", repeats=-1,
+        )
+        Schedule.objects.create(
+            name="once_example.com_" + "a" * 32,
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.ONCE, repeats=1,
+        )
+
+        settings.SCHEDULED_SCANS_ENABLED = False
+        setup_core_schedules()
+
+        assert not Schedule.objects.filter(name__startswith="recurring_").exists()
+        assert not Schedule.objects.filter(name__startswith="once_").exists()


### PR DESCRIPTION
`daily_scan` and `run_monitoring_scan` already re-check `DomainAuthorization` at run time, so a lingering schedule can't scan a domain whose consent was revoked. Three related paths around **user-created** schedules missed that guarantee. This closes all three.

## 1. `run_scheduled_scan` — no run-time consent check
`apps/core/scheduler/scheduler.py`. This is the callable wired to every `recurring_*` and `once_*` schedule created from `/api/scans/start/`. Authorization was verified only at schedule-*creation* time; the run-time callable created a scan session with no gate. So a schedule whose domain was later de-authorized (removed in Django admin), deactivated, or deleted kept scanning unattended.

Now it skips unless the domain is **active and authorized**, mirroring `daily_scan`'s filter. A deleted domain has no `Domain` row, so it skips too — closing the "deleted domain keeps scanning forever" hole at run time.

## 2. `SCHEDULED_SCANS_ENABLED=False` didn't fully disable unattended scans
`setup_core_schedules()` removed only `daily_scan` and `monitor_*` on startup, leaving `recurring_*`/`once_*` jobs firing. So the documented "durably manual-only" master switch didn't actually make a deployment manual-only. It now removes those two schedule families as well.

## 3. `delete_domain` left recurring/one-time schedules behind
`apps/core/domains/api.py`. Deleting a domain reaped its `monitor_*` jobs (via `sync_domain_monitoring_jobs`) but left `recurring_<domain>` / `once_<domain>_*` behind. With the domain's authorization cascade-deleted, gate #1 now no-ops those at run time — but the dead schedule rows shouldn't linger. `delete_domain` now deletes them.

## Tests & docs
Adds 6 tests: `run_scheduled_scan` gate (authorized / unauthorized / inactive / deleted-domain), master-switch removal of `recurring_`+`once_`, and `delete_domain` schedule cleanup. Updates the CLAUDE.md scheduler + consent-gate notes to match. Full fast suite: **940 passed**.

> Note: independent of, and does not conflict with, #189 (subscan / URL-scheme fixes) — different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)