### PR TITLE
fix: partial-scan step diagnostics in PDF report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -586,7 +586,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_nuclei_network.py` | 28 | Network-template parsing, non-web targeting, collector |
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
 | `tests/unit/test_qcluster_config.py` | 4 | Django-Q cluster config |
-| `tests/unit/test_reports.py` | 46 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block |
+| `tests/unit/test_reports.py` | 48 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block |
 | `tests/unit/test_waf_detection.py` | 16 | WAF/block/challenge classifier (spec C1) — vendor fingerprint, false-positive guards, analyzer wiring |
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
@@ -608,4 +608,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1168 tests** (1117 fast + 51 slow domain_security)
+**Total: 1170 tests** (1119 fast + 51 slow domain_security)

--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -501,6 +501,23 @@ def export_scan_pdf(request, session_uuid):
     )
     tool_count = len(active_tools)
 
+    # Workflow step diagnostics — only populated for partial scans
+    workflow_steps = []
+    if session.status == "partial":
+        from apps.core.workflows.models import WorkflowRun, WorkflowStepResult
+        run = WorkflowRun.objects.filter(session=session).first()
+        if run:
+            for step in WorkflowStepResult.objects.filter(run=run).order_by("order"):
+                dur = None
+                if step.started_at and step.finished_at:
+                    dur = int((step.finished_at - step.started_at).total_seconds())
+                workflow_steps.append({
+                    "tool": step.tool,
+                    "status": step.status,
+                    "duration": dur,
+                    "error": step.error or "",
+                })
+
     # Scan duration
     scan_duration = None
     if session.end_time and session.start_time:
@@ -534,6 +551,7 @@ def export_scan_pdf(request, session_uuid):
         "tool_count": tool_count,
         "vector_count": len(methodology),
         "scan_duration": scan_duration,
+        "workflow_steps": workflow_steps,
         "generated_at": timezone.now(),
         "logo_data_uri": _logo_data_uri("white"),          # dark cover
         "header_logo_data_uri": _logo_data_uri("brand"),   # light-page running header

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -236,6 +236,39 @@
 </table>
 <p class="lead" style="font-style:italic;">Every finding is traceable to a specific tool, check type, and target in Detailed Findings. Automated version-to-CVE matching can over-report where a vendor backports fixes without changing the version banner; such matches should be validated against the actual package build.</p>
 
+{% if workflow_steps %}
+<div class="h2">Scan Step Diagnostics (Partial Scan)</div>
+<p class="lead" style="font-style:italic;">This scan completed with status <strong>Partial</strong> — one or more pipeline steps did not finish successfully. The table below shows the outcome of every step that was attempted.</p>
+<table class="grid">
+  <thead>
+    <tr>
+      <th style="width:5%;">#</th>
+      <th style="width:25%;">Tool</th>
+      <th style="width:12%;">Status</th>
+      <th style="width:12%;">Duration</th>
+      <th style="width:46%;">Error / Note</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for step in workflow_steps %}
+    <tr>
+      <td>{{ forloop.counter }}</td>
+      <td><strong>{{ step.tool }}</strong></td>
+      <td>
+        {% if step.status == "completed" %}Completed
+        {% elif step.status == "failed" %}FAILED
+        {% elif step.status == "skipped" %}Skipped
+        {% elif step.status == "running" %}Timed Out
+        {% else %}{{ step.status|title }}{% endif %}
+      </td>
+      <td>{% if step.duration %}{{ step.duration }}s{% else %}—{% endif %}</td>
+      <td style="font-size:0.85em;word-break:break-word;">{% if step.error %}{{ step.error|truncatechars:300 }}{% else %}—{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
 <!-- ==================== 3. FINDINGS SUMMARY ==================== -->
 <div class="page-break"></div>
 <div class="h1">3. Findings Summary</div>

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -401,6 +401,42 @@ class TestPdfSeverityCounts:
         assert "3 raw scanner detections into 1 unique issue" in html
 
 
+@pytest.mark.django_db
+class TestPartialScanDiagnostics:
+    """A 'partial' scan shows a step-diagnostics table explaining which pipeline
+    steps failed; a completed scan shows nothing."""
+
+    def _render(self, authed_client, session):
+        captured = {}
+
+        def cap(html):
+            captured["html"] = html
+            return b"%PDF-1.7"
+
+        with patch("apps.core.reports.views._render_pdf", side_effect=cap):
+            res = authed_client.get(f"/reports/{session.uuid}/pdf/")
+        assert res.status_code == 200
+        return captured["html"]
+
+    def test_diagnostics_shown_for_partial_scan(self, authed_client, session):
+        from apps.core.workflows.models import Workflow, WorkflowRun, WorkflowStepResult
+        session.status = "partial"
+        session.save(update_fields=["status"])
+        wf = Workflow.objects.create(name="WF", is_default=False)
+        run = WorkflowRun.objects.create(session=session, workflow=wf, status="partial")
+        WorkflowStepResult.objects.create(run=run, tool="nuclei", status="failed",
+                                          order=1, error="timed out after 1800s")
+        WorkflowStepResult.objects.create(run=run, tool="httpx", status="completed", order=2)
+        html = self._render(authed_client, session)
+        assert "Scan Step Diagnostics" in html
+        assert "nuclei" in html
+        assert "timed out after 1800s" in html
+
+    def test_no_diagnostics_for_completed_scan(self, authed_client, session):
+        html = self._render(authed_client, session)  # session fixture is 'completed'
+        assert "Scan Step Diagnostics" not in html
+
+
 class TestTopRisksAndIntel:
     """The 'Fix First' block ranks by priority (KEV dominates) and the report
     surfaces EPSS/KEV threat intel collected by cve_intel."""


### PR DESCRIPTION
Last un-merged item from @vennela-cybersecify (1f9f134, authorship preserved). When a scan finishes `partial` (a pipeline step failed/timed out), the report now shows a **Scan Step Diagnostics** table — which steps ran, failed, and why — instead of silently presenting fewer findings with no explanation. Absent for completed scans. +2 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)