### PR TITLE
feat: gitleaks JS-secret scanning tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,11 +256,12 @@ ProjectDiscovery tools installed via `pdtm` at `~/.pdtm/go/bin/`:
 
 OWASP/other tools:
 - `amass` — active subdomain enumeration (install separately: `go install -v github.com/owasp-amass/amass/v4/...@master`)
+- `gitleaks` — hardcoded-secret detection over fetched JS assets (MIT, static Go binary from `github.com/gitleaks/gitleaks` releases; baked into the Docker image)
 
 System binary:
 - `nmap` (Homebrew at `/opt/homebrew/bin/nmap`)
 
-Tool paths are configurable via `TOOL_SUBFINDER`, `TOOL_DNSX`, `TOOL_NAABU`, `TOOL_HTTPX`, `TOOL_KATANA`, `TOOL_NMAP`, `TOOL_NUCLEI`, `TOOL_AMASS`, `TOOL_ALTERX`, `TOOL_CLOUD_ENUM` env vars.
+Tool paths are configurable via `TOOL_SUBFINDER`, `TOOL_DNSX`, `TOOL_NAABU`, `TOOL_HTTPX`, `TOOL_KATANA`, `TOOL_NMAP`, `TOOL_NUCLEI`, `TOOL_AMASS`, `TOOL_ALTERX`, `TOOL_CLOUD_ENUM`, `TOOL_GITLEAKS` env vars.
 
 **Honest scanner identity:** httpx/katana/nuclei send `OPENEASD_USER_AGENT`
 (default `OpenEASD/1.0 (+https://cybersecify.com/openeasd)`) so a target can
@@ -354,7 +355,7 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 - `get_tool_requires()` — for dependency validation
 - `get_source_choices()` — for finding source filtering
 
-### Tool apps (20 registered tools)
+### Tool apps (21 registered tools)
 
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
@@ -377,6 +378,7 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 | `apps/katana/` | 10 | Web Exposure | No | Web crawling, endpoint discovery |
 | `apps/nuclei/` | 11 | Web Exposure | Yes | Web vuln scan (community templates) |
 | `apps/web_checker/` | 11 | Web Exposure | Yes | Security headers, cookies, CORS |
+| `apps/js_secrets/` | 11 | Web Exposure | Yes | Hardcoded-secret detection — fetches discovered `.js` assets and runs gitleaks over them; secret is redacted before storage |
 | `apps/cve_intel/` | 12 | Prioritization | No | Enriches CVE findings in place with EPSS scores + CISA KEV flags (no new findings) |
 
 ### Tool app structure
@@ -392,8 +394,11 @@ apps/<tool>/
 ## Scan pipeline
 
 All scans run through the **dynamic workflow system**. The default "Full Scan"
-workflow executes all 19 tools in phase order. Custom workflows can include
-any subset of tools.
+workflow executes the full tool set in phase order. Custom workflows can include
+any subset of tools. (A newly registered tool is available to any workflow, but
+only joins the default Full Scan when a data migration appends it — see
+`workflows/migrations/0021_*`; `asn_discovery` and `js_secrets` are registered
+but not yet in the default set.)
 
 ```
 Phase 1  domain_security    → Finding (DNS/email/RDAP)
@@ -415,6 +420,7 @@ Phase 9  historical_urls    → URL (gau + waybackurls — archived endpoints)
 Phase 10 katana             → URL (web crawling, endpoint discovery)
 Phase 11 nuclei             → Finding (web vulns via templates on URLs)
 Phase 11 web_checker        → Finding (headers, cookies, CORS on URLs)
+Phase 11 js_secrets         → Finding (gitleaks over fetched .js assets — secret redacted)
 ```
 
 ### Scan flow
@@ -526,6 +532,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 16 | JSON parser, Port lookup, Subdomain link, honest UA, tech-detect flag + technology storage/dedup |
+| `tests/unit/test_js_secrets.py` | 26 | `.js` URL filter + cap, fetch-error handling, gitleaks JSON parser, analyzer Findings + dedup + secret redaction (full secret never stored), scanner, binary-missing/timeout |
 | `tests/unit/test_k8s_manifests.py` | 57 | k8s manifest structure, envFrom order, probes, secret/configmap split |
 | `tests/unit/test_katana.py` | 19 | JSONL parser, Port/Subdomain FK links, scanner orchestrator, honest UA |
 | `tests/unit/test_management_commands.py` | 11 | `verify_tools` + other management commands |
