### PR TITLE
fix: takeover + alterx false-positive fixes

### DIFF
--- a/apps/alterx/scanner.py
+++ b/apps/alterx/scanner.py
@@ -1,4 +1,8 @@
 import logging
+import secrets
+
+import dns.exception
+import dns.resolver
 
 from apps.core.assets.models import Subdomain
 
@@ -6,6 +10,26 @@ from .analyzer import analyze
 from .collector import collect
 
 logger = logging.getLogger(__name__)
+
+
+def _has_wildcard_dns(domain: str) -> bool:
+    """Return True if domain answers wildcard queries (any random hostname resolves).
+
+    Cloudflare and similar CDNs respond to *.domain — so alterx permutations
+    all resolve even though the subdomains don't exist. When detected, the
+    scanner skips alterx to avoid flooding the pipeline with fake hosts.
+    """
+    probe = f"openeasd-wc-{secrets.token_hex(6)}.{domain}"
+    try:
+        dns.resolver.resolve(probe, "A")
+        return True
+    except (
+        dns.resolver.NXDOMAIN,
+        dns.resolver.NoAnswer,
+        dns.exception.Timeout,
+        dns.exception.DNSException,
+    ):
+        return False
 
 
 def run_alterx(session) -> list[Subdomain]:
@@ -17,6 +41,15 @@ def run_alterx(session) -> list[Subdomain]:
 
     if not subdomains:
         logger.info(f"[alterx:{session.id}] no subdomains to permute")
+        return []
+
+    if _has_wildcard_dns(session.domain):
+        logger.warning(
+            "[alterx:%s] wildcard DNS detected for %s — skipping permutations "
+            "(random hostname resolved; all alterx results would be false positives)",
+            session.id,
+            session.domain,
+        )
         return []
 
     raw = collect(subdomains)

--- a/apps/takeover_check/analyzer.py
+++ b/apps/takeover_check/analyzer.py
@@ -75,6 +75,14 @@ def analyze(session, records: list[dict]) -> list[Finding]:
         seen.add(subdomain_name)
 
         service = _service_of(record)
