### PR TITLE
fix: eliminate false positives from CDN scanning, wildcard DNS, and takeover detection

### DIFF
--- a/apps/alterx/scanner.py
+++ b/apps/alterx/scanner.py
@@ -1,4 +1,8 @@
 import logging
+import secrets
+
+import dns.exception
+import dns.resolver
 
 from apps.core.assets.models import Subdomain
 
@@ -6,6 +10,26 @@ from .analyzer import analyze
 from .collector import collect
 
 logger = logging.getLogger(__name__)
+
+
+def _has_wildcard_dns(domain: str) -> bool:
+    """Return True if domain answers wildcard queries (any random hostname resolves).
+
+    Cloudflare and similar CDNs respond to *.domain — so alterx permutations
+    all resolve even though the subdomains don't exist. When detected, the
+    scanner skips alterx to avoid flooding the pipeline with fake hosts.
+    """
+    probe = f"openeasd-wc-{secrets.token_hex(6)}.{domain}"
+    try:
+        dns.resolver.resolve(probe, "A")
+        return True
+    except (
+        dns.resolver.NXDOMAIN,
+        dns.resolver.NoAnswer,
+        dns.exception.Timeout,
+        dns.exception.DNSException,
+    ):
+        return False
 
 
 def run_alterx(session) -> list[Subdomain]:
@@ -17,6 +41,15 @@ def run_alterx(session) -> list[Subdomain]:
 
     if not subdomains:
         logger.info(f"[alterx:{session.id}] no subdomains to permute")
+        return []
+
+    if _has_wildcard_dns(session.domain):
+        logger.warning(
+            "[alterx:%s] wildcard DNS detected for %s — skipping permutations "
+            "(random hostname resolved; all alterx results would be false positives)",
+            session.id,
+            session.domain,
+        )
         return []
 
     raw = collect(subdomains)

--- a/apps/amass/apps.py
+++ b/apps/amass/apps.py
@@ -13,4 +13,5 @@ class AmassConfig(AppConfig):
         "phase_group": "Surface Enumeration",
         "requires": [],
         "produces_findings": False,
+        "active": True,
     }

--- a/apps/core/service_detection/apps.py
+++ b/apps/core/service_detection/apps.py
@@ -13,4 +13,5 @@ class ServiceDetectionConfig(AppConfig):
         "requires": ["naabu"],
         "produces_findings": False,
         "core": True,  # always runs, hidden from workflow UI
+        "active": True,
     }

--- a/apps/core/workflows/registry.py
+++ b/apps/core/workflows/registry.py
@@ -46,6 +46,7 @@ def _discover_tools():
             "requires": meta.get("requires", []),
             "produces_findings": meta.get("produces_findings", False),
             "core": meta.get("core", False),
+            "active": meta.get("active", False),
         }
         logger.debug(f"[registry] Registered tool: {tool_name}")
 
@@ -86,6 +87,11 @@ def get_tool_requires() -> dict[str, list[str]]:
 def get_tool_produces_findings() -> dict[str, bool]:
     """Dynamic map: tool_name → whether the tool writes to the Finding table."""
     return {name: info["produces_findings"] for name, info in get_registry().items()}
+
+
+def get_tool_active() -> dict[str, bool]:
+    """Dynamic map: tool_name → True if the tool performs active network scanning."""
+    return {name: info["active"] for name, info in get_registry().items()}
 
 
 def get_tool_phase_groups() -> dict[str, str]:

--- a/apps/core/workflows/runner.py
+++ b/apps/core/workflows/runner.py
@@ -129,9 +129,27 @@ def run_workflow(workflow_run_id: int, only_tools: list | None = None):
             if t not in tools:
                 tools.append(t)
 
+    from django.conf import settings
+    from .registry import get_tool_active
+    if not getattr(settings, "ACTIVE_SCANNING_ENABLED", True):
+        active_map = get_tool_active()
+        skipped = [t for t in tools if active_map.get(t, False)]
+        if skipped:
+            logger.info(
+                "[workflow:%s] ACTIVE_SCANNING_ENABLED=False — skipping: %s",
+                run.id,
+                ", ".join(skipped),
+            )
+        tools = [t for t in tools if not active_map.get(t, False)]
+
     # service_detection always runs after naabu (core infrastructure).
     # Skip for subscans (assets already classified from parent).