@@ -558,4 +565,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1118 tests** (1067 fast + 51 slow domain_security)
+**Total: 1144 tests** (1093 fast + 51 slow domain_security)

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ARG NUCLEI_VERSION=3.2.9
 ARG AMASS_VERSION=4.2.0
 ARG ALTERX_VERSION=0.0.4
 ARG KATANA_VERSION=1.6.1
+ARG GITLEAKS_VERSION=8.30.1
 
 RUN curl -fsSL "https://github.com/projectdiscovery/subfinder/releases/download/v${SUBFINDER_VERSION}/subfinder_${SUBFINDER_VERSION}_linux_${TARGETARCH}.zip" \
     -o subfinder.zip && unzip subfinder.zip subfinder && rm subfinder.zip
@@ -70,7 +71,12 @@ RUN curl -fsSL "https://github.com/projectdiscovery/katana/releases/download/v${
 RUN curl -fsSL "https://github.com/owasp-amass/amass/releases/download/v${AMASS_VERSION}/amass_Linux_${TARGETARCH}.zip" \
     -o amass.zip && unzip amass.zip && mv amass_Linux_${TARGETARCH}/amass . && rm -rf amass.zip amass_Linux_${TARGETARCH}
 
-RUN chmod +x subfinder dnsx naabu httpx nuclei amass alterx katana
+# gitleaks — MIT, static Go binary. Release assets use x64/arm64 (not amd64).
+RUN GLARCH="$([ "$TARGETARCH" = "amd64" ] && echo x64 || echo arm64)" \
+    && curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GLARCH}.tar.gz" \
+    -o gitleaks.tar.gz && tar -xzf gitleaks.tar.gz gitleaks && rm gitleaks.tar.gz
+
+RUN chmod +x subfinder dnsx naabu httpx nuclei amass alterx katana gitleaks
 
 # ---------------------------------------------------------------------------
 # Stage 2b: build subzy from source (no prebuilt binaries available upstream).

--- a/apps/core/dashboard/management/commands/tools_healthcheck.py
+++ b/apps/core/dashboard/management/commands/tools_healthcheck.py
@@ -100,6 +100,10 @@ def _functional_probes() -> list[Probe]:
             expect_in_stdout="keyword",
             allowed_exit_codes=(0, 1),
         ),
+        Probe(
+            name="gitleaks",
+            cmd=[_tool_binary("TOOL_GITLEAKS", "gitleaks"), "version"],
+        ),
     ]
 
 
@@ -115,6 +119,7 @@ def _quick_probes() -> list[Probe]:
         Probe(name="nmap",      cmd=[_tool_binary("TOOL_NMAP", "nmap"),           "-V"]),
         Probe(name="amass",     cmd=[_tool_binary("TOOL_AMASS", "amass"),         "-version"]),
         Probe(name="cloud_enum", cmd=[_tool_binary("TOOL_CLOUD_ENUM", "cloud_enum"), "-h"], allowed_exit_codes=(0, 1)),
+        Probe(name="gitleaks",  cmd=[_tool_binary("TOOL_GITLEAKS", "gitleaks"),     "version"]),
     ]
 
 

