### PR TITLE
ci: ignore tailwindcss v4 major in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,14 @@ updates:
           - "@radix-ui/*"
           - "class-variance-authority"
           - "tailwind*"
+    ignore:
+      # Tailwind v4 is a breaking migration (PostCSS plugin moved to
+      # @tailwindcss/postcss, CSS-first config). We intentionally pin
+      # Tailwind 3; the v4 jump will be handled as its own tracked
+      # migration, not an unattended group bump. Minor/patch v3 updates
+      # still flow through.
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "frontend"


### PR DESCRIPTION
Stops dependabot re-proposing the broken Tailwind-v4 group bump every week.

**Why:** PR #185 (`shadcn-radix` group) bundled `tailwindcss ^3.4.19 → ^4.3.3`, which breaks the frontend build — v4 moved the PostCSS plugin to `@tailwindcss/postcss` and switched to CSS-first config. That's a migration, not a routine bump. This repo pins Tailwind 3.

**Change:** ignore `tailwindcss` semver-major in the npm config. Radix patches and Tailwind-3 minor/patch updates still flow. Tailwind 4 will be its own tracked migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)