### PR TITLE
fix: cap PDF endpoints at 50/finding to prevent OOM on large scans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,7 +534,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_nuclei_network.py` | 28 | Network-template parsing, non-web targeting, collector |
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
 | `tests/unit/test_qcluster_config.py` | 4 | Django-Q cluster config |
-| `tests/unit/test_reports.py` | 36 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block |
+| `tests/unit/test_reports.py` | 37 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block |
 | `tests/unit/test_waf_detection.py` | 16 | WAF/block/challenge classifier (spec C1) — vendor fingerprint, false-positive guards, analyzer wiring |
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
@@ -555,4 +555,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1051 tests** (1010 fast + 41 slow domain_security)
+**Total: 1067 tests** (1026 fast + 41 slow domain_security)

--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -307,10 +307,13 @@ def _group_findings_by_issue(findings):
                 if c and c not in cves:
                     cves.append(c)
         grp["cves"] = cves
-        # Affected endpoints as a pill grid (3 per row) — xhtml2pdf renders
-        # bordered table cells reliably but not inline-block spans.
+        # Affected endpoints as a pill grid (3 per row). Capped at 50 per group
+        # to prevent OOM when a single finding fires on thousands of URLs.
         endpoints = [(f.url.url if f.url else f.target) for f in grp["instances"]]
-        grp["endpoint_rows"] = [endpoints[i:i + 3] for i in range(0, len(endpoints), 3)]
+        cap = 50
+        shown = endpoints[:cap]
+        grp["endpoint_rows"] = [shown[i:i + 3] for i in range(0, len(shown), 3)]
+        grp["endpoint_overflow"] = max(0, len(endpoints) - cap)
     return result
 
 

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -254,6 +254,7 @@
       <table class="ep-grid">
         {% for row in g.endpoint_rows %}<tr>{% for ep in row %}<td class="ep-cell">{{ ep }}</td>{% endfor %}</tr>{% endfor %}
       </table>
+      {% if g.endpoint_overflow %}<p style="font-size:0.8em;color:#666;margin:4px 0 0;">… and {{ g.endpoint_overflow }} more endpoint{{ g.endpoint_overflow|pluralize }} (see CSV export for full list)</p>{% endif %}
     </td></tr>
   </table>
 

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -368,6 +368,20 @@ class TestFindingGrouping:
         base.update(kw)
         return Finding.objects.create(**base)
 
+    def test_endpoints_capped_at_50_with_overflow(self, db, session):
+        """A finding firing on thousands of targets caps shown endpoints at 50
+        (OOM guard) and records the overflow count for the 'N more' note."""
+        from apps.core.reports.views import _group_findings_by_issue
+        from apps.core.findings.models import Finding
+        for i in range(120):
+            self._mk(session, target=f"10.0.0.{i}:443",
+                     title=f"Unencrypted HTTPS on 10.0.0.{i}:443")
+        findings = Finding.objects.filter(session=session)
+        grp = _group_findings_by_issue(findings)[0]
+        shown = sum(len(row) for row in grp["endpoint_rows"])
+        assert shown == 50
+        assert grp["endpoint_overflow"] == 70
+
     def test_identical_writeups_collapse_and_strip_target(self, db, session):
         from apps.core.reports.views import _group_findings_by_issue
         from apps.core.findings.models import Finding


### PR DESCRIPTION
Tier-1 extraction from @vennela-cybersecify's un-PR'd `fix/pdf-oom-endpoint-cap` branch (her authorship preserved).

## Real bug
Scanning **hdfcbank.com (270k URLs, 976 findings)** OOM-killed gunicorn during PDF generation — WeasyPrint ran out of memory rendering every endpoint pill for findings that fire on thousands of URLs.

## Fix
Cap shown endpoints at **50 per finding group**, render "… and N more endpoints (see CSV export for full list)" below the table. Full list stays available via CSV export. Touches `_group_findings_by_issue` + the template — coexists cleanly with the coverage block.

I added a test locking the 50-cap + overflow count (her commit had none). 1026 fast pass; CLAUDE.md total reconciled to 1067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)