### PR TITLE
ci: sync codeql-action init+analyze versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,13 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
+    groups:
+      # init + analyze must move together — a split bump leaves the two
+      # codeql-action steps on mismatched versions and the Analyze job
+      # fails ("Not all workflow steps ... use the same version").
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -48,6 +48,6 @@ jobs:
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
**Fixes the failing CodeQL Analyze job on dependabot PRs #181/#207.**

**Root cause:** dependabot opens a separate PR for each `github/codeql-action/*` sub-action. #181 bumped only `analyze`, #207 only `init` — each left the other step on the old version. CodeQL requires `init` and `analyze` to run the same version; the mismatch fails the Analyze job (`Not all workflow steps that use github/codeql-action actions use the same version`). Neither PR can ever pass alone.

**Fix:**
- Bump **both** `init` and `analyze` to `f205ea1` (the SHA both PRs target) in one commit.
- Add a `codeql-action` group to `dependabot.yml` so the two steps always bump atomically going forward.

Supersedes #181 and #207 (closing those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)