-    if "service_detection" not in tools and only_tools is None:
+    # Skip when active scanning is disabled (naabu itself is excluded).
+    if (
+        "service_detection" not in tools
+        and only_tools is None
+        and getattr(settings, "ACTIVE_SCANNING_ENABLED", True)
+    ):
         insert_at = 0
         for i, t in enumerate(tools):
             if t == "naabu":

--- a/apps/dnsx/analyzer.py
+++ b/apps/dnsx/analyzer.py
@@ -12,6 +12,33 @@ logger = logging.getLogger(__name__)
 # Python 3.11's is_private does not cover this range; 3.12+ does.
 _CGNAT = ipaddress.ip_network("100.64.0.0/10")
 
+# Known CDN edge IP ranges — IPs here belong to CDN infrastructure, not the
+# customer's origin servers. Port-scanning or TLS-probing them produces findings
+# against the CDN (false positives) rather than the target.
+# Sources: cloudflare.com/ips-v4, api.fastly.com/public-ip-list,
+#          ip-ranges.amazonaws.com/ip-ranges.json (service=CLOUDFRONT).
+_CDN_RANGES = [
+    # Cloudflare
+    "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+    "141.101.64.0/18", "108.162.192.0/18", "190.93.240.0/20", "188.114.96.0/20",
+    "197.234.240.0/22", "198.41.128.0/17", "162.158.0.0/15",
+    "104.16.0.0/13", "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+    # Fastly
+    "23.235.32.0/20", "43.249.72.0/22", "103.244.50.0/24", "103.245.222.0/23",
+    "103.245.224.0/24", "104.156.80.0/20", "140.248.64.0/18", "140.248.128.0/17",
+    "146.75.0.0/17", "151.101.0.0/16", "157.52.64.0/18", "167.82.0.0/17",
+    "167.82.128.0/20", "167.82.160.0/20", "167.82.224.0/20", "172.111.64.0/18",
+    "185.31.16.0/22", "199.27.72.0/21", "199.232.0.0/16",
+    # AWS CloudFront
+    "13.32.0.0/15", "13.35.0.0/16", "52.46.0.0/18", "52.84.0.0/15",
+    "54.182.0.0/16", "54.192.0.0/16", "54.230.0.0/16",
+    "64.252.64.0/18", "64.252.128.0/18", "70.132.0.0/18", "99.84.0.0/16",
+    "204.246.164.0/22", "204.246.168.0/22", "204.246.172.0/23", "204.246.174.0/23",
+    "204.246.176.0/20", "205.251.192.0/19", "205.251.249.0/24",
+    "205.251.250.0/23", "205.251.252.0/23", "216.137.32.0/19",
+]
+_CDN_NETWORKS = [ipaddress.ip_network(r) for r in _CDN_RANGES]
+
 
 def _is_public(ip_str: str) -> bool:
     """Return True if IP is publicly routable (not private/loopback/link-local/reserved/CGNAT)."""
@@ -27,6 +54,15 @@ def _is_public(ip_str: str) -> bool:
         or ip.is_multicast
         or ip in _CGNAT
     )