--- a/apps/js_secrets/analyzer.py
+++ b/apps/js_secrets/analyzer.py
@@ -1,0 +1,124 @@
+"""gitleaks result analysis — maps report records to unified Finding model.
+
+gitleaks JSON report format (one object per leak):
+{
+  "RuleID": "aws-access-token",
+  "Description": "AWS Access Key",
+  "File": "/tmp/xxxx/3.js",
+  "Secret": "AKIA................",
+  "Match": "aws_key = \"AKIA................\"",
+  "StartLine": 42,
+  ...
+}
+
+Redaction is a hard requirement: the full secret must never land in the DB or
+report. We store only a redacted preview of the secret and a scrubbed match.
+"""
+
+import logging
+
+from apps.core.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+
+def _redact(value) -> str:
+    """Redact a secret/match so the full value never leaves this function.
+
+    Short values are fully masked; longer ones keep a tiny prefix/suffix so an
+    operator can eyeball-match without the plaintext being recoverable.
+    """
+    if not value:
+        return ""
+    value = str(value)
+    if len(value) <= 8:
+        return "*" * len(value)
+    return f"{value[:4]}***{value[-2:]} ({len(value)} chars)"
+
+
+def _scrub_match(match, secret) -> str:
+    """Return a truncated match with the raw secret removed."""
+    if not match:
+        return ""
+    match = str(match)
+    if secret:
+        match = match.replace(str(secret), _redact(secret))
+    return match[:120]
+
+
+def _build_finding(session, rec: dict, url_fk=None) -> Finding:
+    rule_id = rec.get("RuleID") or rec.get("Description") or "unknown-rule"
+    source_url = rec.get("_source_url") or ""
+    secret = rec.get("Secret") or ""
+    match = rec.get("Match") or ""
+    start_line = rec.get("StartLine")
+
+    title = f"Hardcoded secret in JavaScript ({rule_id})"
+    if len(title) > 250:
+        title = title[:247] + "..."
+
+    description = (
+        f"gitleaks rule '{rule_id}' matched a likely hardcoded secret in the "
+        f"JavaScript asset served at {source_url or 'an unknown URL'}. "
+        f"Secrets shipped in client-served code are readable by anyone who "
+        f"loads the page."
+    )
+
+    return Finding(
+        session=session,
+        source="js_secrets",
+        check_type="exposed_secret",
+        severity="high",
+        title=title,
+        description=description,
+        remediation=(
+            "Rotate the exposed credential and remove it from client-served "
+            "code. Move secrets to server-side configuration and never ship "
+            "them in JavaScript bundles."
+        ),
+        url=url_fk,
+        target=source_url[:255],
+        extra={
+            "rule_id": rule_id,
+            "description": rec.get("Description", ""),
+            "source_url": source_url,
+            "line": start_line,
+            "secret_preview": _redact(secret),
+            "match_preview": _scrub_match(match, secret),
+        },
+    )
+
+
+def analyze(session, records: list[dict]) -> list[Finding]:
+    """Build Finding objects from gitleaks records.
+
+    Deduplicates by (RuleID, source URL) — gitleaks can report the same rule
+    firing on the same file more than once. Links to the URL asset when the
+    JS URL is a known URL row for this session.
+    """
+    from apps.core.web_assets.models import URL
+
+    if not records:
+        return []
+
+    url_map = {u.url: u for u in URL.objects.filter(session=session)}
+
+    seen: set[tuple[str, str]] = set()
+    findings: list[Finding] = []
+
+    for rec in records:
+        rule_id = rec.get("RuleID") or rec.get("Description") or "unknown-rule"
+        source_url = rec.get("_source_url") or ""
+        dedup_key = (rule_id, source_url)
+        if dedup_key in seen:
+            continue
+        seen.add(dedup_key)
+
+        url_fk = url_map.get(source_url)
+        findings.append(_build_finding(session, rec, url_fk))
+
+    logger.info(
+        f"[js_secrets:{session.id}] {len(findings)} secret findings "
+        f"({len(records) - len(findings)} duplicates removed)"
+    )
+    return findings

--- a/apps/js_secrets/apps.py
+++ b/apps/js_secrets/apps.py
@@ -1,0 +1,16 @@
+from django.apps import AppConfig
+
+
+class JsSecretsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.js_secrets"
+    label = "js_secrets"
+    verbose_name = "JS Secrets (gitleaks)"
+    tool_meta = {
+        "label": "JS Secrets (gitleaks)",
+        "runner": "apps.js_secrets.scanner.run_js_secrets",
+        "phase": 11,
+        "phase_group": "Web Exposure",
+        "requires": ["gitleaks"],
+        "produces_findings": True,
+    }

