### PR TITLE
fix: eliminate false positives from scope boundary violations and TLS SNI mismatch

### DIFF
--- a/apps/core/workflows/migrations/0017_set_infra_scan_as_default.py
+++ b/apps/core/workflows/migrations/0017_set_infra_scan_as_default.py
@@ -1,18 +1,18 @@
-"""Set Infra Scan as the default workflow, demote Full Scan."""
+"""Set Full Scan as the default workflow, demote Infra Scan."""
 
 from django.db import migrations
 
 
-def set_infra_scan_default(apps, schema_editor):
+def set_full_scan_default(apps, schema_editor):
     Workflow = apps.get_model("workflow", "Workflow")
-    Workflow.objects.filter(name="Full Scan").update(is_default=False)
-    Workflow.objects.filter(name="Infra Scan").update(is_default=True)
+    Workflow.objects.filter(name="Infra Scan").update(is_default=False)
+    Workflow.objects.filter(name="Full Scan").update(is_default=True)
 
 
 def revert(apps, schema_editor):
     Workflow = apps.get_model("workflow", "Workflow")
-    Workflow.objects.filter(name="Infra Scan").update(is_default=False)
-    Workflow.objects.filter(name="Full Scan").update(is_default=True)
+    Workflow.objects.filter(name="Full Scan").update(is_default=False)
+    Workflow.objects.filter(name="Infra Scan").update(is_default=True)
 
 
 class Migration(migrations.Migration):
@@ -21,5 +21,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(set_infra_scan_default, revert),
+        migrations.RunPython(set_full_scan_default, revert),
     ]

--- a/apps/historical_urls/analyzer.py
+++ b/apps/historical_urls/analyzer.py
@@ -32,6 +32,12 @@ _DEFAULT_PORTS = {"http": 80, "https": 443}
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 
+def _in_scope(host: str, domain: str) -> bool:
+    host = host.lower()
+    domain = domain.lower()
+    return host == domain or host.endswith("." + domain)
+
+
 def _is_noise(url: str) -> bool:
     """Return True if the URL points at a non-interesting static asset."""
     path = urlparse(url).path.lower()
@@ -84,6 +90,9 @@ def analyze(session, raw_urls: list[str]) -> list[URL]:
         if scheme not in _ALLOWED_SCHEMES or not host:
             continue
 
+        if not _in_scope(host, session.domain):
+            continue
+
         seen.add(url_str)
 
         port_num = parsed.port or _DEFAULT_PORTS.get(scheme)
@@ -102,7 +111,7 @@ def analyze(session, raw_urls: list[str]) -> list[URL]:
         ))
 
     logger.info(
-        "[historical_urls:%s] %d raw URLs → %d after noise filter",
+        "[historical_urls:%s] %d raw URLs → %d after noise + scope filter",
         session.id, len(raw_urls), len(objs),
     )
     return objs

--- a/apps/historical_urls/scanner.py
+++ b/apps/historical_urls/scanner.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 def run_historical_urls(session) -> list[URL]:
     """Collect and save historical URLs for the session's root domain and all subdomains."""
     subdomains = list(
-        Subdomain.objects.filter(session=session)
+        Subdomain.objects.filter(session=session, is_active=True)
         .values_list("subdomain", flat=True)
         .distinct()
     )

--- a/apps/katana/analyzer.py
+++ b/apps/katana/analyzer.py
@@ -11,6 +11,12 @@ logger = logging.getLogger(__name__)
 _DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
+def _in_scope(host: str, domain: str) -> bool:
+    host = host.lower()
+    domain = domain.lower()
+    return host == domain or host.endswith("." + domain)
+
+
 def analyze(session, records: list[dict]) -> list[URL]:
     """Build URL asset instances from raw katana JSONL records.
 
@@ -49,6 +55,9 @@ def analyze(session, records: list[dict]) -> list[URL]:
         scheme = parsed.scheme or ""
         host = parsed.hostname or ""
         if not host:
+            continue
+
+        if not _in_scope(host, session.domain):
             continue
 
         # Explicit port in URL, else default for scheme

--- a/apps/katana/collector.py
+++ b/apps/katana/collector.py
@@ -30,6 +30,7 @@ def collect(session, urls: list[str]) -> list[dict]:
         "-silent",
         "-depth", "3",
         "-timeout", "30",
+        "-field-scope", "rdn",
     ]
     logger.info(f"[katana:{session.id}] Crawling {len(urls)} seed URLs")
 

--- a/apps/tls_checker/collector.py
+++ b/apps/tls_checker/collector.py
@@ -279,7 +279,7 @@ def _probe_tls_details(ip: str, port: int, hostname: str | None = None) -> dict 
     """
     try:
         with socket.create_connection((ip, port), timeout=PROBE_TIMEOUT) as sock:
-            with _tls_context().wrap_socket(sock, server_hostname=ip) as ssock:
+            with _tls_context().wrap_socket(sock, server_hostname=hostname or ip) as ssock:
                 version = ssock.version() or ""
                 cipher_name, _, cipher_bits = ssock.cipher() or ("", "", 0)
                 der_bytes = ssock.getpeercert(binary_form=True)

--- a/tests/unit/test_historical_urls.py
+++ b/tests/unit/test_historical_urls.py
@@ -252,6 +252,30 @@ class TestAnalyze:
         assert len(objs) == 1
         assert objs[0].scheme == "https"
 