+
+
+def _is_cdn_ip(ip_str: str) -> bool:
+    """Return True if the IP belongs to a known CDN edge network."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    return any(ip in net for net in _CDN_NETWORKS)
 
 
 def analyze(session, records: list[dict], subdomain_index: dict) -> tuple[list[IPAddress], list]:
@@ -56,12 +92,15 @@ def analyze(session, records: list[dict], subdomain_index: dict) -> tuple[list[I
             # Resolved but private/internal — do not mark active
             continue
 
-        # Activate subdomain
+        # Activate subdomain — it's publicly reachable even if behind a CDN
         if not sub.is_active:
             activated.append(sub)
 
-        # Build unique IPAddress records
-        for ip_str in public_ips:
+        # Only create IPAddress records for non-CDN IPs. CDN edge IPs (Cloudflare,
+        # Fastly, CloudFront) are shared infrastructure — port-scanning them
+        # produces findings against the CDN, not the customer's origin server.
+        scannable_ips = [ip for ip in public_ips if not _is_cdn_ip(ip)]
+        for ip_str in scannable_ips:
             key = (sub.id, ip_str)
             if key in seen_pairs:
                 continue

--- a/apps/katana/apps.py
+++ b/apps/katana/apps.py
@@ -13,4 +13,5 @@ class KatanaConfig(AppConfig):
         "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": False,
+        "active": True,
     }

--- a/apps/naabu/apps.py
+++ b/apps/naabu/apps.py
@@ -13,4 +13,5 @@ class NaabuConfig(AppConfig):
         "phase_group": "Port Discovery",
         "requires": ["dnsx"],
         "produces_findings": False,
+        "active": True,
     }

--- a/apps/nmap/apps.py
+++ b/apps/nmap/apps.py
@@ -13,4 +13,5 @@ class NmapConfig(AppConfig):
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
+        "active": True,
     }

--- a/apps/nuclei/apps.py
+++ b/apps/nuclei/apps.py
@@ -13,4 +13,5 @@ class NucleiConfig(AppConfig):
         "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": True,
+        "active": True,
     }

--- a/apps/nuclei_network/apps.py
+++ b/apps/nuclei_network/apps.py
@@ -12,4 +12,5 @@ class NucleiNetworkConfig(AppConfig):
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
+        "active": True,
     }

--- a/apps/ssh_checker/apps.py
+++ b/apps/ssh_checker/apps.py
@@ -12,4 +12,5 @@ class SshCheckerConfig(AppConfig):
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
+        "active": True,
     }

--- a/apps/takeover_check/analyzer.py
+++ b/apps/takeover_check/analyzer.py
@@ -75,6 +75,14 @@ def analyze(session, records: list[dict]) -> list[Finding]:
         seen.add(subdomain_name)
 
         service = _service_of(record)
+        if service == "unknown":
+            logger.info(
+                "[takeover_check:%s] Skipping %s — subzy returned no fingerprint",
+                session.id,
+                subdomain_name,
+            )
+            continue
+
         subdomain_fk = subdomain_index.get(subdomain_name)
 
         findings.append(Finding(

--- a/apps/tls_checker/apps.py
+++ b/apps/tls_checker/apps.py
@@ -12,4 +12,5 @@ class TlsCheckerConfig(AppConfig):
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,
+        "active": True,
     }

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -183,6 +183,11 @@ SCHEDULER_ENABLED = config("SCHEDULER_ENABLED", default=True, cast=bool)
 # unauthorized domains even when this is True.
 SCHEDULED_SCANS_ENABLED = config("SCHEDULED_SCANS_ENABLED", default=True, cast=bool)
 
+# When False, active scanning tools (port scanners, vuln scanners, crawlers) are
+# skipped. Passive tools (subfinder, dnsx, httpx, web_checker, etc.) still run.
+# Set to False on the hosted tier to prevent scanning third-party infrastructure.
+ACTIVE_SCANNING_ENABLED = config("ACTIVE_SCANNING_ENABLED", default=True, cast=bool)
+
 # OpenEASD Configuration
 OPENEASD_CONFIG_DIR = BASE_DIR / "config"
 OPENEASD_DATA_DIR = BASE_DIR / "data"

--- a/tests/unit/test_alterx.py
+++ b/tests/unit/test_alterx.py
@@ -136,6 +136,13 @@ class TestScanner:
         from apps.core.scans.models import ScanSession
         return ScanSession.objects.create(domain="example.com", scan_type="full")
 
+    def _subdomain(self, session, name):
+        from apps.core.assets.models import Subdomain
+        return Subdomain.objects.create(
+            session=session, domain="example.com",
+            subdomain=name, source="subfinder",
+        )
+
     def test_no_subdomains_returns_empty_without_calling_collect(self):
         sess = self._session()
         with patch("apps.alterx.scanner.collect") as mock_collect:
@@ -144,44 +151,53 @@ class TestScanner:
         mock_collect.assert_not_called()
 
     def test_passes_existing_subdomain_names_to_collect(self):
-        from apps.core.assets.models import Subdomain
         sess = self._session()
-        Subdomain.objects.create(
-            session=sess, domain="example.com",
-            subdomain="api.example.com", source="subfinder",
-        )
+        self._subdomain(sess, "api.example.com")
         captured = {}
 
         def fake_collect(subdomains):
             captured["subdomains"] = subdomains
             return []
 
-        with patch("apps.alterx.scanner.collect", side_effect=fake_collect):
-            run_alterx(sess)
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", side_effect=fake_collect):
+                run_alterx(sess)
 
         assert "api.example.com" in captured["subdomains"]
 
     def test_saves_permutations_and_returns_them(self):
         from apps.core.assets.models import Subdomain
         sess = self._session()
-        Subdomain.objects.create(
-            session=sess, domain="example.com",
-            subdomain="api.example.com", source="subfinder",
-        )
+        self._subdomain(sess, "api.example.com")
 
-        with patch("apps.alterx.scanner.collect", return_value=["api-dev.example.com", "api2.example.com"]):
-            result = run_alterx(sess)
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", return_value=["api-dev.example.com", "api2.example.com"]):
+                result = run_alterx(sess)
 
         assert Subdomain.objects.filter(session=sess, source="alterx").count() == 2
         assert len(result) == 2
 
     def test_returns_empty_when_collect_returns_nothing(self):
-        from apps.core.assets.models import Subdomain
         sess = self._session()
-        Subdomain.objects.create(
-            session=sess, domain="example.com",
-            subdomain="api.example.com", source="subfinder",
-        )
-        with patch("apps.alterx.scanner.collect", return_value=[]):
-            result = run_alterx(sess)
+        self._subdomain(sess, "api.example.com")
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", return_value=[]):
+                result = run_alterx(sess)
         assert result == []
+
+    def test_skips_collect_when_wildcard_dns_detected(self):
+        sess = self._session()
+        self._subdomain(sess, "api.example.com")
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=True):
+            with patch("apps.alterx.scanner.collect") as mock_collect:
+                result = run_alterx(sess)
+        assert result == []
+        mock_collect.assert_not_called()
+
+    def test_runs_collect_when_no_wildcard_dns(self):
+        sess = self._session()
+        self._subdomain(sess, "api.example.com")
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", return_value=[]) as mock_collect:
+                run_alterx(sess)
+        mock_collect.assert_called_once()

--- a/tests/unit/test_dnsx.py
+++ b/tests/unit/test_dnsx.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from apps.dnsx.analyzer import _is_public, analyze
+from apps.dnsx.analyzer import _is_cdn_ip, _is_public, analyze
 from apps.dnsx.scanner import run_dnsx
 
 
@@ -59,6 +59,40 @@ class TestIsPublic:
         assert _is_public("not-an-ip") is False
         assert _is_public("") is False
         assert _is_public("999.999.999.999") is False
+
+
+# ---------------------------------------------------------------------------
+# CDN IP filter
+# ---------------------------------------------------------------------------
+
+class TestIsCdnIp:
+    def test_cloudflare_ip_detected(self):
+        # 172.67.191.147 is in Cloudflare's 172.64.0.0/13 range
+        assert _is_cdn_ip("172.67.191.147") is True
+
+    def test_cloudflare_ip_104_range(self):
+        # 104.21.84.116 is in Cloudflare's 104.16.0.0/13 range
+        assert _is_cdn_ip("104.21.84.116") is True
+
+    def test_fastly_ip_detected(self):
+        # 151.101.0.1 is in Fastly's 151.101.0.0/16 range
+        assert _is_cdn_ip("151.101.0.1") is True
+
+    def test_cloudfront_ip_detected(self):
+        # 54.192.0.1 is in CloudFront's 54.192.0.0/16 range
+        assert _is_cdn_ip("54.192.0.1") is True
+
+    def test_regular_public_ip_not_cdn(self):
+        assert _is_cdn_ip("8.8.8.8") is False
+
+    def test_another_public_ip_not_cdn(self):
+        assert _is_cdn_ip("54.23.45.67") is False
+
+    def test_private_ip_not_cdn(self):
+        assert _is_cdn_ip("10.0.0.1") is False
+
+    def test_invalid_input(self):
+        assert _is_cdn_ip("not-an-ip") is False
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +160,28 @@ class TestDnsxAnalyzer:
         }]
         ips, _ = analyze(sess, records, index)
         assert len(ips) == 1
+
+    def test_analyze_filters_cdn_ips_from_ip_records(self):
+        # Cloudflare IP should not produce an IPAddress record
+        sess, index = self._make_session_with_subdomains(["cdn.example.com"])
+        records = [{"host": "cdn.example.com", "a": ["172.67.191.147"], "aaaa": []}]
+        ips, activated = analyze(sess, records, index)
+        assert ips == []
+        # But the subdomain IS reachable so it gets activated
+        assert len(activated) == 1
+
+    def test_analyze_keeps_origin_ip_when_mixed_with_cdn(self):
+        # If a subdomain has both a CDN IP and a real origin IP, keep the origin
+        sess, index = self._make_session_with_subdomains(["mixed.example.com"])
+        records = [{
+            "host": "mixed.example.com",
+            "a": ["172.67.191.147", "54.23.45.67"],
+            "aaaa": [],
+        }]
+        ips, activated = analyze(sess, records, index)
+        assert len(ips) == 1
+        assert ips[0].address == "54.23.45.67"
+        assert len(activated) == 1
 
     def test_analyze_skips_unknown_hosts(self):
         sess, index = self._make_session_with_subdomains(["known.example.com"])

--- a/tests/unit/test_takeover_check.py
+++ b/tests/unit/test_takeover_check.py
@@ -125,18 +125,24 @@ class TestAnalyze:
     def test_links_subdomain_fk_when_session_has_match(self):
         sess = self._session()
         sub = self._subdomain(sess, "blog.example.com")
-        records = [{"subdomain": "blog.example.com", "vulnerable": True}]
+        records = [{"subdomain": "blog.example.com", "vulnerable": True, "service": "GitHub Pages"}]
         findings = analyze(sess, records)
         assert findings[0].subdomain_id == sub.id
 
     def test_no_subdomain_fk_when_session_missing_match(self):
         sess = self._session()
-        # Note: no Subdomain row created
-        records = [{"subdomain": "blog.example.com", "vulnerable": True}]
+        # No Subdomain row created, but service is known — finding still created
+        records = [{"subdomain": "blog.example.com", "vulnerable": True, "service": "GitHub Pages"}]
         findings = analyze(sess, records)
         assert findings[0].subdomain is None
-        # But target field still populated for free-floating findings
         assert findings[0].target == "blog.example.com"
+
+    def test_skips_record_with_unknown_service(self):
+        sess = self._session()
+        # subzy returned no fingerprint — "unknown" service must not become a finding
+        records = [{"subdomain": "blog.example.com", "vulnerable": True}]
+        findings = analyze(sess, records)
+        assert findings == []
 
     def test_dedupes_by_subdomain_name(self):
         sess = self._session()

--- a/tests/unit/test_workflow_runner.py
+++ b/tests/unit/test_workflow_runner.py
@@ -560,3 +560,98 @@ class TestPhaseParallelExecution:
         assert WorkflowStepResult.objects.get(run=run, tool="tls_checker").status == "completed"
         # Phase-10 tool was skipped
         assert WorkflowStepResult.objects.get(run=run, tool="nuclei").status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# ACTIVE_SCANNING_ENABLED gate
+# ---------------------------------------------------------------------------
+
+class TestActiveScanningDisabled:
+    """When ACTIVE_SCANNING_ENABLED=False, active tools are skipped."""
+
+    def _make_run(self, db, session, tool_names):
+        wf = Workflow.objects.create(name="Active Gate Test")
+        for i, tool in enumerate(tool_names, start=1):
+            WorkflowStep.objects.create(workflow=wf, tool=tool, order=i, enabled=True)
+        return WorkflowRun.objects.create(workflow=wf, session=session)
+
+    def test_active_tools_skipped_when_disabled(self, db, session):
+        """naabu (active=True) is excluded; subfinder (active=False) still runs."""
+        run = self._make_run(db, session, ["subfinder", "naabu"])
+        tools_used = []
+
+        def track_runner(tool_name):
+            tools_used.append(tool_name)
+            return MagicMock(return_value=None)
+
+        with patch("apps.core.workflows.runner._get_runner", side_effect=track_runner):
+            with patch("django.conf.settings.ACTIVE_SCANNING_ENABLED", False):
+                run_workflow(run.id)
+
+        assert "subfinder" in tools_used
+        assert "naabu" not in tools_used
+
+    def test_passive_tools_run_when_active_scanning_disabled(self, db, session):
+        """Passive tools (subfinder, dnsx, httpx, web_checker) still execute."""
+        run = self._make_run(db, session, ["subfinder", "dnsx", "httpx", "web_checker"])
+        tools_used = []
+
+        def track_runner(tool_name):
+            tools_used.append(tool_name)
+            return MagicMock(return_value=None)
+
+        with patch("apps.core.workflows.runner._get_runner", side_effect=track_runner):
+            with patch("django.conf.settings.ACTIVE_SCANNING_ENABLED", False):
+                run_workflow(run.id)
+
+        for tool in ["subfinder", "dnsx", "httpx", "web_checker"]:
+            assert tool in tools_used
+
+    def test_service_detection_not_injected_when_active_scanning_disabled(self, db, session):
+        """service_detection injection is skipped when active scanning is off."""
+        run = self._make_run(db, session, ["subfinder", "dnsx"])
+        tools_used = []
+
+        def track_runner(tool_name):
+            tools_used.append(tool_name)
+            return MagicMock(return_value=None)
+
+        with patch("apps.core.workflows.runner._get_runner", side_effect=track_runner):
+            with patch("django.conf.settings.ACTIVE_SCANNING_ENABLED", False):
+                run_workflow(run.id)
+
+        assert "service_detection" not in tools_used
+
+    def test_all_active_tools_excluded(self, db, session):
+        """All 9 active tools are blocked; run completes with only passive tools."""
+        active_tools = [
+            "amass", "naabu", "service_detection", "nmap",
+            "tls_checker", "ssh_checker", "nuclei_network", "katana", "nuclei",
+        ]
+        passive_tools = ["subfinder", "dnsx", "httpx"]
+        run = self._make_run(db, session, passive_tools + active_tools)
+        tools_used = []
+
+        def track_runner(tool_name):
+            tools_used.append(tool_name)
+            return MagicMock(return_value=None)
+
+        with patch("apps.core.workflows.runner._get_runner", side_effect=track_runner):
+            with patch("django.conf.settings.ACTIVE_SCANNING_ENABLED", False):
+                run_workflow(run.id)
+
+        for t in active_tools:
+            assert t not in tools_used, f"{t} should not have run"
+        for t in passive_tools:
+            assert t in tools_used, f"{t} should have run"
+
+    def test_run_completes_successfully_with_only_passive_tools(self, db, session):
+        """Run reaches 'completed' status even when all active tools are filtered out."""
+        run = self._make_run(db, session, ["subfinder", "naabu"])
+
+        with _patch_get_runner({"subfinder": _mock_runner([])}):
+            with patch("django.conf.settings.ACTIVE_SCANNING_ENABLED", False):
+                run_workflow(run.id)
+
+        run.refresh_from_db()
+        assert run.status == "completed"


### PR DESCRIPTION
## Summary

Four fixes targeting false positives identified in scan reports:

- **CDN IP exclusion:** dnsx skips Cloudflare/Fastly/CloudFront IPs — no more false CRITICAL findings against CDN infrastructure
- **Wildcard DNS gate:** alterx probes a random hostname first — skips permutations on Cloudflare-fronted domains
- **subzy unknown service:** takeover_check skips records where subzy returns no fingerprint — no more false HIGH findings
- **Active scanning gate:** New ACTIVE_SCANNING_ENABLED env var — when False, port/vuln scanners are skipped for hosted deployments

## Test plan
- [ ] 886 unit tests pass
- [ ] CDN IPs no longer appear in IPAddress records
- [ ] alterx skips on wildcard DNS domains
- [ ] subzy unknown records produce no findings
- [ ] ACTIVE_SCANNING_ENABLED=False blocks active tools, passive tools still run