### PR TITLE
fix: make Full Scan the default workflow again + complete its tool set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,7 +551,8 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_insights_builder.py` | 4 | FindingTypeSummary prune only when aggregation_complete |
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_workflow_runner.py` | 31 | run_workflow, service_detection injection, step failure, cancellation, phase parallelism |
+| `tests/unit/test_default_workflow.py` | 4 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1047 tests** (1006 fast + 41 slow domain_security)
+**Total: 1051 tests** (1010 fast + 41 slow domain_security)

--- a/apps/core/workflows/migrations/0021_set_full_scan_default_and_complete.py
+++ b/apps/core/workflows/migrations/0021_set_full_scan_default_and_complete.py
@@ -1,0 +1,66 @@
+"""Make 'Full Scan' the default workflow and bring it up to the full tool set.
+
+Context: 0017 had set 'Infra Scan' (non-web only) as the default. Product
+decision is to default to the complete Full Scan again. Existing databases
+still carry the older Full Scan (created by 0010 before its tool list was
+expanded, + nuclei_network from 0020), so this migration also fills in any
+canonical tools Full Scan is missing.
+
+Additive and idempotent: only tools not already present are appended (enabled),
+so a user who customised Full Scan keeps their toggles. Execution order is
+unaffected — the runner groups tools by registry phase, so appended steps still
+run in the correct phase regardless of their `order` value. service_detection is
+omitted deliberately: it is a core tool auto-injected by the runner (see 0015).
+"""
+
+from django.db import migrations
+
+# Canonical Full Scan tool set (18 non-core tools, in pipeline phase order).
+_FULL_SCAN_TOOLS = [
+    "domain_security", "subfinder", "amass", "alterx", "dnsx",
+    "takeover_check", "cloud_assets", "naabu", "nmap", "tls_checker",
+    "ssh_checker", "nuclei_network", "httpx", "historical_urls", "katana",
+    "nuclei", "web_checker", "cve_intel",
+]
+
+
+def set_full_scan_default(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+
+    wf = Workflow.objects.filter(name="Full Scan").first()
+    if wf is None:
+        return  # defensive: nothing to promote
+
+    # Fill in any missing canonical tools, appended after the current max order.
+    existing = set(wf.steps.values_list("tool", flat=True))
+    next_order = (wf.steps.order_by("-order").values_list("order", flat=True).first() or 0) + 1
+    for tool in _FULL_SCAN_TOOLS:
+        if tool not in existing:
+            WorkflowStep.objects.create(workflow=wf, tool=tool, order=next_order, enabled=True)
+            next_order += 1
+
+    # Exactly one default.
+    Workflow.objects.exclude(pk=wf.pk).update(is_default=False)
+    Workflow.objects.filter(pk=wf.pk).update(is_default=True)
+
+
+def restore_infra_scan_default(apps, schema_editor):
+    # Reverse only flips the default back to Infra Scan; appended steps are
+    # harmless while Full Scan is not the default and are left in place.
+    Workflow = apps.get_model("workflow", "Workflow")
+    infra = Workflow.objects.filter(name="Infra Scan").first()
+    if infra is None:
+        return
+    Workflow.objects.exclude(pk=infra.pk).update(is_default=False)
+    Workflow.objects.filter(pk=infra.pk).update(is_default=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflow", "0020_add_nuclei_network_to_full_scan"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_full_scan_default, restore_infra_scan_default),
+    ]

--- a/tests/unit/test_default_workflow.py
+++ b/tests/unit/test_default_workflow.py
@@ -1,0 +1,58 @@
+"""The default workflow is 'Full Scan' with the complete tool set (migration 0021)."""
+
+import pytest
+
+
+_EXPECTED_FULL_SCAN = {
+    "domain_security", "subfinder", "amass", "alterx", "dnsx",
+    "takeover_check", "cloud_assets", "naabu", "nmap", "tls_checker",
+    "ssh_checker", "nuclei_network", "httpx", "historical_urls", "katana",
+    "nuclei", "web_checker", "cve_intel",
+}
+
+
+@pytest.mark.django_db
+def test_default_is_full_scan():
+    from apps.core.workflows.models import Workflow
+    default = Workflow.objects.get(is_default=True)
+    assert default.name == "Full Scan"
+
+
+@pytest.mark.django_db
+def test_exactly_one_default():
+    from apps.core.workflows.models import Workflow
+    assert Workflow.objects.filter(is_default=True).count() == 1
+
+
+@pytest.mark.django_db
+def test_full_scan_has_complete_tool_set():
+    from apps.core.workflows.models import Workflow
+    wf = Workflow.objects.get(name="Full Scan")
+    tools = set(wf.steps.values_list("tool", flat=True))
+    assert _EXPECTED_FULL_SCAN <= tools, f"missing: {_EXPECTED_FULL_SCAN - tools}"
+
+
+@pytest.mark.django_db
+def test_forward_is_idempotent_and_fills_gaps():
+    """Re-running the promotion on a partial Full Scan adds only missing tools."""
+    import importlib
+    from django.apps import apps as django_apps
+    from apps.core.workflows.models import Workflow, WorkflowStep
+
+    _0021 = importlib.import_module(
+        "apps.core.workflows.migrations.0021_set_full_scan_default_and_complete"
+    )
+
+    wf = Workflow.objects.get(name="Full Scan")
+    # Simulate an older/partial Full Scan: keep only three tools.
+    WorkflowStep.objects.filter(workflow=wf).exclude(
+        tool__in=["domain_security", "subfinder", "httpx"]
+    ).delete()
+    assert wf.steps.count() == 3
+
+    _0021.set_full_scan_default(django_apps, None)
+
+    tools = set(wf.steps.values_list("tool", flat=True))
+    assert _EXPECTED_FULL_SCAN <= tools
+    # no duplicates introduced
+    assert wf.steps.count() == len(set(wf.steps.values_list("tool", flat=True)))


### PR DESCRIPTION
Follow-up to the #235 discussion: the default workflow was **Infra Scan** (non-web, set in `0017`), not Full Scan. Product decision: **default to the complete Full Scan.**

## What migration 0021 does
- **Promotes Full Scan to default** (demotes Infra Scan) — applies to existing databases too, not just fresh installs.
- **Fills in missing canonical tools** on Full Scan (existing DBs carried the older 10-tool + nuclei_network version). Additive + idempotent: only tools not already present are appended as enabled, so a user who customised Full Scan keeps their toggles.
- Execution order is unaffected — the runner groups tools by registry **phase**, so appended steps still run in the right phase regardless of `order`. `service_detection` is intentionally omitted (core, auto-injected — see 0015).

## Why additive, not a rebuild
Rebuilding steps would reset any user customisation. Appending is safe because phase-grouping in the runner makes step `order` irrelevant across phases.

## Tests
+`test_default_workflow.py` (4): default is Full Scan, exactly one default, complete tool set, idempotent gap-fill. 1010 fast pass. CLAUDE.md 1047 → 1051. This also makes reality match CLAUDE.md, which already described Full Scan as the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)