--- a/apps/js_secrets/collector.py
+++ b/apps/js_secrets/collector.py
@@ -1,0 +1,174 @@
+"""gitleaks JS-secret collection.
+
+Fetches the JavaScript assets discovered during the scan and runs the gitleaks
+binary over them to catch hardcoded API keys / tokens / secrets that nuclei's
+path-based templates miss.
+
+Flow:
+  1. Filter the session's URLs down to JavaScript files (path ends in ``.js``).
+  2. Fetch each JS file over HTTP into a throwaway temp directory.
+  3. Run ``gitleaks dir <tmpdir> --report-format json --report-path <out>``.
+  4. Return the parsed gitleaks report records, each tagged with the source URL
+     it came from (``_source_url``) so the analyzer can build Findings.
+"""
+
+import json
+import logging
+import os
+import subprocess
+import tempfile
+from urllib.parse import urlparse
+
+import requests
+import urllib3
+from django.conf import settings
+
+from apps.core.workflows.exceptions import ToolBinaryMissing, ToolTimeout
+
+logger = logging.getLogger(__name__)
+
+# Suppress InsecureRequestWarning from verify=False — we fetch assets from
+# hosts whose certs we don't control and don't want to fail closed on.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Bound the work: cap how many JS files we pull and scan per session.
+MAX_JS_FILES = 200
+FETCH_TIMEOUT = 10   # seconds per HTTP fetch
+GITLEAKS_TIMEOUT = 300  # wall-clock cap for the gitleaks run
+
+
+def _is_js_url(url: str) -> bool:
+    """True when the URL's path ends in .js (case-insensitive; ignores query)."""
+    path = urlparse(url).path
+    return path.lower().endswith(".js")
+
+
+def _fetch(url: str, user_agent: str) -> str | None:
+    """Fetch a single JS file's body. Returns text, or None on any failure."""
+    try:
+        resp = requests.get(
+            url,
+            timeout=FETCH_TIMEOUT,
+            verify=False,
+            headers={"User-Agent": user_agent},
+            allow_redirects=True,
+        )
+    except requests.RequestException as e:
+        logger.debug(f"[js_secrets] fetch failed for {url}: {e}")
+        return None
+    if resp.status_code != 200 or not resp.text:
+        return None
+    return resp.text
+
+
+def collect(session, urls: list[str]) -> list[dict]:
+    """Fetch JS assets from ``urls`` and run gitleaks over them.
+
+    ``urls`` is the full URL list for the session; this filters to .js files
+    and caps at MAX_JS_FILES. Returns raw gitleaks report records, each with a
+    private ``_source_url`` key naming the JS asset it came from.
+    """
+    js_urls = [u for u in urls if _is_js_url(u)]
+    if not js_urls:
+        logger.info(f"[js_secrets:{session.id}] No JavaScript URLs to scan")
+        return []
+
+    if len(js_urls) > MAX_JS_FILES:
+        logger.info(
+            f"[js_secrets:{session.id}] {len(js_urls)} JS URLs found — "
+            f"truncating to first {MAX_JS_FILES}"
+        )
+        js_urls = js_urls[:MAX_JS_FILES]
+
+    user_agent = getattr(settings, "OPENEASD_USER_AGENT", "OpenEASD/1.0")
+    binary = getattr(settings, "TOOL_GITLEAKS", "gitleaks")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # filename → source URL, so gitleaks' File field maps back to the URL.
+        file_map: dict[str, str] = {}
+        for i, url in enumerate(js_urls):
+            content = _fetch(url, user_agent)
+            if content is None:
+                continue
+            fname = f"{i}.js"
+            try:
+                with open(os.path.join(tmpdir, fname), "w", encoding="utf-8") as f:
+                    f.write(content)
+            except OSError as e:
+                logger.debug(f"[js_secrets:{session.id}] write failed for {url}: {e}")
+                continue
+            file_map[fname] = url
+
+        if not file_map:
+            logger.info(f"[js_secrets:{session.id}] No JS files fetched successfully")
+            return []
+
+        logger.info(
+            f"[js_secrets:{session.id}] Scanning {len(file_map)} fetched JS files with gitleaks"
+        )
+
+        # Report goes OUTSIDE the scanned dir so gitleaks never scans its own output.
+        report_fd, report_path = tempfile.mkstemp(suffix=".json", prefix="gitleaks-")
+        os.close(report_fd)
+        cmd = [
+            binary, "dir", tmpdir,
+            "--report-format", "json",
+            "--report-path", report_path,
+            "--no-banner",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GITLEAKS_TIMEOUT,
+                stdin=subprocess.DEVNULL,
+            )
+        except FileNotFoundError:
+            logger.error(f"[js_secrets:{session.id}] Binary not found: {binary}")
+            raise ToolBinaryMissing(f"gitleaks binary not found: {binary}")
+        except subprocess.TimeoutExpired:
+            logger.error(f"[js_secrets:{session.id}] gitleaks timed out")
+            raise ToolTimeout(f"gitleaks timed out after {GITLEAKS_TIMEOUT}s")
+        else:
+            # gitleaks exits non-zero (1) when leaks are found — that's expected,
+            # not an execution error. Only log a stderr on unusual exit codes.
+            if result.returncode not in (0, 1) and result.stderr:
+                logger.warning(
+                    f"[js_secrets:{session.id}] gitleaks exit={result.returncode} "
+                    f"stderr: {result.stderr[:500]}"
+                )
+            records = _parse_report(report_path)
+        finally:
+            try:
+                os.unlink(report_path)
+            except OSError:
+                pass
+
+    # Tag each record with the URL its File came from.
+    tagged = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        fname = os.path.basename(rec.get("File", "") or "")
+        rec["_source_url"] = file_map.get(fname, "")
+        tagged.append(rec)
+    return tagged
+
+
+def _parse_report(report_path: str) -> list[dict]:
+    """Read gitleaks' JSON report defensively. Returns a list of records."""
+    try:
+        with open(report_path, "r", encoding="utf-8", errors="replace") as f:
+            text = f.read().strip()
+    except OSError:
+        return []
+    if not text:
+        return []
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [r for r in data if isinstance(r, dict)]

