### PR TITLE
feat: DNSSEC chain-of-trust + MTA-STS + open-relay checks (domain_security)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,7 +519,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_cve_intel.py` | 24 | EPSS/KEV enrichment, CVE extraction (both finding shapes), feed-failure fallback |
 | `tests/unit/test_dnsx.py` | 21 | Public IP filter, analyzer, scanner |
 | `tests/unit/test_domain_authorization.py` | 9 | DomainAuthorization model + scan-entry gating |
-| `tests/unit/test_domain_security.py` | 41 | DNS/email/RDAP — **slow, real network** |
+| `tests/unit/test_domain_security.py` | 51 | DNS/email/RDAP — **slow, real network** |
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 12 | JSON parser, Port lookup, Subdomain link, honest UA |
@@ -555,4 +555,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1078 tests** (1037 fast + 41 slow domain_security)
+**Total: 1088 tests** (1037 fast + 51 slow domain_security)

--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -44,6 +44,7 @@ _SCOPE_BY_SOURCE = {
 }
 _SCOPE_BY_CHECK = {
     "rdap": "Domain", "dns": "DNS", "caa": "DNS", "dnssec": "DNS",
+    "open_relay": "Email / DNS",
 }
 
 # CWE mapping per check_type. Unmapped check types render "—".
@@ -66,6 +67,15 @@ _CWE_BY_CHECK = {
     "dmarc": "CWE-358: Improperly Implemented Security Check for Standard",
     "spf": "CWE-358: Improperly Implemented Security Check for Standard",
     "dkim": "CWE-358: Improperly Implemented Security Check for Standard",
+    "dnssec": "CWE-346: Origin Validation Error",
+    "dns": "CWE-693: Protection Mechanism Failure",
+    "open_relay": "CWE-284: Improper Access Control",
+    "rdap": "CWE-284: Improper Access Control",
+    "sshv1_supported": "CWE-327: Use of a Broken or Risky Cryptographic Algorithm",
+    "weak_ssh_host_key": "CWE-326: Inadequate Encryption Strength",
+    "weak_ssh_cipher": "CWE-326: Inadequate Encryption Strength",
+    "ssh_password_auth": "CWE-287: Improper Authentication",
+    "ssh_root_login": "CWE-269: Improper Privilege Management",
 }
 
 

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -223,6 +223,88 @@ def _check_lame_delegation(session, domain, ns_records) -> list:
     return findings
 
 
+def _check_dnssec(session, domain) -> list:
+    """Full DNSSEC check: DNSKEY at domain + DS record at parent zone (chain of trust).
+
+    Three failure modes:
+    - Not configured: no DNSKEY, no DS → high
+    - Broken chain: DNSKEY present but DS not published at parent → high
+    - Signing removed: DS published but DNSKEY gone → high (causes resolution failures)
+    """
+    has_dnskey = False
+    has_ds = False
+
+    try:
+        resp = dns.resolver.resolve(domain, "DNSKEY")
+        has_dnskey = len(resp) > 0
+    except Exception:
+        pass
+
+    try:
+        resp = dns.resolver.resolve(domain, "DS")
+        has_ds = len(resp) > 0
+    except Exception:
+        pass
+
+    if not has_dnskey and not has_ds:
+        return [Finding(
+            session=session, source="domain_security", target=domain,
+            check_type="dnssec", severity="high",
+            title="DNSSEC not enabled",
+            description=(
+                f"{domain} has no DNSSEC configured. DNS responses can be forged — "
+                "an attacker can silently redirect users to malicious servers. "
+                "DNSSEC is mandatory for .bank.in domains under the RBI cybersecurity framework."
+            ),
+            remediation=(
+                "Enable DNSSEC at your domain registrar:\n"
+                "1. Enable DNSSEC signing in your DNS provider settings\n"
+                "2. Retrieve the DS record from your DNS provider\n"
+                "3. Publish the DS record at your registrar\n"
+                "The chain of trust must run: Root → TLD → your domain."
+            ),
+        )]
+
+    if has_dnskey and not has_ds:
+        return [Finding(
+            session=session, source="domain_security", target=domain,
+            check_type="dnssec", severity="high",
+            title="DNSSEC chain of trust broken — DS record not published",
+            description=(
+                f"{domain} has DNSKEY records but the DS record is not published at the "
+                "parent zone. The chain of trust is incomplete — DNSSEC validation fails "
+                "for validating resolvers, which may fall back to unvalidated responses."
+            ),
+            remediation=(
+                "Publish the DS record at your registrar to complete the chain of trust:\n"
+                "1. Retrieve the DS record from your DNS provider\n"
+                "2. Add it under DNSSEC settings at your registrar\n"
+                "Without the DS record, DNSSEC provides no protection."
+            ),
+            extra={"has_dnskey": True, "has_ds": False},
+        )]
+
+    if has_ds and not has_dnskey:
+        return [Finding(
+            session=session, source="domain_security", target=domain,
+            check_type="dnssec", severity="high",
+            title="DNSSEC misconfigured — DS published but DNSKEY missing",
+            description=(
+                f"{domain} has a DS record at the parent zone but no DNSKEY at the domain. "
+                "DNSSEC validation fails for all validating resolvers, making the domain "
+                "unreachable for users on DNSSEC-enforcing networks."
+            ),
+            remediation=(
+                "Either re-enable DNSSEC signing on your DNS provider so DNSKEY records "
+                "are published, or remove the DS record from your registrar if you intend "
+                "to disable DNSSEC. A DS record without a matching DNSKEY causes outages."
+            ),
+            extra={"has_dnskey": False, "has_ds": True},
+        )]
+
+    return []  # both present — DNSSEC correctly configured
+
+
 def _check_dns(session, domain) -> list:
     """Run all DNS checks and return list of DomainFinding objects (not yet saved)."""
     findings = []
@@ -262,20 +344,7 @@ def _check_dns(session, domain) -> list:
         ))
 
     # DNSSEC
-    try:
-        response = dns.resolver.resolve(domain, "DNSKEY")
-        has_dnssec = len(response) > 0
-    except Exception:
-        has_dnssec = False
-
-    if not has_dnssec:
-        findings.append(Finding(
-            session=session, source="domain_security", target=domain, check_type="dns",
-            severity="medium",
-            title="DNSSEC not enabled",
-            description=f"{domain} does not have DNSSEC configured.",
-            remediation="Enable DNSSEC at your domain registrar to prevent DNS spoofing.",
-        ))
+    findings += _check_dnssec(session, domain)
 
     # CAA records
     findings += _check_caa(session, domain)

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -14,6 +14,7 @@ used independently; it is NOT imported here.
 
 import datetime
 import logging
+import smtplib
 import time
 import urllib.parse
 
@@ -401,48 +402,146 @@ def _check_dkim(session, domain) -> list:
 
 
 def _check_mta_sts(session, domain) -> list:
-    """Check MTA-STS — enforces TLS for inbound email delivery."""
+    """Check MTA-STS — enforces TLS for inbound email delivery.
+
+    Two-step check per RFC 8461:
+    1. DNS TXT record at _mta-sts.domain must exist (signals policy presence)
+    2. Policy file at https://mta-sts.domain/.well-known/mta-sts.txt must be
+       reachable and have mode: enforce (mode is in the file, NOT the DNS record)
+    """
     findings = []
     mta_sts_records = _get_txt_record(f"_mta-sts.{domain}")
-    mta_sts = next((r for r in mta_sts_records if r.startswith("v=STSv1")), None)
+    mta_sts_dns = next((r for r in mta_sts_records if r.startswith("v=STSv1")), None)
 
-    if not mta_sts:
+    if not mta_sts_dns:
         findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
-            severity="medium",
+            severity="high",
             title="MTA-STS not configured",
             description=(
-                f"{domain} has no MTA-STS policy. Inbound email delivery is not protected "
-                "against TLS downgrade attacks — a MITM can force plaintext email delivery "
-                "even when your mail server supports TLS."
+                f"{domain} has no MTA-STS policy. Email delivery to your mail server is not "
+                "protected against TLS downgrade attacks — a network attacker between mail "
+                "servers can force plaintext delivery and intercept email in transit."
             ),
             remediation=(
-                f"1. Add TXT record at _mta-sts.{domain}: v=STSv1; id=<timestamp>\n"
-                f"2. Publish policy at https://mta-sts.{domain}/.well-known/mta-sts.txt\n"
-                "   Content: version: STSv1\\nmode: enforce\\nmx: mail.{domain}\\nmax_age: 86400"
+                f"1. Add DNS TXT record at _mta-sts.{domain}: v=STSv1; id=<timestamp>\n"
+                f"2. Host policy file at https://mta-sts.{domain}/.well-known/mta-sts.txt\n"
+                "   Content: version: STSv1\\nmode: enforce\\nmx: <your-mx-host>\\nmax_age: 86400"
             ),
         ))
-    else:
-        if "mode=testing" in mta_sts:
-            findings.append(Finding(
-            session=session, source="domain_security", target=domain, check_type="email",
-                severity="low",
-                title="MTA-STS is in testing mode",
-                description="MTA-STS mode=testing reports failures but does not enforce TLS.",
-                remediation="Change MTA-STS mode from testing to enforce once verified.",
-                extra={"mta_sts_record": mta_sts},
-            ))
-        elif "mode=none" in mta_sts:
-            findings.append(Finding(
-            session=session, source="domain_security", target=domain, check_type="email",
-                severity="medium",
-                title="MTA-STS is in none mode (disabled)",
-                description="MTA-STS mode=none disables enforcement.",
-                remediation="Change MTA-STS mode to enforce.",
-                extra={"mta_sts_record": mta_sts},
-            ))
+        return findings
 
+    # DNS record present — fetch and validate the policy file
+    policy_url = f"https://mta-sts.{domain}/.well-known/mta-sts.txt"
+    try:
+        resp = requests.get(policy_url, timeout=_HTTP_TIMEOUT)
+        resp.raise_for_status()
+        policy_text = resp.text
+    except Exception:
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="high",
+            title="MTA-STS policy file not reachable",
+            description=(
+                f"{domain} has an MTA-STS DNS record but the policy file at {policy_url} "
+                "is not reachable. Sending mail servers cannot retrieve the policy and "
+                "will not enforce TLS — the DNS record alone provides no protection."
+            ),
+            remediation=(
+                f"Host the policy file at https://mta-sts.{domain}/.well-known/mta-sts.txt "
+                "with a valid TLS certificate. The file must be publicly accessible over HTTPS."
+            ),
+            extra={"policy_url": policy_url},
+        ))
+        return findings
+
+    # Parse mode field — this is what actually controls enforcement
+    mode = None
+    for line in policy_text.splitlines():
+        if line.strip().lower().startswith("mode:"):
+            mode = line.split(":", 1)[1].strip().lower()
+            break
+
+    if mode == "enforce":
+        return []  # correctly configured
+
+    title_map = {
+        "testing": "MTA-STS is in testing mode — TLS not enforced",
+        "none": "MTA-STS is disabled (mode: none)",
+    }
+    description_map = {
+        "testing": (
+            f"{domain} MTA-STS policy is set to mode: testing. Failures are reported "
+            "but TLS is not enforced — email can still be downgraded to plaintext."
+        ),
+        "none": (
+            f"{domain} MTA-STS policy is explicitly disabled (mode: none). "
+            "No TLS is enforced on inbound email delivery."
+        ),
+    }
+    findings.append(Finding(
+        session=session, source="domain_security", target=domain, check_type="email",
+        severity="medium",
+        title=title_map.get(mode, "MTA-STS policy mode is invalid or missing"),
+        description=description_map.get(mode, (
+            f"{domain} MTA-STS policy at {policy_url} has an unrecognised or missing "
+            f"mode field (found: {mode!r}). Sending servers will not enforce TLS."
+        )),
+        remediation="Update the MTA-STS policy file: set mode: enforce",
+        extra={"policy_url": policy_url, "mode": mode},
+    ))
     return findings
+
+
+def _check_open_relay(session, domain) -> list:
+    """Attempt unauthenticated SMTP relay through the domain's MX server.
+
+    Connects to port 25 and sends a relay probe using two external addresses.
+    A 250 response to the RCPT TO confirms the server relays for anyone.
+    """
+    mx_records = _resolve(domain, "MX")
+    if not mx_records:
+        return []
+
+    try:
+        mx_host = str(sorted(mx_records, key=lambda r: r.preference)[0].exchange).rstrip(".")
+    except Exception:
+        return []
+
+    try:
+        with smtplib.SMTP(mx_host, 25, timeout=10) as smtp:
+            smtp.ehlo("probe.openeasd.local")
+            code, _ = smtp.mail("probe@relay-test.openeasd.local")
+            if code != 250:
+                return []
+            code, _ = smtp.rcpt("probe@relay-check.openeasd.local")
+            if code == 250:
+                return [Finding(
+                    session=session, source="domain_security", target=mx_host,
+                    check_type="open_relay", severity="critical",
+                    title="Open mail relay detected",
+                    description=(
+                        f"The mail server {mx_host} (MX for {domain}) accepted a relay "
+                        "attempt from an external address to an external address. "
+                        "Anyone on the internet can send email through this server — "
+                        "enabling spam campaigns and phishing attacks that appear to "
+                        "originate from your infrastructure, and risking IP blacklisting."
+                    ),
+                    remediation=(
+                        "Immediately restrict SMTP relay on your mail server:\n"
+                        "1. Configure your MTA to only relay for authenticated users or trusted IPs\n"
+                        "2. Postfix: set mynetworks and smtpd_relay_restrictions = permit_mynetworks, "
+                        "permit_sasl_authenticated, reject\n"
+                        "3. Exchange: disable anonymous relay in receive connectors\n"
+                        "4. Verify: telnet <mx-host> 25 → EHLO → MAIL FROM external → "
+                        "RCPT TO external → must receive 5xx rejection"
+                    ),
+                    extra={"mx_host": mx_host, "domain": domain},
+                )]
+    except Exception:
+        pass
+
+    return []
 
 
 def _check_tls_rpt(session, domain) -> list:
@@ -501,6 +600,7 @@ def _check_email(session, domain) -> list:
     findings += _check_dmarc(session, domain)
     findings += _check_dkim(session, domain)
     findings += _check_mta_sts(session, domain)
+    findings += _check_open_relay(session, domain)
     findings += _check_tls_rpt(session, domain)
     findings += _check_bimi(session, domain)
     return findings

--- a/tests/unit/test_domain_security.py
+++ b/tests/unit/test_domain_security.py
@@ -84,22 +84,67 @@ class TestDNSChecks:
         titles = [f.title for f in findings]
         assert "No NS records found" in titles
 
-    def test_dnssec_not_enabled_creates_medium_finding(self, db):
-        from apps.domain_security.scanner import _check_dns
+    def test_dnssec_not_enabled_creates_high_finding(self, db):
+        from apps.domain_security.scanner import _check_dnssec
         session = self._make_session(db)
 
-        def mock_resolve(domain, record_type):
-            return ["mock"] if record_type in ("A", "NS", "MX") else []
+        with patch("apps.domain_security.scanner.dns") as mock_dns:
+            mock_dns.resolver.resolve.side_effect = Exception("no records")
+            findings = _check_dnssec(session, "example.com")
 
-        with patch("apps.domain_security.scanner._resolve", side_effect=mock_resolve):
-            with patch("apps.domain_security.scanner.dns") as mock_dns:
-                mock_dns.resolver.resolve.side_effect = Exception("no DNSKEY")
-                findings = _check_dns(session, "example.com")
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.title == "DNSSEC not enabled"
+        assert f.severity == "high"
+        assert f.check_type == "dnssec"
 
-        titles = [f.title for f in findings]
-        assert "DNSSEC not enabled" in titles
-        dnssec = next(f for f in findings if f.title == "DNSSEC not enabled")
-        assert dnssec.severity == "medium"
+    def test_dnssec_broken_chain_dnskey_no_ds(self, db):
+        from apps.domain_security.scanner import _check_dnssec
+        session = self._make_session(db)
+
+        def mock_resolve(domain, rdtype):
+            if rdtype == "DNSKEY":
+                return [MagicMock()]
+            raise Exception("no DS")
+
+        with patch("apps.domain_security.scanner.dns") as mock_dns:
+            mock_dns.resolver.resolve.side_effect = mock_resolve
+            findings = _check_dnssec(session, "example.com")
+
+        assert len(findings) == 1
+        f = findings[0]
+        assert "chain of trust broken" in f.title
+        assert f.severity == "high"
+        assert f.extra == {"has_dnskey": True, "has_ds": False}
+
+    def test_dnssec_broken_ds_no_dnskey(self, db):
+        from apps.domain_security.scanner import _check_dnssec
+        session = self._make_session(db)
+
+        def mock_resolve(domain, rdtype):
+            if rdtype == "DS":
+                return [MagicMock()]
+            raise Exception("no DNSKEY")
+
+        with patch("apps.domain_security.scanner.dns") as mock_dns:
+            mock_dns.resolver.resolve.side_effect = mock_resolve
+            findings = _check_dnssec(session, "example.com")
+
+        assert len(findings) == 1
+        f = findings[0]
+        assert "DS published but DNSKEY missing" in f.title
+        assert f.severity == "high"
+        assert f.extra == {"has_dnskey": False, "has_ds": True}
+
+    def test_dnssec_fully_configured_no_finding(self, db):
+        from apps.domain_security.scanner import _check_dnssec
+        session = self._make_session(db)
+
+        with patch("apps.domain_security.scanner.dns") as mock_dns:
+            mock_dns.resolver.resolve.return_value = [MagicMock()]
+            findings = _check_dnssec(session, "example.com")
+
+        assert findings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_domain_security.py
+++ b/tests/unit/test_domain_security.py
@@ -556,7 +556,14 @@ class TestMTASTSChecks:
         from apps.core.scans.models import ScanSession
         return ScanSession.objects.create(domain="example.com", scan_type="full", status="pending")
 
-    def test_missing_mta_sts_creates_medium_finding(self, db):
+    def _mock_policy(self, mode):
+        """Return a mock requests.Response with the given MTA-STS policy mode."""
+        resp = MagicMock()
+        resp.text = f"version: STSv1\nmode: {mode}\nmx: mail.example.com\nmax_age: 86400"
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def test_missing_mta_sts_dns_creates_high_finding(self, db):
         from apps.domain_security.scanner import _check_mta_sts
         session = self._make_session(db)
 
@@ -564,29 +571,143 @@ class TestMTASTSChecks:
             findings = _check_mta_sts(session, "example.com")
 
         assert len(findings) == 1
-        assert findings[0].severity == "medium"
+        assert findings[0].severity == "high"
         assert "MTA-STS not configured" in findings[0].title
 
-    def test_mta_sts_testing_mode_creates_low_finding(self, db):
+    def test_dns_record_present_but_policy_file_unreachable_creates_high_finding(self, db):
         from apps.domain_security.scanner import _check_mta_sts
         session = self._make_session(db)
 
-        with patch("apps.domain_security.scanner._get_txt_record",
-                   return_value=["v=STSv1; id=20240101; mode=testing"]):
+        with patch("apps.domain_security.scanner._get_txt_record", return_value=["v=STSv1; id=20240101"]), \
+             patch("apps.domain_security.scanner.requests.get", side_effect=Exception("connection refused")):
             findings = _check_mta_sts(session, "example.com")
 
         assert len(findings) == 1
-        assert findings[0].severity == "low"
+        assert findings[0].severity == "high"
+        assert "not reachable" in findings[0].title
 
-    def test_mta_sts_enforce_mode_no_finding(self, db):
+    def test_policy_mode_testing_creates_medium_finding(self, db):
         from apps.domain_security.scanner import _check_mta_sts
         session = self._make_session(db)
 
-        with patch("apps.domain_security.scanner._get_txt_record",
-                   return_value=["v=STSv1; id=20240101; mode=enforce"]):
+        with patch("apps.domain_security.scanner._get_txt_record", return_value=["v=STSv1; id=20240101"]), \
+             patch("apps.domain_security.scanner.requests.get", return_value=self._mock_policy("testing")):
+            findings = _check_mta_sts(session, "example.com")
+
+        assert len(findings) == 1
+        assert findings[0].severity == "medium"
+        assert "testing" in findings[0].title
+
+    def test_policy_mode_none_creates_medium_finding(self, db):
+        from apps.domain_security.scanner import _check_mta_sts
+        session = self._make_session(db)
+
+        with patch("apps.domain_security.scanner._get_txt_record", return_value=["v=STSv1; id=20240101"]), \
+             patch("apps.domain_security.scanner.requests.get", return_value=self._mock_policy("none")):
+            findings = _check_mta_sts(session, "example.com")
+
+        assert len(findings) == 1
+        assert findings[0].severity == "medium"
+
+    def test_policy_mode_enforce_no_finding(self, db):
+        from apps.domain_security.scanner import _check_mta_sts
+        session = self._make_session(db)
+
+        with patch("apps.domain_security.scanner._get_txt_record", return_value=["v=STSv1; id=20240101"]), \
+             patch("apps.domain_security.scanner.requests.get", return_value=self._mock_policy("enforce")):
             findings = _check_mta_sts(session, "example.com")
 
         assert len(findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Open relay checks
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestOpenRelayChecks:
+    def _make_session(self, db):
+        from apps.core.scans.models import ScanSession
+        return ScanSession.objects.create(domain="example.com", scan_type="full", status="pending")
+
+    def _mock_mx(self, hostname="mail.example.com", preference=10):
+        mx = MagicMock()
+        mx.preference = preference
+        mx.exchange = MagicMock()
+        mx.exchange.__str__ = lambda self: hostname
+        return [mx]
+
+    def test_no_mx_records_returns_empty(self, db):
+        from apps.domain_security.scanner import _check_open_relay
+        session = self._make_session(db)
+
+        with patch("apps.domain_security.scanner._resolve", return_value=[]):
+            findings = _check_open_relay(session, "example.com")
+
+        assert findings == []
+
+    def test_open_relay_confirmed_creates_critical_finding(self, db):
+        from apps.domain_security.scanner import _check_open_relay
+        session = self._make_session(db)
+
+        smtp_mock = MagicMock()
+        smtp_mock.__enter__ = MagicMock(return_value=smtp_mock)
+        smtp_mock.__exit__ = MagicMock(return_value=False)
+        smtp_mock.ehlo.return_value = (250, b"ok")
+        smtp_mock.mail.return_value = (250, b"ok")
+        smtp_mock.rcpt.return_value = (250, b"ok")  # relay accepted
+
+        with patch("apps.domain_security.scanner._resolve", return_value=self._mock_mx()), \
+             patch("apps.domain_security.scanner.smtplib.SMTP", return_value=smtp_mock):
+            findings = _check_open_relay(session, "example.com")
+
+        assert len(findings) == 1
+        assert findings[0].severity == "critical"
+        assert findings[0].check_type == "open_relay"
+        assert "Open mail relay" in findings[0].title
+
+    def test_relay_rejected_returns_empty(self, db):
+        from apps.domain_security.scanner import _check_open_relay
+        session = self._make_session(db)
+
+        smtp_mock = MagicMock()
+        smtp_mock.__enter__ = MagicMock(return_value=smtp_mock)
+        smtp_mock.__exit__ = MagicMock(return_value=False)
+        smtp_mock.ehlo.return_value = (250, b"ok")
+        smtp_mock.mail.return_value = (250, b"ok")
+        smtp_mock.rcpt.return_value = (554, b"relay denied")  # rejected
+
+        with patch("apps.domain_security.scanner._resolve", return_value=self._mock_mx()), \
+             patch("apps.domain_security.scanner.smtplib.SMTP", return_value=smtp_mock):
+            findings = _check_open_relay(session, "example.com")
+
+        assert findings == []
+
+    def test_smtp_connection_refused_returns_empty(self, db):
+        from apps.domain_security.scanner import _check_open_relay
+        session = self._make_session(db)
+
+        with patch("apps.domain_security.scanner._resolve", return_value=self._mock_mx()), \
+             patch("apps.domain_security.scanner.smtplib.SMTP", side_effect=ConnectionRefusedError):
+            findings = _check_open_relay(session, "example.com")
+
+        assert findings == []
+
+    def test_mail_from_rejected_returns_empty(self, db):
+        from apps.domain_security.scanner import _check_open_relay
+        session = self._make_session(db)
+
+        smtp_mock = MagicMock()
+        smtp_mock.__enter__ = MagicMock(return_value=smtp_mock)
+        smtp_mock.__exit__ = MagicMock(return_value=False)
+        smtp_mock.ehlo.return_value = (250, b"ok")
+        smtp_mock.mail.return_value = (550, b"not allowed")  # MAIL FROM rejected
+
+        with patch("apps.domain_security.scanner._resolve", return_value=self._mock_mx()), \
+             patch("apps.domain_security.scanner.smtplib.SMTP", return_value=smtp_mock):
+            findings = _check_open_relay(session, "example.com")
+
+        assert findings == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Brand-Protection-salvage compliance checks, extracted from @vennela-cybersecify's un-PR'd branches (her authorship). All free, all in OpenEASD's DNS/email scope, all RBI `.bank.in`-migration-relevant.

**Validated each:**
- **DNSSEC — full chain of trust.** Checks DNSKEY at the domain *and* the DS record at the parent zone, distinguishing "not enabled" from "chain broken (DS not published)". More rigorous than a presence check.
- **MTA-STS** — flags missing MTA-STS policy (email TLS-downgrade protection).
- **Open relay** — **safe probe**: connects to the MX on :25, does MAIL FROM + RCPT TO with external dummy addresses, checks the response, then QUITs — **never sends DATA**, so it cannot actually relay mail. A 250 on RCPT = open relay (critical).
- Plus CWE mappings for the new + several SSH check types.

Tests live in the slow `test_domain_security.py` suite (real DNS/SMTP, excluded from fast CI): 41 → 51. Fast suite green (1037). CLAUDE.md total → 1088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)