### PR TITLE
fix: subdomain scope boundary in enumeration + genericize DNSSEC text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,7 +515,7 @@ GET  /api/notifications/alerts/           — alert history
 |---|---|---|
 | `tests/unit/test_alerts.py` | 7 | Slack/Teams dispatcher |
 | `tests/unit/test_alterx.py` | 17 | collector (binary missing, timeout, happy path, stdin), analyzer, scanner |
-| `tests/unit/test_amass.py` | 19 | Active subdomain enum collector, analyzer, scanner |
+| `tests/unit/test_amass.py` | 20 | Active subdomain enum collector, analyzer, scanner |
 | `tests/unit/test_asn_discovery.py` | 22 | ASN/CIDR discovery — org derivation, ASN/CIDR parsing, collector (binary missing, timeout, two-step happy path), analyzer (info Finding per ASN, safe-scope remediation), scanner |
 | `tests/unit/test_assets.py` | 12 | Asset model constraints, FK chains, cascade delete |
 | `tests/unit/test_cloud_assets.py` | 20 | cloud_assets collector, analyzer, keyword derivation, scanner |
@@ -558,4 +558,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1117 tests** (1066 fast + 51 slow domain_security)
+**Total: 1118 tests** (1067 fast + 51 slow domain_security)

--- a/apps/alterx/analyzer.py
+++ b/apps/alterx/analyzer.py
@@ -23,9 +23,12 @@ def analyze(session, raw: list[str]) -> list[Subdomain]:
     objs: list[Subdomain] = []
     seen: set[str] = set()
 
+    domain = session.domain.lower()
     for line in raw:
         host = line.strip().lower()
         if not host or not _VALID_HOSTNAME.match(host):
+            continue
+        if not (host == domain or host.endswith("." + domain)):
             continue
         if host in seen or host in existing:
             continue

--- a/apps/amass/analyzer.py
+++ b/apps/amass/analyzer.py
@@ -7,13 +7,23 @@ from apps.core.assets.models import Subdomain
 logger = logging.getLogger(__name__)
 
 
+def _in_scope(host: str, domain: str) -> bool:
+    host = host.lower()
+    domain = domain.lower()
+    return host == domain or host.endswith("." + domain)
+
+
 def analyze(session, records: list[dict]) -> list[Subdomain]:
     """Build shared Subdomain asset instances from raw collector records."""
     objs = []
     seen = set()
+    dropped = 0
     for record in records:
         host = record.get("host", "").strip().lower()
         if not host or host in seen:
+            continue
+        if not _in_scope(host, session.domain):
+            dropped += 1
             continue
         seen.add(host)
         objs.append(Subdomain(
@@ -22,4 +32,6 @@ def analyze(session, records: list[dict]) -> list[Subdomain]:
             subdomain=host,
             source="amass",
         ))
+    if dropped:
+        logger.info("[amass:%s] dropped %d out-of-scope subdomains", session.id, dropped)
     return objs

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -254,7 +254,8 @@ def _check_dnssec(session, domain) -> list:
             description=(
                 f"{domain} has no DNSSEC configured. DNS responses can be forged — "
                 "an attacker can silently redirect users to malicious servers. "
-                "DNSSEC is mandatory for .bank.in domains under the RBI cybersecurity framework."
+                "DNSSEC authenticates DNS answers and is required or recommended by "
+                "many security and compliance frameworks."
             ),
             remediation=(
                 "Enable DNSSEC at your domain registrar:\n"

--- a/apps/nmap/analyzer.py
+++ b/apps/nmap/analyzer.py
@@ -152,6 +152,13 @@ def analyze(session, xml_outputs: dict[str, str]) -> list[Finding]:
                             severity = "info"
                             extra.update(backport_info)
 
+                        cvss_score = v.get("cvss", 0)
+                        desc = (
+                            f"{v['id']} was detected by Nmap Vulners on "
+                            f"{service_name or 'unknown service'} {version} at {ip}:{port_num}. "
+                            f"Reported CVSS score: {cvss_score}. "
+                            "This is a version-based match — validate against the installed package build before treating as confirmed."
+                        )
                         findings.append(Finding(
                             session=session,
                             source="nmap",
@@ -160,8 +167,8 @@ def analyze(session, xml_outputs: dict[str, str]) -> list[Finding]:
                             target=f"{ip}:{port_num}",
                             severity=severity,
                             title=f"{v['id']} on {service_name or 'unknown'} {version}".strip(),
-                            description=output[:2000],
-                            extra=extra,
+                            description=desc,
+                            extra={**extra, "raw_vulners_output": output[:2000]},
                         ))
 
     return findings

--- a/apps/subfinder/analyzer.py
+++ b/apps/subfinder/analyzer.py
@@ -7,13 +7,23 @@ from apps.core.assets.models import Subdomain
 logger = logging.getLogger(__name__)
 
 
+def _in_scope(host: str, domain: str) -> bool:
+    host = host.lower()
+    domain = domain.lower()
+    return host == domain or host.endswith("." + domain)
+
+
 def analyze(session, records: list[dict]) -> list[Subdomain]:
     """Build shared Subdomain asset instances from raw collector records."""
     objs = []
     seen = set()
+    dropped = 0
     for record in records:
         host = record.get("host", "").strip().lower()
         if not host or host in seen:
+            continue
+        if not _in_scope(host, session.domain):
+            dropped += 1
             continue
         seen.add(host)
         objs.append(Subdomain(
@@ -22,4 +32,6 @@ def analyze(session, records: list[dict]) -> list[Subdomain]:
             subdomain=host,
             source="subfinder",
         ))
+    if dropped:
+        logger.info("[subfinder:%s] dropped %d out-of-scope subdomains", session.id, dropped)
     return objs

--- a/tests/unit/test_amass.py
+++ b/tests/unit/test_amass.py
@@ -180,6 +180,21 @@ class TestAmassAnalyzer:
         objs = analyze(sess, records)
         assert len(objs) == 1
 
+    def test_drops_out_of_scope_hosts(self):
+        """Scope boundary: only the target domain + its subdomains are kept;
+        suffix-bypass tricks are rejected."""
+        from apps.core.scans.models import ScanSession
+        sess = ScanSession.objects.create(domain="example.com", scan_type="full")
+        records = [
+            {"host": "api.example.com"},        # in scope
+            {"host": "example.com"},            # in scope (apex)
+            {"host": "notexample.com"},         # out — suffix bypass
+            {"host": "example.com.evil.com"},   # out — prefix trick
+            {"host": "other.org"},              # out
+        ]
+        hosts = {o.subdomain for o in analyze(sess, records)}
+        assert hosts == {"api.example.com", "example.com"}
+
     def test_normalizes_to_lowercase(self):
         from apps.core.scans.models import ScanSession
         sess = ScanSession.objects.create(domain="example.com", scan_type="full")


### PR DESCRIPTION
Two fixes:

**1. Subdomain scope boundary** (vennela, 666415e) — amass/subfinder/alterx analyzers now drop hosts outside the target domain (same suffix-safe `_in_scope` check as the katana/historical_urls filter in #241: rejects `notexample.com`, `example.com.evil.com`), plus cleaner nmap CVE descriptions. Added a lock test for the drop behavior.

**2. Genericize DNSSEC finding** — the DNSSEC check shipped in #244 hardcoded *"mandatory for .bank.in domains under the RBI cybersecurity framework"* — India-banking-specific text in a worldwide tool. Replaced with framework-neutral guidance. (This is vennela's own later genericization, which I hadn't merged with the DNSSEC check.)

Fast suite green (1060). No report/CLAUDE-count collisions with the in-flight tool PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)