--- a/apps/js_secrets/collector.py
+++ b/apps/js_secrets/collector.py
@@ -49,7 +49,7 @@ def _fetch(url: str, user_agent: str) -> str | None:
         resp = requests.get(
             url,
             timeout=FETCH_TIMEOUT,
-            verify=False,
+            verify=False,  # nosec B501 — intentional: scanning target hosts that may have self-signed certs
             headers={"User-Agent": user_agent},
             allow_redirects=True,
         )
@@ -143,6 +143,8 @@ def collect(session, urls: list[str]) -> list[dict]:
             try:
                 os.unlink(report_path)
             except OSError:
+                # Best-effort cleanup of the temp report file; nothing to do if
+                # it was already removed or never created.
                 pass
 
     # Tag each record with the URL its File came from.

--- a/apps/js_secrets/models.py
+++ b/apps/js_secrets/models.py
@@ -1,0 +1,1 @@
+# js_secrets writes to apps/core/findings/Finding — no local models needed.

--- a/apps/js_secrets/scanner.py
+++ b/apps/js_secrets/scanner.py
@@ -1,0 +1,35 @@
+"""js_secrets scanner — orchestrator: collect JS URLs -> gitleaks -> save findings."""
+
+import logging
+
+from apps.core.findings.models import Finding
+from apps.core.web_assets.models import URL
+from .collector import collect
+from .analyzer import analyze
+
+logger = logging.getLogger(__name__)
+
+
+def run_js_secrets(session) -> list[Finding]:
+    """Scan the session's discovered JavaScript assets for hardcoded secrets.
+
+    Pulls every URL discovered by the web-exposure phase (httpx / historical /
+    katana), lets the collector filter to .js files, fetch them, and run
+    gitleaks, then saves one Finding per unique secret.
+    """
+    urls = list(URL.objects.filter(session=session).values_list("url", flat=True))
+    if not urls:
+        logger.info(f"[js_secrets:{session.id}] No URLs to scan")
+        return []
+
+    records = collect(session, urls)
+    findings = analyze(session, records)
+
+    if findings:
+        Finding.objects.bulk_create(findings)
+
+    logger.info(
+        f"[js_secrets:{session.id}] {len(findings)} findings saved "
+        f"from {len(records)} raw gitleaks results"
+    )
+    return findings

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -93,6 +93,7 @@ INSTALLED_APPS = [
     "apps.nuclei",
     "apps.nuclei_network",
     "apps.web_checker",
+    "apps.js_secrets",
     "apps.cve_intel",
 ]
 
@@ -263,6 +264,7 @@ TOOL_NUCLEI = config("TOOL_NUCLEI", default="nuclei")
 TOOL_AMASS = config("TOOL_AMASS", default="amass")
 TOOL_ALTERX = config("TOOL_ALTERX", default="alterx")
 TOOL_CLOUD_ENUM = config("TOOL_CLOUD_ENUM", default="cloud_enum")
+TOOL_GITLEAKS = config("TOOL_GITLEAKS", default="gitleaks")
 
 # Honest scanner identity. Sent as the User-Agent on the tools that probe the
 # target's web surface (httpx, katana, nuclei) so a customer can deliberately

