### PR TITLE
fix: resolve CodeQL alerts in CDN exclusion code

### DIFF
--- a/apps/core/utils/cdn.py
+++ b/apps/core/utils/cdn.py
@@ -111,7 +111,9 @@ def _cdn_networks() -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]
         try:
             nets.append(ipaddress.ip_network(cidr, strict=False))
         except ValueError:
-            pass
+            # Skip a malformed entry in the hardcoded list rather than break
+            # every scan — a bad CIDR here is a typo, not runtime input.
+            continue
     return tuple(nets)
 
 

--- a/tests/unit/test_tls_checker.py
+++ b/tests/unit/test_tls_checker.py
@@ -1010,7 +1010,7 @@ class TestTlsCheckerCdnExclusion:
         sess = self._make_session_with_cdn_ip()
         with patch("apps.tls_checker.collector._probe_tls") as mock_probe:
             with patch("apps.tls_checker.collector._probe_tls_details") as mock_details:
-                results = collect(sess)
+                collect(sess)
         mock_probe.assert_not_called()
         mock_details.assert_not_called()
 


### PR DESCRIPTION
Cleans the two CodeQL alerts flagged on #237 (both code-quality, not security):
- `cdn.py:113` — bare `except: pass` → `continue` + comment (skip a malformed hardcoded CIDR rather than break every scan).
- `test_tls_checker.py:1013` — dropped unused `results` assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)