+        if service == "unknown":
+            logger.info(
+                "[takeover_check:%s] Skipping %s — subzy returned no fingerprint",
+                session.id,
+                subdomain_name,
+            )
+            continue
+
         subdomain_fk = subdomain_index.get(subdomain_name)
 
         findings.append(Finding(

--- a/tests/unit/test_alterx.py
+++ b/tests/unit/test_alterx.py
@@ -136,6 +136,13 @@ class TestScanner:
         from apps.core.scans.models import ScanSession
         return ScanSession.objects.create(domain="example.com", scan_type="full")
 
+    def _subdomain(self, session, name):
+        from apps.core.assets.models import Subdomain
+        return Subdomain.objects.create(
+            session=session, domain="example.com",
+            subdomain=name, source="subfinder",
+        )
+
     def test_no_subdomains_returns_empty_without_calling_collect(self):
         sess = self._session()
         with patch("apps.alterx.scanner.collect") as mock_collect:
@@ -144,44 +151,53 @@ class TestScanner:
         mock_collect.assert_not_called()
 
     def test_passes_existing_subdomain_names_to_collect(self):
-        from apps.core.assets.models import Subdomain
         sess = self._session()
-        Subdomain.objects.create(
-            session=sess, domain="example.com",
-            subdomain="api.example.com", source="subfinder",
-        )
+        self._subdomain(sess, "api.example.com")
         captured = {}
 
         def fake_collect(subdomains):
             captured["subdomains"] = subdomains
             return []
 
-        with patch("apps.alterx.scanner.collect", side_effect=fake_collect):
-            run_alterx(sess)
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", side_effect=fake_collect):
+                run_alterx(sess)
 
         assert "api.example.com" in captured["subdomains"]
 
     def test_saves_permutations_and_returns_them(self):
         from apps.core.assets.models import Subdomain
         sess = self._session()
-        Subdomain.objects.create(
-            session=sess, domain="example.com",
-            subdomain="api.example.com", source="subfinder",
-        )
+        self._subdomain(sess, "api.example.com")
 
-        with patch("apps.alterx.scanner.collect", return_value=["api-dev.example.com", "api2.example.com"]):
-            result = run_alterx(sess)
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", return_value=["api-dev.example.com", "api2.example.com"]):
+                result = run_alterx(sess)
 
         assert Subdomain.objects.filter(session=sess, source="alterx").count() == 2
         assert len(result) == 2
 
     def test_returns_empty_when_collect_returns_nothing(self):
-        from apps.core.assets.models import Subdomain
         sess = self._session()
-        Subdomain.objects.create(
-            session=sess, domain="example.com",
-            subdomain="api.example.com", source="subfinder",
-        )
-        with patch("apps.alterx.scanner.collect", return_value=[]):
-            result = run_alterx(sess)
+        self._subdomain(sess, "api.example.com")
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", return_value=[]):
+                result = run_alterx(sess)
         assert result == []
+
+    def test_skips_collect_when_wildcard_dns_detected(self):
+        sess = self._session()
+        self._subdomain(sess, "api.example.com")
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=True):
+            with patch("apps.alterx.scanner.collect") as mock_collect:
+                result = run_alterx(sess)
+        assert result == []
+        mock_collect.assert_not_called()
+
+    def test_runs_collect_when_no_wildcard_dns(self):
+        sess = self._session()
+        self._subdomain(sess, "api.example.com")
+        with patch("apps.alterx.scanner._has_wildcard_dns", return_value=False):
+            with patch("apps.alterx.scanner.collect", return_value=[]) as mock_collect:
+                run_alterx(sess)
+        mock_collect.assert_called_once()

--- a/tests/unit/test_takeover_check.py
+++ b/tests/unit/test_takeover_check.py
@@ -125,18 +125,24 @@ class TestAnalyze:
     def test_links_subdomain_fk_when_session_has_match(self):
         sess = self._session()
         sub = self._subdomain(sess, "blog.example.com")
-        records = [{"subdomain": "blog.example.com", "vulnerable": True}]
+        records = [{"subdomain": "blog.example.com", "vulnerable": True, "service": "GitHub Pages"}]
         findings = analyze(sess, records)
         assert findings[0].subdomain_id == sub.id
 
     def test_no_subdomain_fk_when_session_missing_match(self):
         sess = self._session()
-        # Note: no Subdomain row created
-        records = [{"subdomain": "blog.example.com", "vulnerable": True}]
+        # No Subdomain row created, but service is known — finding still created
+        records = [{"subdomain": "blog.example.com", "vulnerable": True, "service": "GitHub Pages"}]
         findings = analyze(sess, records)
         assert findings[0].subdomain is None
-        # But target field still populated for free-floating findings
         assert findings[0].target == "blog.example.com"
+
+    def test_skips_record_with_unknown_service(self):
+        sess = self._session()
+        # subzy returned no fingerprint — "unknown" service must not become a finding
+        records = [{"subdomain": "blog.example.com", "vulnerable": True}]
+        findings = analyze(sess, records)
+        assert findings == []
 
     def test_dedupes_by_subdomain_name(self):
         sess = self._session()


### PR DESCRIPTION
Tier-2 extraction from @vennela-cybersecify's #224 (her authorship). The last two clean fixes from that branch — the CDN part shipped in #237; the `ACTIVE_SCANNING_ENABLED` flag stays parked pending a product decision.

**Validated each (correctness + app-goal fit — false-positive reduction):**
- **Skip takeover on unknown service** — subzy flags "vulnerable" with `service=unknown` when it can't fingerprint the takeover target; that's the highest-FP class for a high-severity finding. Only confirmed-service takeovers become findings now.
- **Skip alterx on wildcard DNS** — textbook detection (resolve a random `openeasd-wc-<hex>.domain`; if it answers, `*.domain` is live), then skip alterx so permutations don't flood the pipeline with phantom subdomains. Fails open on timeout.

Both wired and tested (55 takeover/alterx tests pass; full fast suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)