+    def test_drops_out_of_scope_urls(self):
+        sess = self._session()
+        urls = [
+            "https://example.com/page",
+            "https://cid.karnataka.gov.in/cyber-crime",
+            "https://linkedin.com/company/example",
+            "https://aws.amazon.com/console",
+            "https://sub.example.com/api",
+        ]
+        objs = analyze(sess, urls)
+        hosts = {o.host for o in objs}
+        assert hosts == {"example.com", "sub.example.com"}
+        assert "cid.karnataka.gov.in" not in hosts
+        assert "linkedin.com" not in hosts
+        assert "aws.amazon.com" not in hosts
+
+    def test_keeps_subdomains_of_target(self):
+        sess = self._session()
+        objs = analyze(sess, [
+            "https://app.example.com/login",
+            "https://api.example.com/v1/data",
+        ])
+        assert len(objs) == 2
+
 
 # ---------------------------------------------------------------------------
 # Scanner

--- a/tests/unit/test_historical_urls.py
+++ b/tests/unit/test_historical_urls.py
@@ -302,7 +302,7 @@ class TestScanner:
         sess = self._session()
         Subdomain.objects.create(
             session=sess, domain="example.com",
-            subdomain="www.example.com", source="subfinder",
+            subdomain="www.example.com", source="subfinder", is_active=True,
         )
         captured = {}
 
@@ -320,7 +320,7 @@ class TestScanner:
         sess = self._session()
         Subdomain.objects.create(
             session=sess, domain="example.com",
-            subdomain="blog.example.com", source="subfinder",
+            subdomain="blog.example.com", source="subfinder", is_active=True,
         )
         captured = {}
 
@@ -340,7 +340,7 @@ class TestScanner:
         sess = self._session()
         Subdomain.objects.create(
             session=sess, domain="example.com",
-            subdomain="blog.example.com", source="subfinder",
+            subdomain="blog.example.com", source="subfinder", is_active=True,
         )
         fake_urls = ["https://blog.example.com/old-post", "https://blog.example.com/api/v1"]
 
@@ -355,7 +355,7 @@ class TestScanner:
         sess = self._session()
         Subdomain.objects.create(
             session=sess, domain="example.com",
-            subdomain="sub.example.com", source="subfinder",
+            subdomain="sub.example.com", source="subfinder", is_active=True,
         )
         with patch("apps.historical_urls.scanner.collect", return_value=[]):
             result = run_historical_urls(sess)
@@ -367,7 +367,7 @@ class TestScanner:
         # apex domain recorded as a subdomain row (subfinder/amass emit this)
         Subdomain.objects.create(
             session=sess, domain="example.com",
-            subdomain="example.com", source="subfinder",
+            subdomain="example.com", source="subfinder", is_active=True,
         )
         captured = {}
 

--- a/tests/unit/test_katana.py
+++ b/tests/unit/test_katana.py
@@ -180,6 +180,29 @@ class TestKatanaAnalyzer:
         sess, _, _ = _make_session_with_assets()
         assert analyze(sess, []) == []
 
+    def test_drops_out_of_scope_urls(self):
+        sess, _, _ = _make_session_with_assets()
+        records = [
+            {"request": {"endpoint": "https://example.com/page"}},
+            {"request": {"endpoint": "https://cid.karnataka.gov.in/cyber-crime"}},
+            {"request": {"endpoint": "https://linkedin.com/company/example"}},
+            {"request": {"endpoint": "https://sub.example.com/api"}},
+        ]
+        objs = analyze(sess, records)
+        hosts = {o.host for o in objs}
+        assert hosts == {"example.com", "sub.example.com"}
+        assert "cid.karnataka.gov.in" not in hosts
+        assert "linkedin.com" not in hosts
+
+    def test_keeps_subdomains_of_target(self):
+        sess, _, _ = _make_session_with_assets()
+        records = [
+            {"request": {"endpoint": "https://app.example.com/login"}},
+            {"request": {"endpoint": "https://api.example.com/v1/data"}},
+        ]
+        objs = analyze(sess, records)
+        assert len(objs) == 2
+
 
 from apps.katana.scanner import run_katana
 


### PR DESCRIPTION
  Summary

  - Scope boundary fix: katana and historical_urls analyzers now drop any URL whose host is not the target domain or a subdomain
  of it (_in_scope() check) — prevents external site findings (Karnataka govt, LinkedIn, AWS etc.) being stored as customer assets
  - katana -field-scope rdn: stops katana crawling external sites at source during the crawl phase, fixing scans hitting the
  4-hour watchdog timeout and ending as Partial
  - historical_urls is_active=True: only queries subdomains that have DNS resolution — inactive subdomains have no live web
  presence so querying Wayback Machine for them adds noise with no value
  - Full Scan as default: Full Scan (19 tools, network + web layer) is now the default workflow — gives the complete external
  attacker view which is right for any customer with a web presence
  - TLS SNI fix: tls_checker was sending the raw IP address as SNI during the TLS handshake — shared hosting platforms (Framer,
  Webflow, Shopify) return their platform wildcard cert (*.framer.app) instead of the customer cert, producing a false HIGH SAN
  mismatch finding

  Test plan

  - [ ] Run full scan on a domain hosted on shared hosting (Framer/Webflow) — confirm no SAN mismatch finding
  - [ ] Run full scan on a domain with blog content linking to external sites — confirm 0 external site findings
  - [ ] Confirm scan completes as Completed (not Partial) within time limit
  - [ ] Confirm Full Scan is selected by default on new scan