### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v0.10.0] — 2026-08-03
+
 ### Added
 
 - **Self-serve add-and-scan-once from the Start Scan page.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "0.9.0"
+version = "0.10.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1245,7 +1245,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Version bump 0.9.0 → 0.10.0 + changelog roll-up. Tag pushed after merge triggers the `:v0.10` image publish.