--- a/tests/unit/test_js_secrets.py
+++ b/tests/unit/test_js_secrets.py
@@ -1,0 +1,296 @@
+"""Unit tests for apps/js_secrets — gitleaks over discovered JavaScript assets.
+
+No real network, no real gitleaks: the HTTP fetch (requests) and the gitleaks
+subprocess are both mocked. The gitleaks mock writes a JSON report to the
+--report-path the collector chose, so the report parser is exercised for real.
+"""
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.js_secrets.collector import collect, _is_js_url
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _session():
+    from apps.core.scans.models import ScanSession
+    return ScanSession.objects.create(domain="example.com", scan_type="full")
+
+
+def _fake_response(text: str, status: int = 200):
+    m = MagicMock()
+    m.status_code = status
+    m.text = text
+    return m
+
+
+def _fake_gitleaks(records: list[dict]):
+    """Return a subprocess.run stand-in that writes `records` to the report path."""
+    def _run(cmd, **kwargs):
+        report_path = cmd[cmd.index("--report-path") + 1]
+        with open(report_path, "w", encoding="utf-8") as f:
+            json.dump(records, f)
+        m = MagicMock()
+        m.returncode = 1 if records else 0  # gitleaks exits 1 when leaks found
+        m.stdout = ""
+        m.stderr = ""
+        return m
+    return _run
+
+
+# --------------------------------------------------------------------------- #
+# _is_js_url
+# --------------------------------------------------------------------------- #
+class TestIsJsUrl:
+    def test_plain_js(self):
+        assert _is_js_url("https://example.com/app.js")
+
+    def test_uppercase_extension(self):
+        assert _is_js_url("https://example.com/APP.JS")
+
+    def test_ignores_query_string(self):
+        assert _is_js_url("https://example.com/bundle.js?v=123")
+
+    def test_non_js_rejected(self):
+        assert not _is_js_url("https://example.com/index.html")
+        assert not _is_js_url("https://example.com/style.css")
+
+    def test_js_in_query_only_rejected(self):
+        # .js appears only in the query, not the path
+        assert not _is_js_url("https://example.com/load?file=app.js")
+
+
+# --------------------------------------------------------------------------- #
+# collector
+# --------------------------------------------------------------------------- #
+@pytest.mark.django_db
+class TestJsSecretsCollector:
+    def test_returns_empty_when_no_js_urls(self):
+        sess = _session()
+        with patch("apps.js_secrets.collector.subprocess.run") as run:
+            records = collect(sess, ["https://example.com/", "https://example.com/a.css"])
+        assert records == []
+        run.assert_not_called()
+
+    def test_filters_to_js_and_fetches_only_js(self):
+        sess = _session()
+        urls = [
+            "https://example.com/index.html",
+            "https://example.com/app.js",
+            "https://example.com/style.css",
+            "https://example.com/vendor.js",
+        ]
+        with patch("apps.js_secrets.collector.requests.get", return_value=_fake_response("var x=1;")) as get, \
+             patch("apps.js_secrets.collector.subprocess.run", side_effect=_fake_gitleaks([])):
+            collect(sess, urls)
+        fetched = [c.args[0] for c in get.call_args_list]
+        assert set(fetched) == {"https://example.com/app.js", "https://example.com/vendor.js"}
+
+    def test_caps_number_of_js_files(self):
+        sess = _session()
+        urls = [f"https://example.com/f{i}.js" for i in range(5)]
+        with patch("apps.js_secrets.collector.MAX_JS_FILES", 2), \
+             patch("apps.js_secrets.collector.requests.get", return_value=_fake_response("x")) as get, \
+             patch("apps.js_secrets.collector.subprocess.run", side_effect=_fake_gitleaks([])):
+            collect(sess, urls)
+        assert get.call_count == 2
+
+    def test_handles_fetch_errors_gracefully(self):
+        import requests
+        sess = _session()
+        urls = ["https://example.com/bad.js", "https://example.com/good.js"]
+
+        def _get(url, **kwargs):
+            if "bad" in url:
+                raise requests.RequestException("boom")
+            return _fake_response("secret code")
+
+        record = {"RuleID": "generic", "File": "/x/1.js", "Secret": "s", "Match": "m"}
+        with patch("apps.js_secrets.collector.requests.get", side_effect=_get), \
+             patch("apps.js_secrets.collector.subprocess.run", side_effect=_fake_gitleaks([record])):
+            records = collect(sess, urls)
+        # The good.js file is index 1 → written as 1.js → record maps to it.
+        assert len(records) == 1
+        assert records[0]["_source_url"] == "https://example.com/good.js"
+
+    def test_skips_gitleaks_when_nothing_fetched(self):
+        import requests
+        sess = _session()
+        with patch("apps.js_secrets.collector.requests.get",
+                   side_effect=requests.RequestException("boom")), \
+             patch("apps.js_secrets.collector.subprocess.run") as run:
+            records = collect(sess, ["https://example.com/app.js"])
+        assert records == []
+        run.assert_not_called()
+
+    def test_parses_gitleaks_report_and_tags_source_url(self):
+        sess = _session()
+        records_in = [
+            {"RuleID": "aws-access-token", "File": "/tmp/x/0.js",
+             "Secret": "AKIAIOSFODNN7EXAMPLE", "Match": "k = AKIAIOSFODNN7EXAMPLE", "StartLine": 3},
+            {"RuleID": "generic-api-key", "File": "/tmp/x/0.js",
+             "Secret": "abcd1234", "Match": "key=abcd1234", "StartLine": 9},
+        ]
+        with patch("apps.js_secrets.collector.requests.get", return_value=_fake_response("code")), \
+             patch("apps.js_secrets.collector.subprocess.run", side_effect=_fake_gitleaks(records_in)):
+            records = collect(sess, ["https://example.com/app.js"])
+        assert len(records) == 2
+        assert all(r["_source_url"] == "https://example.com/app.js" for r in records)
+
+    def test_empty_report_returns_empty(self):
+        sess = _session()
+        with patch("apps.js_secrets.collector.requests.get", return_value=_fake_response("code")), \
+             patch("apps.js_secrets.collector.subprocess.run", side_effect=_fake_gitleaks([])):
+            records = collect(sess, ["https://example.com/app.js"])
+        assert records == []
+
+    def test_raises_on_binary_missing(self):
+        from apps.core.workflows.exceptions import ToolBinaryMissing
+        sess = _session()
+        with patch("apps.js_secrets.collector.requests.get", return_value=_fake_response("code")), \
+             patch("apps.js_secrets.collector.subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(ToolBinaryMissing):
+                collect(sess, ["https://example.com/app.js"])
+
+    def test_raises_on_timeout(self):
+        from apps.core.workflows.exceptions import ToolTimeout
+        sess = _session()
+        with patch("apps.js_secrets.collector.requests.get", return_value=_fake_response("code")), \
+             patch("apps.js_secrets.collector.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("gitleaks", 300)):
+            with pytest.raises(ToolTimeout):
+                collect(sess, ["https://example.com/app.js"])
+
+
+# --------------------------------------------------------------------------- #
+# analyzer
+# --------------------------------------------------------------------------- #
+from apps.js_secrets.analyzer import analyze, _redact
+
+
+class TestRedact:
+    def test_short_secret_fully_masked(self):
+        assert _redact("abcd1234") == "*" * 8
+        assert "abcd1234" not in _redact("abcd1234")
+
+    def test_long_secret_partly_masked_never_full(self):
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        out = _redact(secret)
+        assert secret not in out
+        assert "chars" in out
+
+    def test_empty(self):
+        assert _redact("") == ""
+
+
+@pytest.mark.django_db
+class TestJsSecretsAnalyzer:
+    def _rec(self, **over):
+        base = {
+            "RuleID": "aws-access-token",
+            "Description": "AWS Access Key",
+            "File": "/tmp/x/0.js",
+            "Secret": "AKIAIOSFODNN7EXAMPLE",
+            "Match": "const key = \"AKIAIOSFODNN7EXAMPLE\"",
+            "StartLine": 12,
+            "_source_url": "https://example.com/app.js",
+        }
+        base.update(over)
+        return base
+
+    def test_builds_finding(self):
+        sess = _session()
+        findings = analyze(sess, [self._rec()])
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.source == "js_secrets"
+        assert f.check_type == "exposed_secret"
+        assert f.severity == "high"
+        assert "aws-access-token" in f.title
+        assert f.target == "https://example.com/app.js"
+
+    def test_full_secret_never_stored(self):
+        sess = _session()
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        findings = analyze(sess, [self._rec()])
+        f = findings[0]
+        blob = json.dumps(f.extra) + f.title + f.description + f.remediation + f.target
+        assert secret not in blob
+
+    def test_dedupes_by_rule_and_url(self):
+        sess = _session()
+        findings = analyze(sess, [self._rec(), self._rec()])
+        assert len(findings) == 1
+
+    def test_different_rules_not_deduped(self):
+        sess = _session()
+        findings = analyze(sess, [self._rec(), self._rec(RuleID="generic-api-key", Secret="zzzz9999")])
+        assert len(findings) == 2
+
+    def test_links_url_fk_when_known(self):
+        from apps.core.web_assets.models import URL
+        sess = _session()
+        url_row = URL.objects.create(
+            session=sess, url="https://example.com/app.js", scheme="https",
+            host="example.com", port_number=443, source="katana",
+        )
+        findings = analyze(sess, [self._rec()])
+        assert findings[0].url_id == url_row.id
+
+    def test_no_url_fk_for_unknown(self):
+        sess = _session()
+        findings = analyze(sess, [self._rec(_source_url="https://example.com/other.js")])
+        assert findings[0].url is None
+
+    def test_returns_empty_for_no_records(self):
+        sess = _session()
+        assert analyze(sess, []) == []
+
+
+# --------------------------------------------------------------------------- #
+# scanner
+# --------------------------------------------------------------------------- #
+from apps.js_secrets.scanner import run_js_secrets
+
+
+@pytest.mark.django_db
+class TestJsSecretsScanner:
+    def test_returns_empty_when_no_urls(self):
+        sess = _session()
+        with patch("apps.js_secrets.scanner.collect") as mock_collect:
+            result = run_js_secrets(sess)
+        assert result == []
+        mock_collect.assert_not_called()
+
+    def test_passes_urls_to_collector_and_saves_findings(self):
+        from apps.core.web_assets.models import URL
+        from apps.core.findings.models import Finding
+        sess = _session()
+        URL.objects.create(
+            session=sess, url="https://example.com/app.js", scheme="https",
+            host="example.com", port_number=443, source="katana",
+        )
+        record = {
+            "RuleID": "aws-access-token", "File": "/tmp/x/0.js",
+            "Secret": "AKIAIOSFODNN7EXAMPLE", "Match": "k=AKIAIOSFODNN7EXAMPLE",
+            "StartLine": 1, "_source_url": "https://example.com/app.js",
+        }
+        captured = {}
+
+        def fake_collect(session, urls):
+            captured["urls"] = urls
+            return [record]
+
+        with patch("apps.js_secrets.scanner.collect", side_effect=fake_collect):
+            result = run_js_secrets(sess)
+
+        assert "https://example.com/app.js" in captured["urls"]
+        assert len(result) == 1
+        saved = Finding.objects.filter(session=sess, source="js_secrets")
+        assert saved.count() == 1
+        assert saved.first().check_type == "exposed_secret"

--- a/tests/unit/test_tools_healthcheck.py
+++ b/tests/unit/test_tools_healthcheck.py
@@ -120,11 +120,11 @@ class TestCommand:
             return_value=(True, "OK"),
         ) as mock_probe:
             call_command("tools_healthcheck", "--quick", stdout=out)
-        # All 9 quick probes should fire (subfinder, dnsx, naabu, httpx, katana, nuclei, nmap, amass, cloud_enum)
-        assert mock_probe.call_count == 9
+        # All 10 quick probes should fire (subfinder, dnsx, naabu, httpx, katana, nuclei, nmap, amass, cloud_enum, gitleaks)
+        assert mock_probe.call_count == 10
         output = out.getvalue()
         assert "version mode" in output
-        assert "All 9 tools OK." in output
+        assert "All 10 tools OK." in output
 
     def test_functional_mode_runs_full_probes(self, db):
         out = StringIO()
@@ -133,7 +133,7 @@ class TestCommand:
             return_value=(True, "OK"),
         ) as mock_probe:
             call_command("tools_healthcheck", stdout=out)
