### PR TITLE
fix: prune stale FindingTypeSummary rows + kill scan_detail N+1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -512,6 +512,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 11 | JSON parser, Port lookup, Subdomain link |
+| `tests/unit/test_insights_builder.py` | 4 | rebuild_finding_type_summaries upsert + prune (stale/deleted types, error-safe) |
 | `tests/unit/test_k8s_manifests.py` | 57 | k8s manifest structure, envFrom order, probes, secret/configmap split |
 | `tests/unit/test_katana.py` | 18 | JSONL parser, Port/Subdomain FK links, scanner orchestrator |
 | `tests/unit/test_management_commands.py` | 11 | `verify_tools` + other management commands |
@@ -537,6 +538,6 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
+| `tests/test_api_endpoints.py` | 90 | Smoke tests for all API endpoints (auth + payload shape); scan_detail N+1 guard |
 
-**Total: 975 tests** (934 fast + 41 slow domain_security)
+**Total: 980 tests** (939 fast + 41 slow domain_security)

--- a/apps/core/insights/builder.py
+++ b/apps/core/insights/builder.py
@@ -10,6 +10,7 @@ All tool finding models must have a `severity` field with values:
 
 import logging
 
+from django.db import transaction
 from django.db.models import Count, Max
 from django.utils import timezone as django_tz
 
@@ -83,6 +84,11 @@ def rebuild_finding_type_summaries() -> None:
                 else existing["last_seen"],
         }
 
