### PR TITLE
ci: run backports refresh manual-first (disable weekly cron)

### DIFF
--- a/.github/workflows/refresh-backports.yml
+++ b/.github/workflows/refresh-backports.yml
@@ -1,8 +1,12 @@
 name: Refresh Backports
 
 on:
-  schedule:
-    - cron: '0 0 * * 0' # Every Sunday at midnight
+  # Manual-first rollout: the weekly cron is disabled until the Ubuntu/Debian/
+  # Alpine feed parsers have proven stable against upstream format drift. Refresh
+  # on demand via the "Run workflow" button below, or the `refresh_backports`
+  # management command. Re-enable the schedule once the parsers are trusted.
+  # schedule:
+  #   - cron: '0 0 * * 0' # Every Sunday at midnight
   workflow_dispatch: # Allow manual trigger
 
 # Explicit least-privilege permissions (matches ci.yml posture)


### PR DESCRIPTION
Follow-up to #123. Keeps turfin's parsers, `refresh_backports` command, and the workflow (with `workflow_dispatch`), but disables the weekly cron until the three feed parsers prove stable against upstream format drift. Re-enable the schedule once trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)