### PR TITLE
fix: scheduler consent-gate, SECRET_KEY guard, FindingTypeSummary prune (integrates #190-192)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 11 | JSON parser, Port lookup, Subdomain link |
+| `tests/unit/test_insights_builder.py` | 4 | rebuild_finding_type_summaries upsert + prune (stale/deleted types, error-safe) |
 | `tests/unit/test_k8s_manifests.py` | 57 | k8s manifest structure, envFrom order, probes, secret/configmap split |
 | `tests/unit/test_katana.py` | 18 | JSONL parser, Port/Subdomain FK links, scanner orchestrator |
 | `tests/unit/test_management_commands.py` | 11 | `verify_tools` + other management commands |
@@ -542,7 +543,6 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/unit/test_settings_security.py` | 4 | SECRET_KEY production guard (`_validate_secret_key`) |
-| `tests/test_api_endpoints.py` | 94 | Smoke tests for all API endpoints (auth + payload shape); must_change_password 403 gate |
+| `tests/test_api_endpoints.py` | 90 | Smoke tests for all API endpoints (auth + payload shape); scan_detail N+1 guard |
 
-**Total: 984 tests** (943 fast + 41 slow domain_security)
+**Total: 980 tests** (939 fast + 41 slow domain_security)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,11 @@ Runs on every container start (init container in K8s, or `CMD` override in Docke
 ### First login
 `docker-entrypoint.sh` creates `admin/admin` with `must_change_password=True` on first run. The React app redirects to `/change-password` before allowing access. On every startup, if the default password is still in use, the flag is re-set.
 
+**Server-side enforcement:** the flag is not only a React redirect. All API routers authenticate via `apps/core/api/auth.py::JWTAuth` (a subclass of ninja-jwt's), which returns **403** for any request from a user whose `must_change_password` is set — except `GET /api/user/` (to read the flag) and `POST /api/user/change-password/`. So a holder of default `admin/admin` credentials cannot use the API by calling it directly; they must change the password first.
+
+### SECRET_KEY guard
+`openeasd/settings.py` calls `_validate_secret_key()` at import: when `DEBUG=False` and `SECRET_KEY` is unset/still the `django-insecure…` placeholder, it raises `ImproperlyConfigured` and the process refuses to start. The key also signs JWTs (`NINJA_JWT["SIGNING_KEY"]`), so the default would let anyone forge tokens. Enforcement is skipped under pytest (pytest-django imports settings before any env hook can set a key); the logic is unit-tested directly.
+
 ### microk8s deployment (host IP changed)
 If the host IP changes, microk8s certs and kubeconfigs reference the old IP and the cluster goes "not running":
 1. Update IP-SAN in `/var/snap/microk8s/current/certs/csr.conf.template` (the `IP.3` line), then `sudo microk8s refresh-certs --cert server.crt`.
@@ -537,6 +542,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 90 | Smoke tests for all API endpoints (auth + payload shape) |
+| `tests/unit/test_settings_security.py` | 4 | SECRET_KEY production guard (`_validate_secret_key`) |
+| `tests/test_api_endpoints.py` | 94 | Smoke tests for all API endpoints (auth + payload shape); must_change_password 403 gate |
 
-**Total: 981 tests** (940 fast + 41 slow domain_security)
+**Total: 984 tests** (943 fast + 41 slow domain_security)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,11 +227,6 @@ Runs on every container start (init container in K8s, or `CMD` override in Docke
 ### First login
 `docker-entrypoint.sh` creates `admin/admin` with `must_change_password=True` on first run. The React app redirects to `/change-password` before allowing access. On every startup, if the default password is still in use, the flag is re-set.
 
-**Server-side enforcement:** the flag is not only a React redirect. All API routers authenticate via `apps/core/api/auth.py::JWTAuth` (a subclass of ninja-jwt's), which returns **403** for any request from a user whose `must_change_password` is set — except `GET /api/user/` (to read the flag) and `POST /api/user/change-password/`. So a holder of default `admin/admin` credentials cannot use the API by calling it directly; they must change the password first.
-
-### SECRET_KEY guard
-`openeasd/settings.py` calls `_validate_secret_key()` at import: when `DEBUG=False` and `SECRET_KEY` is unset/still the `django-insecure…` placeholder, it raises `ImproperlyConfigured` and the process refuses to start. The key also signs JWTs (`NINJA_JWT["SIGNING_KEY"]`), so the default would let anyone forge tokens. Enforcement is skipped under pytest (pytest-django imports settings before any env hook can set a key); the logic is unit-tested directly.
-
 ### microk8s deployment (host IP changed)
 If the host IP changes, microk8s certs and kubeconfigs reference the old IP and the cluster goes "not running":
 1. Update IP-SAN in `/var/snap/microk8s/current/certs/csr.conf.template` (the `IP.3` line), then `sudo microk8s refresh-certs --cert server.crt`.
@@ -246,8 +241,8 @@ Don't enable the `ingress` addon if the host already runs Caddy on :80/:443 — 
 ### Scheduler
 - Daily scan runs at `SCAN_DAILY_HOUR:SCAN_DAILY_MINUTE` (uses `TIME_ZONE` in settings, default 02:00)
 - Configured via env vars: `SCAN_DAILY_HOUR`, `SCAN_DAILY_MINUTE`
-- **Auto-scan consent gate:** every unattended entry point — `daily_scan`, per-domain monitoring (`run_monitoring_scan`), and user-created recurring/one-time jobs (`run_scheduled_scan`) — re-checks at run time that the domain is active and has a `DomainAuthorization` record (`is_active=True, authorization__isnull=False`) before scanning. The scheduler cannot bypass the authorization gate the manual API/UI already enforce, and a schedule whose domain was later revoked or deleted no-ops instead of scanning.
-- **`SCHEDULED_SCANS_ENABLED`** (env, default `True`) is the master switch for unattended scanning. When `False`, `setup_core_schedules()` registers only the hygiene jobs (watchdog + token purge) and removes every existing unattended-scan schedule — `daily_scan`, `monitor_*`, `recurring_*`, and `once_*` — on startup, so no schedule of any kind can fire. This is how a deployment is made durably manual-only (set in `k8s/configmap.yaml`). Manual/API scans are unaffected.
+- **Auto-scan consent gate:** `daily_scan` and per-domain monitoring only scan domains with a `DomainAuthorization` record (`is_active=True, authorization__isnull=False`); `run_monitoring_scan` re-checks at run time. The scheduler cannot bypass the authorization gate the manual API/UI already enforce.
+- **`SCHEDULED_SCANS_ENABLED`** (env, default `True`) is the master switch for unattended scanning. When `False`, `setup_core_schedules()` registers only the hygiene jobs (watchdog + token purge) and removes any existing `daily_scan`/`monitor_*` schedules on startup — this is how a deployment is made durably manual-only (set in `k8s/configmap.yaml`). Manual/API scans are unaffected.
 - Schedule history visible in Django admin under "Django Q" → "Scheduled tasks"
 - Scheduler code lives in `apps/core/scheduler/scheduler.py`
 - `setup_core_schedules()` called from `apps/core/scheduler/apps.py` → `SchedulerConfig.ready()`
@@ -517,7 +512,6 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 11 | JSON parser, Port lookup, Subdomain link |
-| `tests/unit/test_insights_builder.py` | 4 | rebuild_finding_type_summaries upsert + prune (stale/deleted types, error-safe) |
 | `tests/unit/test_k8s_manifests.py` | 57 | k8s manifest structure, envFrom order, probes, secret/configmap split |
 | `tests/unit/test_katana.py` | 18 | JSONL parser, Port/Subdomain FK links, scanner orchestrator |
 | `tests/unit/test_management_commands.py` | 11 | `verify_tools` + other management commands |
@@ -531,7 +525,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_qcluster_config.py` | 4 | Django-Q cluster config |
 | `tests/unit/test_reports.py` | 34 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
-| `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, run_scheduled_scan + monitoring authorization gates, `SCHEDULED_SCANS_ENABLED` switch |
+| `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, authorization gate, `SCHEDULED_SCANS_ENABLED` switch |
 | `tests/unit/test_service_detection.py` | 64 | XML parsing, Port enrichment, is_web |
 | `tests/unit/test_ssh_checker.py` | 34 | SSH probe, host key, kex/cipher/MAC, auth, collector |
 | `tests/unit/test_subfinder.py` | 10 | JSON parser, dedup, hostname normalization |
@@ -540,9 +534,11 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_tls_checker.py` | 87 | Cert parsing, ciphers, protocols, HSTS, collector, scanner, cipher enumeration |
 | `tests/unit/test_tools_healthcheck.py` | 14 | Tool binary preflight / health checks |
 | `tests/unit/test_user_profile.py` | 7 | UserProfile `must_change_password` flag |
+| `tests/unit/test_settings_security.py` | 4 | SECRET_KEY strength guard (DEBUG=False + insecure default) |
+| `tests/unit/test_insights_builder.py` | 4 | FindingTypeSummary prune only when aggregation_complete |
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 90 | Smoke tests for all API endpoints (auth + payload shape); scan_detail N+1 guard |
+| `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 980 tests** (939 fast + 41 slow domain_security)
+**Total: 1020 tests** (979 fast + 41 slow domain_security)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,8 +241,8 @@ Don't enable the `ingress` addon if the host already runs Caddy on :80/:443 — 
 ### Scheduler
 - Daily scan runs at `SCAN_DAILY_HOUR:SCAN_DAILY_MINUTE` (uses `TIME_ZONE` in settings, default 02:00)
 - Configured via env vars: `SCAN_DAILY_HOUR`, `SCAN_DAILY_MINUTE`
-- **Auto-scan consent gate:** `daily_scan` and per-domain monitoring only scan domains with a `DomainAuthorization` record (`is_active=True, authorization__isnull=False`); `run_monitoring_scan` re-checks at run time. The scheduler cannot bypass the authorization gate the manual API/UI already enforce.
-- **`SCHEDULED_SCANS_ENABLED`** (env, default `True`) is the master switch for unattended scanning. When `False`, `setup_core_schedules()` registers only the hygiene jobs (watchdog + token purge) and removes any existing `daily_scan`/`monitor_*` schedules on startup — this is how a deployment is made durably manual-only (set in `k8s/configmap.yaml`). Manual/API scans are unaffected.
+- **Auto-scan consent gate:** every unattended entry point — `daily_scan`, per-domain monitoring (`run_monitoring_scan`), and user-created recurring/one-time jobs (`run_scheduled_scan`) — re-checks at run time that the domain is active and has a `DomainAuthorization` record (`is_active=True, authorization__isnull=False`) before scanning. The scheduler cannot bypass the authorization gate the manual API/UI already enforce, and a schedule whose domain was later revoked or deleted no-ops instead of scanning.
+- **`SCHEDULED_SCANS_ENABLED`** (env, default `True`) is the master switch for unattended scanning. When `False`, `setup_core_schedules()` registers only the hygiene jobs (watchdog + token purge) and removes every existing unattended-scan schedule — `daily_scan`, `monitor_*`, `recurring_*`, and `once_*` — on startup, so no schedule of any kind can fire. This is how a deployment is made durably manual-only (set in `k8s/configmap.yaml`). Manual/API scans are unaffected.
 - Schedule history visible in Django admin under "Django Q" → "Scheduled tasks"
 - Scheduler code lives in `apps/core/scheduler/scheduler.py`
 - `setup_core_schedules()` called from `apps/core/scheduler/apps.py` → `SchedulerConfig.ready()`
@@ -525,7 +525,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_qcluster_config.py` | 4 | Django-Q cluster config |
 | `tests/unit/test_reports.py` | 34 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
-| `tests/unit/test_scheduler.py` | 28 | reap_stuck_scans, token purge, daily_scan, authorization gate, `SCHEDULED_SCANS_ENABLED` switch |
+| `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, run_scheduled_scan + monitoring authorization gates, `SCHEDULED_SCANS_ENABLED` switch |
 | `tests/unit/test_service_detection.py` | 64 | XML parsing, Port enrichment, is_web |
 | `tests/unit/test_ssh_checker.py` | 34 | SSH probe, host key, kex/cipher/MAC, auth, collector |
 | `tests/unit/test_subfinder.py` | 10 | JSON parser, dedup, hostname normalization |
@@ -537,6 +537,6 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
+| `tests/test_api_endpoints.py` | 90 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 983 tests** (942 fast + 41 slow domain_security)
+**Total: 981 tests** (940 fast + 41 slow domain_security)

--- a/apps/core/api/auth.py
+++ b/apps/core/api/auth.py
@@ -1,0 +1,34 @@
+"""Project JWT auth that also enforces the forced-password-change gate.
+
+Every API router authenticates with this ``JWTAuth`` instead of importing
+ninja_jwt's directly. Beyond normal token validation, it blocks a user whose
+``UserProfile.must_change_password`` flag is set from doing anything except
+reading their own user record and setting a new password — so the forced
+password change is enforced server-side, not only by the React redirect. A
+holder of default ``admin/admin`` credentials therefore cannot use the API by
+talking to it directly.
+"""
+
+from ninja.errors import HttpError
+from ninja_jwt.authentication import JWTAuth as _BaseJWTAuth
+
+# Path suffixes a flagged user may still reach: read own identity (to see the
+# flag) and change the password. The token issue/refresh/blacklist endpoints do
+# not use this auth class at all, so they need no exemption here.
+_EXEMPT_SUFFIXES = ("/user/", "/user/change-password/")
+
+
+def _is_exempt(request) -> bool:
+    path = request.path.rstrip("/") + "/"
+    return path.endswith(_EXEMPT_SUFFIXES)
+
+
+class JWTAuth(_BaseJWTAuth):
+    def authenticate(self, request, token):
+        user = super().authenticate(request, token)
+        if user is None:
+            return None
+        profile = getattr(user, "profile", None)
+        if profile is not None and profile.must_change_password and not _is_exempt(request):
+            raise HttpError(403, "Password change required before continuing")
+        return user

--- a/apps/core/api/ninja.py
+++ b/apps/core/api/ninja.py
@@ -6,8 +6,9 @@ from ninja.errors import HttpError, ValidationError
 from ninja_jwt.routers.obtain import obtain_pair_router   # POST /pair, POST /refresh
 from ninja_jwt.routers.verify import verify_router        # POST /verify
 from ninja_jwt.routers.blacklist import blacklist_router  # POST /blacklist
-from ninja_jwt.authentication import JWTAuth
 from ninja_jwt.exceptions import AuthenticationFailed as JWTAuthenticationFailed, TokenError
+
+from apps.core.api.auth import JWTAuth
 
 api = NinjaAPI(title="OpenEASD API", version="1.0", docs_url="/docs")
 

--- a/apps/core/dashboard/api.py
+++ b/apps/core/dashboard/api.py
@@ -4,7 +4,7 @@ from django.db.models import Max
 
 from ninja import Router
 
-from ninja_jwt.authentication import JWTAuth
+from apps.core.api.auth import JWTAuth
 from apps.core.scans.models import ScanSession
 from apps.core.findings.models import Finding
 from apps.core.domains.models import Domain

--- a/apps/core/domains/api.py
+++ b/apps/core/domains/api.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from ninja import Router, Schema, Status
 from ninja.errors import HttpError
 
-from ninja_jwt.authentication import JWTAuth
+from apps.core.api.auth import JWTAuth
 from apps.core.domains.models import Domain, DomainAuthorization
 from apps.core.findings.models import Finding
 from apps.core.insights.builder import rebuild_finding_type_summaries

--- a/apps/core/domains/api.py
+++ b/apps/core/domains/api.py
@@ -193,6 +193,16 @@ def delete_domain(request, pk: int):
     rebuild_finding_type_summaries()
     from apps.core.scheduler.scheduler import sync_domain_monitoring_jobs
     sync_domain_monitoring_jobs()
+
+    # Remove the domain's recurring/one-time scan schedules. sync_domain_monitoring_jobs
+    # only reaps monitor_* jobs; a leftover recurring_<domain> would keep firing
+    # unattended for a domain that no longer exists (its authorization was
+    # cascade-deleted, so run_scheduled_scan's gate now no-ops it — but the dead
+    # schedule row and its noise should not linger).
+    from django_q.models import Schedule
+    Schedule.objects.filter(name=f"recurring_{domain_name}").delete()
+    Schedule.objects.filter(name__startswith=f"once_{domain_name}_").delete()
+
     return {"deleted": domain_name}
 
 

--- a/apps/core/insights/api.py
+++ b/apps/core/insights/api.py
@@ -6,7 +6,7 @@ from django.db.models import Count, F, Max, Q
 
 from ninja import Router
 
-from ninja_jwt.authentication import JWTAuth
+from apps.core.api.auth import JWTAuth
 from apps.core.assets.models import IPAddress, Port, Subdomain
 from apps.core.domains.models import Domain
 from apps.core.findings.models import Finding

--- a/apps/core/insights/builder.py
+++ b/apps/core/insights/builder.py
@@ -10,6 +10,7 @@ All tool finding models must have a `severity` field with values:
 
 import logging
 
+from django.db import transaction
 from django.db.models import Count, Max
 from django.utils import timezone as django_tz
 
@@ -83,6 +84,11 @@ def rebuild_finding_type_summaries() -> None:
                 else existing["last_seen"],
         }
 
