### PR TITLE
feat: report 'Fix First' priority block + surface EPSS/KEV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,7 +534,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_nuclei_network.py` | 28 | Network-template parsing, non-web targeting, collector |
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
 | `tests/unit/test_qcluster_config.py` | 4 | Django-Q cluster config |
-| `tests/unit/test_reports.py` | 37 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block |
+| `tests/unit/test_reports.py` | 41 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block |
 | `tests/unit/test_waf_detection.py` | 16 | WAF/block/challenge classifier (spec C1) — vendor fingerprint, false-positive guards, analyzer wiring |
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
@@ -555,4 +555,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1067 tests** (1026 fast + 41 slow domain_security)
+**Total: 1078 tests** (1037 fast + 41 slow domain_security)

--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -307,6 +307,13 @@ def _group_findings_by_issue(findings):
                 if c and c not in cves:
                     cves.append(c)
         grp["cves"] = cves
+        # Threat intel rollup from cve_intel (extra: cisa_kev / epss_score /
+        # epss_percentile). KEV = at least one CVE is on CISA's actively-exploited
+        # list; EPSS percentile is the highest across the group's CVEs.
+        dict_extras = [f.extra for f in grp["instances"] if isinstance(f.extra, dict)]
+        grp["cisa_kev"] = any(e.get("cisa_kev") for e in dict_extras)
+        pctls = [e.get("epss_percentile") for e in dict_extras if e.get("epss_percentile") is not None]
+        grp["epss_percentile"] = max(pctls) if pctls else None
         # Affected endpoints as a pill grid (3 per row). Capped at 50 per group
         # to prevent OOM when a single finding fires on thousands of URLs.
         endpoints = [(f.url.url if f.url else f.target) for f in grp["instances"]]
@@ -315,6 +322,52 @@ def _group_findings_by_issue(findings):
         grp["endpoint_rows"] = [shown[i:i + 3] for i in range(0, len(shown), 3)]
         grp["endpoint_overflow"] = max(0, len(endpoints) - cap)
     return result
+
+
+# Plain-language business risk for the headline "Fix First" block — spoken to a
+# decision-maker, not an engineer. Keyed by check_type; severity fallback below.
+_BUSINESS_IMPACT = {
+    "unencrypted_service": "Data to this service crosses the internet in plaintext — anyone on the network path can read it.",
+    "subdomain_takeover": "An attacker can claim this dangling subdomain and serve content under your name — phishing, malware, or session-cookie theft.",
+    "missing_csp": "A single injected script would run in your users' browsers (cross-site scripting).",
+    "cve": "A publicly known vulnerability with a documented exploit is reachable from the internet.",
+    "dnssec": "DNS answers for your domain can be forged, silently redirecting users to attacker servers.",
+    "dmarc": "Anyone can send email that appears to come from your domain — brand and phishing risk.",
+    "mta_sts": "Email to your mail servers can be forced down to plaintext and intercepted in transit.",
+    "rdap": "Your domain registration lapses soon — expiry means outage and a hijack window.",
+}
+_BUSINESS_IMPACT_BY_SEV = {
+    "critical": "Directly exploitable from the internet and high-impact — treat as urgent.",
+    "high": "A serious weakness an external attacker can leverage.",
+}
+_SEV_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+
+
+def _priority_score(grp) -> float:
+    """Rank findings for the 'Fix First' block: severity first, then measured
+    CVSS, with a dominant boost for actively-exploited (CISA KEV) issues and a
+    nudge for high EPSS (exploit-probability)."""
+    score = _SEV_RANK.get(grp["severity"], 0) * 100
+    score += (grp.get("cvss") or 0) * 5
+    if grp.get("cisa_kev"):
+        score += 500  # actively exploited in the wild dominates the ranking
+    if grp.get("epss_percentile"):
+        score += grp["epss_percentile"] * 50
+    return score
+
+
+def _top_risks(groups, limit=5):
+    """The decision-maker's shortlist: critical/high (or actively-exploited)
+    issues, ranked by priority, each with a plain-language impact line."""
+    candidates = [
+        g for g in groups
+        if g["severity"] in ("critical", "high") or g.get("cisa_kev")
+    ]
+    ranked = sorted(candidates, key=_priority_score, reverse=True)[:limit]
+    for g in ranked:
+        g["impact"] = _BUSINESS_IMPACT.get(g["check_type"]) or \
+            _BUSINESS_IMPACT_BY_SEV.get(g["severity"], "")
+    return ranked
 
 
 def _render_pdf(html: str) -> bytes:
@@ -430,6 +483,7 @@ def export_scan_pdf(request, session_uuid):
         "total_findings": len(issue_groups),   # headline = unique issue count
         "raw_total": raw_total,                # raw detections, shown only in the note
         "risk_rating": risk_rating,
+        "top_risks": _top_risks(issue_groups),
         "coverage": _coverage_context(session),
         "asset_counts": asset_counts,
         "methodology": methodology,

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -169,6 +169,30 @@
 </div>
 {% endif %}
 
+{% if top_risks %}
+<div class="h2">Priority Actions — Fix These First</div>
+<p class="lead">The highest-impact issues, ranked. Actively-exploited (CISA KEV) and internet-facing critical issues come first. The full list is in Section 3.</p>
+<table class="grid">
+  <thead><tr>
+    <th style="width:5%;">#</th><th style="width:36%;">Issue</th>
+    <th style="width:47%;">Why it matters</th><th style="width:12%;">Severity</th>
+  </tr></thead>
+  <tbody>
+    {% for r in top_risks %}
+    <tr>
+      <td><strong>{{ forloop.counter }}</strong></td>
+      <td>
+        <strong>{{ r.title }}</strong>{% if r.cisa_kev %} <span class="badge" style="background:#c92a2a;">Actively Exploited</span>{% endif %}
+        <div style="font-size:8px;color:#888;margin-top:2px;">{{ r.scope }} · {{ r.instances|length }} host{{ r.instances|length|pluralize }}</div>
+      </td>
+      <td style="font-size:9px;line-height:1.4;">{{ r.impact }}</td>
+      <td><span class="badge bg-{{ r.severity }}">{{ r.severity|upper }}</span>{% if r.cvss %} <span style="font-size:8px;color:#888;">{{ r.cvss }}</span>{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 <div class="h2">Severity Distribution</div>
 <table class="tiles"><tr>
   <td><div class="n">{{ total_findings }}</div><div class="l">Total Findings</div></td>
@@ -216,7 +240,7 @@
     {% for g in issue_groups %}
     <tr>
       <td style="white-space:nowrap; word-break:normal;">{{ g.fid }}</td>
-      <td><strong>{{ g.title }}</strong></td>
+      <td><strong>{{ g.title }}</strong>{% if g.cisa_kev %} <span class="badge" style="background:#c92a2a;">KEV</span>{% endif %}</td>
       <td>{{ g.scope }}</td>
       <td><span class="badge bg-{{ g.severity }}">{{ g.severity|upper }}</span></td>
       <td>{% if g.cvss %}{{ g.cvss }}{% else %}—{% endif %}</td>
@@ -250,6 +274,7 @@
     <tr><th>Category</th><td>{% if g.cwe %}{{ g.cwe }}{% else %}—{% endif %}</td></tr>
     <tr><th>Source / Check</th><td><span style="font-family:'Courier New',monospace;">{{ g.source }} · {{ g.check_type }}</span></td></tr>
     {% if g.cves %}<tr><th>CVEs</th><td><span style="font-family:'Courier New',monospace;">{{ g.cves|join:", " }}</span></td></tr>{% endif %}
+    {% if g.cisa_kev or g.epss_percentile %}<tr><th>Exploitation</th><td>{% if g.cisa_kev %}<span class="badge" style="background:#c92a2a;">CISA KEV — Actively Exploited</span> {% endif %}{% if g.epss_percentile %}EPSS {{ g.epss_percentile|floatformat:2 }} percentile{% endif %}</td></tr>{% endif %}
     <tr><th>Affected Endpoints</th><td style="padding:4px 6px;">
       <table class="ep-grid">
         {% for row in g.endpoint_rows %}<tr>{% for ep in row %}<td class="ep-cell">{{ ep }}</td>{% endfor %}</tr>{% endfor %}

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -354,6 +354,68 @@ class TestPdfSeverityCounts:
         assert "3 raw scanner detections into 1 unique issue" in html
 
 
+class TestTopRisksAndIntel:
+    """The 'Fix First' block ranks by priority (KEV dominates) and the report
+    surfaces EPSS/KEV threat intel collected by cve_intel."""
+
+    def _mk(self, session, **kw):
+        from apps.core.findings.models import Finding
+        base = dict(
+            session=session, source="tls_checker", check_type="unencrypted_service",
+            severity="critical", target="1.1.1.1:5432", description="d", remediation="r",
+            status="open", title="Unencrypted POSTGRESQL", extra={},
+        )
+        base.update(kw)
+        return Finding.objects.create(**base)
+
+    def _groups(self, session):
+        from apps.core.reports.views import _group_findings_by_issue
+        from apps.core.findings.models import Finding
+        return _group_findings_by_issue(Finding.objects.filter(session=session))
+
+    def test_epss_kev_rollup_onto_group(self, db, session):
+        self._mk(session, source="nmap", check_type="cve", title="OpenSSL CVE",
+                 extra={"cisa_kev": True, "epss_percentile": 0.97})
+        grp = self._groups(session)[0]
+        assert grp["cisa_kev"] is True
+        assert grp["epss_percentile"] == 0.97
+
+    def test_kev_outranks_non_kev_critical(self, db, session):
+        from apps.core.reports.views import _top_risks
+        self._mk(session, title="Plain critical", extra={})
+        self._mk(session, source="nmap", check_type="cve", severity="medium",
+                 title="Exploited medium", target="2.2.2.2:80",
+                 extra={"cisa_kev": True, "epss_percentile": 0.99})
+        top = _top_risks(self._groups(session))
+        assert top[0]["title"] == "Exploited medium"  # KEV dominates severity
+        assert top[0]["impact"]  # plain-language line attached
+
+    def test_top_risks_excludes_low_medium_noise(self, db, session):
+        from apps.core.reports.views import _top_risks
+        self._mk(session, title="Crit", extra={})
+        self._mk(session, severity="low", check_type="missing_referrer_policy",
+                 title="Low thing", target="x", extra={})
+        titles = [g["title"] for g in _top_risks(self._groups(session))]
+        assert "Crit" in titles
+        assert "Low thing" not in titles  # low/medium without KEV are not "fix first"
+
+    def test_report_renders_fix_first_and_kev_badge(self, authed_client, session):
+        self._mk(session, source="nmap", check_type="cve", title="Exploited CVE",
+                 extra={"cisa_kev": True, "epss_percentile": 0.98})
+        captured = {}
+
+        def cap(html):
+            captured["html"] = html
+            return b"%PDF-1.7"
+
+        with patch("apps.core.reports.views._render_pdf", side_effect=cap):
+            res = authed_client.get(f"/reports/{session.uuid}/pdf/")
+        assert res.status_code == 200
+        assert "Priority Actions" in captured["html"]
+        assert "KEV" in captured["html"]
+
+
+@pytest.mark.django_db
 class TestFindingGrouping:
     """Repeated issues (identical write-up across targets) collapse into one
     block with a table of affected targets, instead of one full card each."""


### PR DESCRIPTION
Improves the **report generator** (every new scan gets it — not a one-off edit) so the output reads like a consultant's read, not a scanner dump.

## 1. Executive 'Priority Actions — Fix These First'
Ranks the top critical/high (or actively-exploited) issues by a priority score — **CISA KEV dominates**, EPSS nudges, then severity/CVSS — each with a **plain-language business-impact line** aimed at a decision-maker ("anyone on the network path can read data to this service"), not an engineer.

## 2. Surface EPSS/KEV (already collected by cve_intel, never shown)
- **KEV badge** in the Findings Summary next to actively-exploited issues.
- **Exploitation row** (CISA KEV / EPSS percentile) in detailed cards.

Rendered a real sample: an actively-exploited HIGH CVE correctly ranks **#1 above a CRITICAL** unencrypted-Postgres finding, with an "Actively Exploited" badge explaining why — that's the judgment layer.

**No sales/upsell copy in the PDF** — OSS honesty; the report earns value by being genuinely good, not by pitching.

Tests: +`TestTopRisksAndIntel` (4) — ranking (KEV dominates), EPSS/KEV rollup, low/medium excluded from Fix-First, block+badge render. 1037 fast pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)