-        assert mock_probe.call_count == 9
+        assert mock_probe.call_count == 10
         assert "functional mode" in out.getvalue()
 
     def test_failure_summary_lists_count(self, db):
@@ -151,7 +151,7 @@ class TestCommand:
         output = out.getvalue()
         assert "FAIL" in output
         assert "naabu" in output
-        assert "1 of 9 tool(s) failed" in output
+        assert "1 of 10 tool(s) failed" in output
 
     def test_command_always_exits_zero_even_with_failures(self, db):
         """Healthcheck is observability, not gating — never crashes the boot."""


### PR DESCRIPTION
## What

New tool `apps/js_secrets/` (phase 11, Web Exposure) that fetches the JavaScript assets a scan discovered and runs **gitleaks** over them to catch hardcoded API keys/tokens/secrets that nuclei's path-based templates miss.

- **collector** — filters the session's URLs to `.js` (case-insensitive, ignores query strings), caps at 200 files, fetches each over HTTP (10s timeout, honest `OPENEASD_USER_AGENT`, skips fetch failures), runs `gitleaks dir <tmpdir> --report-format json --report-path <out> --no-banner`, and defensively parses the JSON report.
- **analyzer** — one `high` Finding per unique secret (deduped by rule + JS URL), `check_type="exposed_secret"`, target = the JS URL, links the `URL` FK when known.
- **Redaction is enforced**: the full secret never lands in the DB or report — only a masked preview (`AKIA***LE (20 chars)`) and a scrubbed match are stored. A test asserts the full secret is absent from every Finding field.

## Wiring
- `TOOL_GITLEAKS` setting + `apps.js_secrets` in `INSTALLED_APPS`
- Dockerfile installs the gitleaks static binary (MIT), arch-mapped amd64→x64 / arm64
- `tools_healthcheck` gains a gitleaks probe

## Tests
26 new tests in `tests/unit/test_js_secrets.py` (subprocess + `requests` both mocked — no real network or gitleaks). Full fast suite: **1085 passed**. `makemigrations --check` clean.

## Note
Registered and available to any workflow, but not appended to the default Full Scan (matches the current `asn_discovery` precedent — new tools join Full Scan only via a data migration). Easy follow-up if we want it on by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)