+    # Track whether both aggregations ran cleanly. If either raised, `aggregated`
+    # is incomplete, so we must NOT prune — deleting rows we simply failed to
+    # recompute would drop live finding types from the global view.
+    aggregation_complete = True
+
     try:
         rows = (
             Finding.objects
@@ -94,6 +100,7 @@ def rebuild_finding_type_summaries() -> None:
         for row in rows:
             _merge((row["title"], row["check_type"]), row["severity"], row["count"], row["last"])
     except Exception as e:
+        aggregation_complete = False
         logger.warning(f"[insights] Finding aggregation failed: {e}")
 
     try:
@@ -108,16 +115,35 @@ def rebuild_finding_type_summaries() -> None:
             cve = row.get("extra__cve") or ""
             _merge((cve, "cve"), row["severity"], row["count"], row["last"])
     except Exception as e:
+        aggregation_complete = False
         logger.warning(f"[insights] Nmap CVE aggregation failed: {e}")
 
-    # Bulk upsert
-    for (title, check_type), data in aggregated.items():
-        FindingTypeSummary.objects.update_or_create(
-            title=title,
-            check_type=check_type,
-            defaults={
-                "severity": data["severity"],
-                "occurrence_count": data["occurrence_count"],
-                "last_seen": data["last_seen"],
-            },
-        )
+    # Upsert the current set and prune rows that no longer appear in any latest
+    # scan (resolved/disappeared finding types, or types from deleted domains).
+    # Without the prune this table only ever grows and reports stale counts.
+    with transaction.atomic():
+        for (title, check_type), data in aggregated.items():
+            FindingTypeSummary.objects.update_or_create(
+                title=title,
+                check_type=check_type,
+                defaults={
+                    "severity": data["severity"],
+                    "occurrence_count": data["occurrence_count"],
+                    "last_seen": data["last_seen"],
+                },
+            )
+
+        if aggregation_complete:
+            wanted = set(aggregated.keys())
+            stale_ids = [
+                row_id
+                for row_id, title, check_type in FindingTypeSummary.objects.values_list(
+                    "id", "title", "check_type"
+                )
+                if (title, check_type) not in wanted
+            ]
+            if stale_ids:
+                FindingTypeSummary.objects.filter(id__in=stale_ids).delete()
+                logger.info(f"[insights] Pruned {len(stale_ids)} stale finding-type summary row(s)")
+        else:
+            logger.warning("[insights] Skipping prune — finding aggregation incomplete this run")

--- a/apps/core/notifications/api.py
+++ b/apps/core/notifications/api.py
@@ -4,7 +4,7 @@ import logging
 
 from ninja import Router, Schema
 from ninja.errors import HttpError
-from ninja_jwt.authentication import JWTAuth
+from apps.core.api.auth import JWTAuth
 
 logger = logging.getLogger(__name__)
 

--- a/apps/core/scans/api.py
+++ b/apps/core/scans/api.py
@@ -15,7 +15,7 @@ import json as _json
 from ninja import Router, Schema, Status
 from ninja.errors import HttpError
 
-from ninja_jwt.authentication import JWTAuth
+from apps.core.api.auth import JWTAuth
 from apps.core.constants import SEVERITY_LEVELS
 from apps.core.insights.builder import rebuild_finding_type_summaries
 from apps.core.queries import latest_session_ids

--- a/apps/core/scans/api.py
+++ b/apps/core/scans/api.py
@@ -483,18 +483,22 @@ def scan_detail(request, session_uuid: uuid.UUID):
     ports = list(Port.objects.filter(session=session).select_related("ip_address").order_by("address", "port"))
     urls = list(URL.objects.filter(session=session).select_related("port", "subdomain").order_by("url"))
 
+    # select_related("session"): _serialize_finding reads finding.session.uuid,
+    # which would otherwise fire one query per finding (N+1) on this detail load.
     nmap_findings = list(
-        Finding.objects.filter(session=session, source="nmap").select_related("port").order_by("-discovered_at")
+        Finding.objects.filter(session=session, source="nmap")
+        .select_related("port", "session")
+        .order_by("-discovered_at")
     )
     domain_findings = list(
         Finding.objects.filter(session=session, source="domain_security")
-        .select_related("subdomain")
+        .select_related("subdomain", "session")
         .order_by("-severity", "-discovered_at")
     )
     other_findings = list(
         Finding.objects.filter(session=session)
         .exclude(source__in=["nmap", "domain_security"])
-        .select_related("port", "url")
+        .select_related("port", "url", "session")
         .order_by("-discovered_at")
     )
 

--- a/apps/core/scheduler/scheduler.py
+++ b/apps/core/scheduler/scheduler.py
@@ -35,10 +35,12 @@ def setup_core_schedules():
     """Register/update the fixed system schedules in Django-Q2.
 
     System-hygiene schedules (stuck-scan watchdog, token purge) always run.
-    The unattended-scan schedules (daily scan + per-domain monitoring) are
-    registered only when SCHEDULED_SCANS_ENABLED is True; when False they are
-    actively removed, so flipping the flag on a running deployment takes effect
-    on the next startup even if the schedules were created by an earlier boot.
+    Every unattended-scan schedule (daily scan, per-domain monitoring, and
+    user-created recurring/one-time jobs) is registered/kept only when
+    SCHEDULED_SCANS_ENABLED is True; when False they are all actively removed,
+    so flipping the flag on a running deployment takes effect on the next
+    startup even if the schedules were created by an earlier boot. This is what
+    makes the switch a durable, complete "manual-only" mode.
     """
     from django.conf import settings
     from django_q.models import Schedule
@@ -67,6 +69,11 @@ def setup_core_schedules():
     if not settings.SCHEDULED_SCANS_ENABLED:
         removed = Schedule.objects.filter(name="daily_scan").delete()[0]
         removed += Schedule.objects.filter(name__startswith="monitor_").delete()[0]
+        # User-created recurring/one-time jobs are unattended scans too — remove
+        # them as well, or the switch wouldn't actually make the deployment
+        # manual-only (they would keep firing run_scheduled_scan).
+        removed += Schedule.objects.filter(name__startswith="recurring_").delete()[0]
+        removed += Schedule.objects.filter(name__startswith="once_").delete()[0]
         logger.info(
             "[scheduler] SCHEDULED_SCANS_ENABLED=False — manual-only mode; "
             f"removed {removed} auto-scan schedule(s). Hygiene schedules registered."
@@ -167,9 +174,26 @@ def run_monitoring_scan(domain: str):
 
 
 def run_scheduled_scan(domain: str, triggered_by: str = "scheduled"):
-    """Top-level callable for Django-Q2 one-time and recurring scan jobs."""
+    """Top-level callable for Django-Q2 one-time and recurring scan jobs.
+
+    Re-checks consent at run time, mirroring daily_scan/run_monitoring_scan.
+    A user-created recurring/one-time schedule is authorization-checked only
+    when created (scans/api.start_scan); without this gate it would keep
+    scanning a domain whose authorization was later revoked, that was
+    deactivated, or that was deleted (a deleted domain has no row, so the
+    active+authorized filter skips it). Gated on both is_active and
+    authorization to match the daily_scan guarantee.
+    """
+    from apps.core.domains.models import Domain
     from apps.core.scans.pipeline import create_scan_session
     from apps.core.scans.tasks import run_scan_task
+
+    is_scannable = Domain.objects.filter(
+        name=domain, is_active=True, authorization__isnull=False
+    ).exists()
+    if not is_scannable:
+        logger.warning(f"[scheduled_scan] Skipping {domain} — not an active, authorized domain")
+        return
 
     session = create_scan_session(domain, triggered_by=triggered_by)
     if session is None:

--- a/apps/core/workflows/api.py
+++ b/apps/core/workflows/api.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404
 from ninja import Router, Schema, Status
 from ninja.errors import HttpError
 
-from ninja_jwt.authentication import JWTAuth
+from apps.core.api.auth import JWTAuth
 from apps.core.workflows.models import Workflow, WorkflowStep
 from apps.core.workflows.registry import (
     get_tool_choices,

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -5,8 +5,11 @@ OpenEASD - Automated External Attack Surface Detection
 Company: Cybersecify | Author: Rathnakara G N
 """
 
+import sys
 from datetime import timedelta
 from pathlib import Path
+
+from django.core.exceptions import ImproperlyConfigured
 from decouple import config
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -14,6 +17,30 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = config("SECRET_KEY", default="django-insecure-change-me-in-production")
 
 DEBUG = config("DEBUG", default=False, cast=bool)
+
+
+def _validate_secret_key(secret_key: str, debug: bool) -> None:
+    """Fail fast in production on an unset/placeholder SECRET_KEY.
+
+    The key also signs JWTs (NINJA_JWT["SIGNING_KEY"] below), so the well-known
+    default would let anyone forge access/refresh tokens for any user. DEBUG
+    builds keep the default for local dev.
+    """
+    if not debug and secret_key.startswith("django-insecure"):
+        raise ImproperlyConfigured(
+            "SECRET_KEY is unset or still the insecure default while DEBUG=False. "
+            "Generate one with `openssl rand -hex 32` and set it via the SECRET_KEY "
+            "environment variable. This key also signs JWT access/refresh tokens, so "
+            "the default value allows anyone to forge authentication tokens."
+        )
+
+
+# Skip enforcement under the test runner: pytest-django imports settings before
+# any conftest/env hook can set a key, and token-signing key strength is
+# irrelevant to tests. The logic itself is covered by unit tests that call
+# _validate_secret_key directly.
+if "pytest" not in sys.modules:
+    _validate_secret_key(SECRET_KEY, DEBUG)
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="localhost,127.0.0.1").split(",")
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -351,6 +351,26 @@ class TestDomainsDelete:
     def test_requires_auth(self, client, domain):
         assert post_json(client, f"/api/domains/{domain.pk}/delete/", {}).status_code == 401
 
+    def test_removes_recurring_and_once_schedules(self, auth_client, domain):
+        """Deleting a domain must not leave its scan schedules firing unattended."""
+        from django_q.models import Schedule
+
+        Schedule.objects.create(
+            name=f"recurring_{domain.name}",
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.CRON, cron="0 2 * * *", repeats=-1,
+        )
+        Schedule.objects.create(
+            name=f"once_{domain.name}_" + "a" * 32,
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.ONCE, repeats=1,
+        )
+
+        res = post_json(auth_client, f"/api/domains/{domain.pk}/delete/", {})
+        assert res.status_code == 200
+        assert not Schedule.objects.filter(name=f"recurring_{domain.name}").exists()
+        assert not Schedule.objects.filter(name__startswith=f"once_{domain.name}_").exists()
+
 
 # ---------------------------------------------------------------------------
 # Scans

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -234,6 +234,53 @@ class TestChangePassword:
         assert res.status_code == 401
 
 
+class TestMustChangePasswordGate:
+    """Server-side enforcement of the forced-password-change flag.
+
+    While the flag is set, the JWT authenticates but access to everything except
+    reading the own user record and changing the password is blocked (403) — so
+    the React redirect is not the only barrier.
+    """
+
+    def _flag(self, user):
+        from apps.core.dashboard.models import UserProfile
+        profile, _ = UserProfile.objects.get_or_create(user=user)
+        profile.must_change_password = True
+        profile.save()
+
+    def test_flagged_user_blocked_from_protected_endpoint(self, auth_client, user):
+        self._flag(user)
+        res = auth_client.get("/api/domains/")
+        assert res.status_code == 403
+
+    def test_flagged_user_can_read_own_user(self, auth_client, user):
+        self._flag(user)
+        res = auth_client.get("/api/user/")
+        assert res.status_code == 200
+        assert res.json()["must_change_password"] is True
+
+    def test_flagged_user_can_change_password(self, auth_client, user):
+        self._flag(user)
+        res = post_json(auth_client, "/api/user/change-password/", {
+            "current_password": "pass123",
+            "new_password": "newpass456",
+        })
+        assert res.status_code == 200
+
+    def test_unflagged_user_reaches_protected_endpoint(self, auth_client, user):
+        res = auth_client.get("/api/domains/")
+        assert res.status_code == 200
+
+    def test_gate_lifts_after_password_change(self, auth_client, user):
+        self._flag(user)
+        post_json(auth_client, "/api/user/change-password/", {
+            "current_password": "pass123",
+            "new_password": "newpass456",
+        })
+        res = auth_client.get("/api/domains/")
+        assert res.status_code == 200
+
+
 # ---------------------------------------------------------------------------
 # Dashboard
 # ---------------------------------------------------------------------------

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -484,6 +484,24 @@ class TestScanDetail:
     def test_not_found(self, auth_client):
         assert auth_client.get("/api/scans/00000000-0000-0000-0000-000000000000/").status_code == 404
 
+    def test_no_n_plus_one_on_findings(self, auth_client, django_assert_max_num_queries, scan):
+        """scan_detail must not issue one query per finding to resolve session.uuid."""
+        from apps.core.findings.models import Finding
+
+        for i in range(25):
+            Finding.objects.create(
+                session=scan, source="web_checker", target=f"h{i}.example.com",
+                check_type="hdr", severity="low", title=f"Finding {i}",
+                description="d", remediation="r",
+            )
+        # Warm up one-time caches (content types, auth) so the bound reflects
+        # steady state, not first-request setup.
+        auth_client.get(f"/api/scans/{scan.uuid}/")
+        # With select_related("session") the query count is constant; without it
+        # this load would issue 25+ extra per-finding queries.
+        with django_assert_max_num_queries(20):
+            auth_client.get(f"/api/scans/{scan.uuid}/")
+
     def test_requires_auth(self, client, scan):
         assert client.get(f"/api/scans/{scan.uuid}/").status_code == 401
 

--- a/tests/unit/test_insights_builder.py
+++ b/tests/unit/test_insights_builder.py
@@ -1,0 +1,86 @@
+"""Unit tests for rebuild_finding_type_summaries — upsert + prune behavior."""
+
+import pytest
+from unittest.mock import patch
+from django.utils import timezone
+
+
+def _completed_session(domain, subdomain_offset=0):
+    from apps.core.scans.models import ScanSession
+    return ScanSession.objects.create(
+        domain=domain, scan_type="full", status="completed", end_time=timezone.now(),
+    )
+
+
+def _finding(session, title, check_type="dns", severity="high", source="domain_security"):
+    from apps.core.findings.models import Finding
+    return Finding.objects.create(
+        session=session, source=source, target=session.domain,
+        check_type=check_type, severity=severity, title=title,
+        description="d", remediation="r",
+    )
+
+
+@pytest.mark.django_db
+class TestRebuildFindingTypeSummaries:
+    def test_upserts_current_finding_type(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        Domain.objects.create(name="agg.com", is_active=True)
+        s = _completed_session("agg.com")
+        _finding(s, "Missing SPF")
+
+        rebuild_finding_type_summaries()
+
+        row = FindingTypeSummary.objects.get(title="Missing SPF", check_type="dns")
+        assert row.occurrence_count == 1
+
+    def test_prunes_type_absent_from_latest_scan(self, db):
+        """A finding type present in an old scan but not the latest is pruned."""
+        from apps.core.domains.models import Domain
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        Domain.objects.create(name="agg.com", is_active=True)
+        s1 = _completed_session("agg.com")
+        _finding(s1, "Old Issue")
+        rebuild_finding_type_summaries()
+        assert FindingTypeSummary.objects.filter(title="Old Issue").exists()
+
+        # Newer scan for the same domain no longer has "Old Issue".
+        s2 = _completed_session("agg.com")
+        _finding(s2, "New Issue")
+        rebuild_finding_type_summaries()
+
+        assert not FindingTypeSummary.objects.filter(title="Old Issue").exists()
+        assert FindingTypeSummary.objects.filter(title="New Issue").exists()
+
+    def test_prunes_all_when_no_findings_remain(self, db):
+        """With no findings anywhere, every summary row is pruned."""
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        FindingTypeSummary.objects.create(
+            title="Ghost", check_type="dns", severity="high",
+            occurrence_count=5, last_seen=timezone.now(),
+        )
+        rebuild_finding_type_summaries()
+
+        assert FindingTypeSummary.objects.count() == 0
+
+    def test_skips_prune_when_aggregation_errors(self, db):
+        """If aggregation raises, existing rows are preserved (not wrongly deleted)."""
+        from apps.core.findings.models import Finding
+        from apps.core.insights.builder import rebuild_finding_type_summaries
+        from apps.core.insights.models import FindingTypeSummary
+
+        FindingTypeSummary.objects.create(
+            title="Keep Me", check_type="dns", severity="high",
+            occurrence_count=1, last_seen=timezone.now(),
+        )
+        with patch.object(Finding.objects, "filter", side_effect=RuntimeError("boom")):
+            rebuild_finding_type_summaries()
+
+        assert FindingTypeSummary.objects.filter(title="Keep Me").exists()

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -372,6 +372,65 @@ class TestRunMonitoringScanAuthorization:
 
 
 # ---------------------------------------------------------------------------
+# run_scheduled_scan consent gate (recurring / one-time jobs)
+# ---------------------------------------------------------------------------
+
+class TestRunScheduledScanConsentGate:
+    def test_runs_for_active_authorized_domain(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        _authorize(Domain.objects.create(name="sched-ok.example.com", is_active=True))
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            fake_session = MagicMock()
+            fake_session.id = 1
+            mock_create.return_value = fake_session
+            run_scheduled_scan("sched-ok.example.com", "recurring")
+
+        mock_create.assert_called_once()
+        mock_task.assert_called_once()
+
+    def test_skips_unauthorized_domain(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        Domain.objects.create(name="sched-noauth.example.com", is_active=True)  # no auth
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            run_scheduled_scan("sched-noauth.example.com", "recurring")
+
+        mock_create.assert_not_called()
+        mock_task.assert_not_called()
+
+    def test_skips_inactive_domain(self, db):
+        from apps.core.domains.models import Domain
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        _authorize(Domain.objects.create(name="sched-inactive.example.com", is_active=False))
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            run_scheduled_scan("sched-inactive.example.com", "recurring")
+
+        mock_create.assert_not_called()
+        mock_task.assert_not_called()
+
+    def test_skips_deleted_domain(self, db):
+        """A recurring schedule left behind by a deleted domain must not scan."""
+        from apps.core.scheduler.scheduler import run_scheduled_scan
+
+        with patch("apps.core.scans.tasks.run_scan_task") as mock_task, \
+             patch("apps.core.scans.pipeline.create_scan_session") as mock_create:
+            run_scheduled_scan("gone.example.com", "recurring")  # no Domain row at all
+
+        mock_create.assert_not_called()
+        mock_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # setup_core_schedules master switch (SCHEDULED_SCANS_ENABLED)
 # ---------------------------------------------------------------------------
 
@@ -420,3 +479,25 @@ class TestSetupCoreSchedules:
 
         assert not Schedule.objects.filter(name="daily_scan").exists()
         assert not Schedule.objects.filter(name__startswith="monitor_").exists()
+
+    def test_disabled_removes_recurring_and_once_schedules(self, db, settings):
+        """Manual-only mode must also drop user-created recurring/one-time jobs."""
+        from django_q.models import Schedule
+        from apps.core.scheduler.scheduler import setup_core_schedules
+
+        Schedule.objects.create(
+            name="recurring_example.com",
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.CRON, cron="0 2 * * *", repeats=-1,
+        )
+        Schedule.objects.create(
+            name="once_example.com_" + "a" * 32,
+            func="apps.core.scheduler.scheduler.run_scheduled_scan",
+            schedule_type=Schedule.ONCE, repeats=1,
+        )
+
+        settings.SCHEDULED_SCANS_ENABLED = False
+        setup_core_schedules()
+
+        assert not Schedule.objects.filter(name__startswith="recurring_").exists()
+        assert not Schedule.objects.filter(name__startswith="once_").exists()

--- a/tests/unit/test_settings_security.py
+++ b/tests/unit/test_settings_security.py
@@ -1,0 +1,24 @@
+"""Unit tests for the SECRET_KEY production guard in openeasd/settings.py."""
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from openeasd.settings import _validate_secret_key
+
+
+class TestSecretKeyGuard:
+    def test_raises_on_default_key_in_production(self):
+        with pytest.raises(ImproperlyConfigured):
+            _validate_secret_key("django-insecure-change-me-in-production", debug=False)
+
+    def test_raises_on_any_insecure_prefixed_key_in_production(self):
+        with pytest.raises(ImproperlyConfigured):
+            _validate_secret_key("django-insecure-anything", debug=False)
+
+    def test_allows_default_key_when_debug(self):
+        # No raise — local dev is permitted to keep the placeholder key.
+        _validate_secret_key("django-insecure-change-me-in-production", debug=True)
+
+    def test_allows_real_key_in_production(self):
+        # No raise — a properly-set key passes even with DEBUG off.
+        _validate_secret_key("a1b2c3d4e5f6-a-real-strong-secret", debug=False)


### PR DESCRIPTION
Integrates the three remaining `rathnakara-aivar` fork PRs — **#190, #191, #192** — via cherry-pick (preserving Rathnakara's authorship), because they conflicted with each other only on the CLAUDE.md test-count line after #189 merged.

- **#190** — `run_scheduled_scan` re-checks `is_active + authorization` at run time; recurring/once schedules reaped on domain delete + `SCHEDULED_SCANS_ENABLED=False`.
- **#191** — SECRET_KEY strength guard (raises only when `DEBUG=False` **and** the insecure default is still in use; change-password routes exempt from the flagged-user 403 gate).
- **#192** — prune stale `FindingTypeSummary` rows only when aggregation completed (in a transaction); `select_related` kills the scan_detail N+1.

All three reviewed + fast-suite-green individually and together (979 fast pass). Their own tests included.

Closes #190, closes #191, closes #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)