+    # Track whether both aggregations ran cleanly. If either raised, `aggregated`
+    # is incomplete, so we must NOT prune — deleting rows we simply failed to
+    # recompute would drop live finding types from the global view.
+    aggregation_complete = True
+
     try:
         rows = (
             Finding.objects
@@ -94,6 +100,7 @@ def rebuild_finding_type_summaries() -> None:
         for row in rows:
             _merge((row["title"], row["check_type"]), row["severity"], row["count"], row["last"])
     except Exception as e:
+        aggregation_complete = False
         logger.warning(f"[insights] Finding aggregation failed: {e}")
 
     try:
@@ -108,16 +115,35 @@ def rebuild_finding_type_summaries() -> None:
             cve = row.get("extra__cve") or ""
             _merge((cve, "cve"), row["severity"], row["count"], row["last"])
     except Exception as e:
+        aggregation_complete = False
         logger.warning(f"[insights] Nmap CVE aggregation failed: {e}")
 
-    # Bulk upsert
-    for (title, check_type), data in aggregated.items():
-        FindingTypeSummary.objects.update_or_create(
-            title=title,
-            check_type=check_type,
-            defaults={
-                "severity": data["severity"],
-                "occurrence_count": data["occurrence_count"],
-                "last_seen": data["last_seen"],
-            },
-        )
+    # Upsert the current set and prune rows that no longer appear in any latest
+    # scan (resolved/disappeared finding types, or types from deleted domains).
+    # Without the prune this table only ever grows and reports stale counts.
+    with transaction.atomic():
+        for (title, check_type), data in aggregated.items():
+            FindingTypeSummary.objects.update_or_create(
+                title=title,
+                check_type=check_type,
+                defaults={
+                    "severity": data["severity"],
+                    "occurrence_count": data["occurrence_count"],
+                    "last_seen": data["last_seen"],
+                },
+            )
+
+        if aggregation_complete:
+            wanted = set(aggregated.keys())
+            stale_ids = [
+                row_id
+                for row_id, title, check_type in FindingTypeSummary.objects.values_list(
+                    "id", "title", "check_type"
+                )
+                if (title, check_type) not in wanted
+            ]
+            if stale_ids:
+                FindingTypeSummary.objects.filter(id__in=stale_ids).delete()
+                logger.info(f"[insights] Pruned {len(stale_ids)} stale finding-type summary row(s)")
+        else:
+            logger.warning("[insights] Skipping prune — finding aggregation incomplete this run")

--- a/apps/core/scans/api.py
+++ b/apps/core/scans/api.py
@@ -483,18 +483,22 @@ def scan_detail(request, session_uuid: uuid.UUID):
     ports = list(Port.objects.filter(session=session).select_related("ip_address").order_by("address", "port"))
     urls = list(URL.objects.filter(session=session).select_related("port", "subdomain").order_by("url"))
 
+    # select_related("session"): _serialize_finding reads finding.session.uuid,
+    # which would otherwise fire one query per finding (N+1) on this detail load.
     nmap_findings = list(
-        Finding.objects.filter(session=session, source="nmap").select_related("port").order_by("-discovered_at")
+        Finding.objects.filter(session=session, source="nmap")
+        .select_related("port", "session")
+        .order_by("-discovered_at")
     )
     domain_findings = list(
         Finding.objects.filter(session=session, source="domain_security")
-        .select_related("subdomain")
+        .select_related("subdomain", "session")
         .order_by("-severity", "-discovered_at")
     )
     other_findings = list(
         Finding.objects.filter(session=session)
         .exclude(source__in=["nmap", "domain_security"])
-        .select_related("port", "url")
+        .select_related("port", "url", "session")
         .order_by("-discovered_at")
     )
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -417,6 +417,24 @@ class TestScanDetail:
     def test_not_found(self, auth_client):
         assert auth_client.get("/api/scans/00000000-0000-0000-0000-000000000000/").status_code == 404
 
+    def test_no_n_plus_one_on_findings(self, auth_client, django_assert_max_num_queries, scan):
+        """scan_detail must not issue one query per finding to resolve session.uuid."""
+        from apps.core.findings.models import Finding
+
+        for i in range(25):
+            Finding.objects.create(
+                session=scan, source="web_checker", target=f"h{i}.example.com",
+                check_type="hdr", severity="low", title=f"Finding {i}",
+                description="d", remediation="r",
+            )
+        # Warm up one-time caches (content types, auth) so the bound reflects
+        # steady state, not first-request setup.
+        auth_client.get(f"/api/scans/{scan.uuid}/")
+        # With select_related("session") the query count is constant; without it
+        # this load would issue 25+ extra per-finding queries.
+        with django_assert_max_num_queries(20):
+            auth_client.get(f"/api/scans/{scan.uuid}/")
+
     def test_requires_auth(self, client, scan):
         assert client.get(f"/api/scans/{scan.uuid}/").status_code == 401
 

--- a/tests/unit/test_insights_builder.py
+++ b/tests/unit/test_insights_builder.py
@@ -1,0 +1,86 @@
+"""Unit tests for rebuild_finding_type_summaries — upsert + prune behavior."""
+
+import pytest
+from unittest.mock import patch
+from django.utils import timezone
+
+
+def _completed_session(domain, subdomain_offset=0):
+    from apps.core.scans.models import ScanSession
+    return ScanSession.objects.create(
+        domain=domain, scan_type="full", status="completed", end_time=timezone.now(),
+    )
+
+
+def _finding(session, title, check_type="dns", severity="high", source="domain_security"):
+    from apps.core.findings.models import Finding
+    return Finding.objects.create(
+        session=session, source=source, target=session.domain,
+        check_type=check_type, severity=severity, title=title,
+        description="d", remediation="r",
+    )
+
+
+@pytest.mark.django_db
+class TestRebuildFindingTypeSummaries:
+    def test_upserts_current_finding_type(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        Domain.objects.create(name="agg.com", is_active=True)
+        s = _completed_session("agg.com")
+        _finding(s, "Missing SPF")
+
+        rebuild_finding_type_summaries()
+
+        row = FindingTypeSummary.objects.get(title="Missing SPF", check_type="dns")
+        assert row.occurrence_count == 1
+
+    def test_prunes_type_absent_from_latest_scan(self, db):
+        """A finding type present in an old scan but not the latest is pruned."""
+        from apps.core.domains.models import Domain
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        Domain.objects.create(name="agg.com", is_active=True)
+        s1 = _completed_session("agg.com")
+        _finding(s1, "Old Issue")
+        rebuild_finding_type_summaries()
+        assert FindingTypeSummary.objects.filter(title="Old Issue").exists()
+
+        # Newer scan for the same domain no longer has "Old Issue".
+        s2 = _completed_session("agg.com")
+        _finding(s2, "New Issue")
+        rebuild_finding_type_summaries()
+
+        assert not FindingTypeSummary.objects.filter(title="Old Issue").exists()
+        assert FindingTypeSummary.objects.filter(title="New Issue").exists()
+
+    def test_prunes_all_when_no_findings_remain(self, db):
+        """With no findings anywhere, every summary row is pruned."""
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        FindingTypeSummary.objects.create(
+            title="Ghost", check_type="dns", severity="high",
+            occurrence_count=5, last_seen=timezone.now(),
+        )
+        rebuild_finding_type_summaries()
+
+        assert FindingTypeSummary.objects.count() == 0
+
+    def test_skips_prune_when_aggregation_errors(self, db):
+        """If aggregation raises, existing rows are preserved (not wrongly deleted)."""
+        from apps.core.findings.models import Finding
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        FindingTypeSummary.objects.create(
+            title="Keep Me", check_type="dns", severity="high",
+            occurrence_count=1, last_seen=timezone.now(),
+        )
+        with patch.object(Finding.objects, "filter", side_effect=RuntimeError("boom")):
+            rebuild_finding_type_summaries()
+
+        assert FindingTypeSummary.objects.filter(title="Keep Me").exists()


### PR DESCRIPTION
Two backend cleanups from the full-project review.

## 1. `FindingTypeSummary` never pruned (unbounded stale rows)
`rebuild_finding_type_summaries()` (`apps/core/insights/builder.py`) recomputed the global finding-type aggregates over the latest scan per domain, but only ever `update_or_create`'d — it never deleted rows for types that no longer appear. Consequences:
- `delete_domain` calls this after wiping a domain's sessions/findings, yet the deleted domain's finding types stayed in the table forever with their old `occurrence_count`.
- A finding type that's resolved/gone on the next scan kept its stale global row.
- The table grew monotonically and drove `top_finding_types` in the insights API with counts that no longer matched reality.

Now it prunes rows whose `(title, check_type)` isn't in the recomputed set, in the same `transaction.atomic()` as the upsert. **Prune is skipped when either aggregation query raised** (tracked via a flag), so a transient error can never delete types it merely failed to recompute — it just re-upserts what it has, preserving the old rows.

## 2. N+1 in `scan_detail`
`apps/core/scans/api.py`. The three finding querysets used `select_related("port"/"subdomain"/"url")` but not `"session"`, while `_serialize_finding` reads `finding.session.uuid` — one query per finding on every scan-detail load (hundreds on a large scan). Added `"session"` to each `select_related`, matching what `list_findings` already does.

## Tests
Adds 5 tests: 4 for the prune (upsert; stale type removed when the next scan drops it; prune-all when no findings remain; error-safe skip when aggregation raises) and 1 N+1 guard using `django_assert_max_num_queries` (25 findings must not scale the query count). Full fast suite: **939 passed**.

> Independent of #189/#190/#191; only CLAUDE.md overlaps (test-table rows / tally), so at most a trivial merge conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)