### PR TITLE
fix: add asn_discovery + js_secrets to Full Scan (21 tools end-to-end)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,25 @@ Per-module routers (each file exports a `router = Router(auth=JWTAuth())`):
 
 ### Tool auto-registration
 
-Tools self-register via `AppConfig.tool_meta`. **No core files need editing when adding a new tool** (except `settings.INSTALLED_APPS`).
+Tools self-register via `AppConfig.tool_meta`. No core *code* needs editing to
+register a tool — but registration alone does **not** put it in a scan.
+
+**Definition of done for adding (or removing) a tool** — all of these, or the
+registry, the scan, the report, and the public docs drift out of sync (this is
+how asn_discovery/js_secrets shipped registered-but-not-scanned, reading 21 in
+the registry and 19 in every actual scan):
+
+1. Add the app to `settings.INSTALLED_APPS`.
+2. **Add it to the default Full Scan workflow** via a data migration (unless it
+   is deliberately default-off — then document why). Enforced by
+   `tests/unit/test_default_workflow.py::test_full_scan_covers_every_registered_tool`,
+   which fails CI if a registered non-core tool is missing from Full Scan.
+3. Set the `"active"` flag correctly (passive = no target contact → no auth).
+4. Update `README.md` — the tool count, the tool list, and the pipeline diagram.
+5. Update `CHANGELOG.md` (What + Why) and the tool tables in this file.
+6. **Flag the website session** — cybersecify.com's tool count, feature cards,
+   and the sample report must match. Keeping GitHub + website in sync on any
+   tool/feature change is a standing requirement, not an afterthought.
 
 ```python
 # Example: apps/my_tool/apps.py
@@ -604,8 +622,8 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_passive_scan.py` | 21 | registry `active` classification, `is_passive_tool_set`, Passive Scan workflow all-passive invariant, passive-scan auth-gate bypass + active-scan gate, subscan gate |
 | `tests/unit/test_workflow_runner.py` | 32 | run_workflow, naabu-gated service_detection injection, step failure, cancellation, phase parallelism |
-| `tests/unit/test_default_workflow.py` | 4 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
+| `tests/unit/test_default_workflow.py` | 5 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1170 tests** (1119 fast + 51 slow domain_security)
+**Total: 1171 tests** (1120 fast + 51 slow domain_security)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline**: 19-tool scan workflow from domain to findings
+- **Automated pipeline**: 21-tool scan workflow from domain to findings
 - **Network attack surface scanning**: CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **CVE prioritisation**: EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows**: Create custom scan configurations, enable/disable tools per workflow

--- a/apps/core/workflows/migrations/0023_add_asn_jssecrets_to_full_scan.py
+++ b/apps/core/workflows/migrations/0023_add_asn_jssecrets_to_full_scan.py
@@ -1,0 +1,49 @@
+"""Add asn_discovery + js_secrets to the Full Scan workflow.
+
+Both tools were registered (#245, #248) but never added to the default Full
+Scan, so the workflow-computed tool count (report + hosted scan) stayed at 19
+while the registry had 21 — a claim/behaviour mismatch. Adding them here makes
+"21 tools" true end to end: registry, Full Scan workflow, and report all agree.
+
+Additive and idempotent (skips a tool already present), matching 0021. Execution
+order is unaffected — the runner groups by registry phase, so appended steps run
+in their correct phase regardless of `order`.
+"""
+
+from django.db import migrations
+
+_NEW_TOOLS = ["asn_discovery", "js_secrets"]
+
+
+def add_tools(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+
+    wf = Workflow.objects.filter(name="Full Scan").first()
+    if wf is None:
+        return
+    existing = set(wf.steps.values_list("tool", flat=True))
+    next_order = (wf.steps.order_by("-order").values_list("order", flat=True).first() or 0) + 1
+    for tool in _NEW_TOOLS:
+        if tool not in existing:
+            WorkflowStep.objects.create(workflow=wf, tool=tool, order=next_order, enabled=True)
+            next_order += 1
+
+
+def remove_tools(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    wf = Workflow.objects.filter(name="Full Scan").first()
+    if wf is None:
+        return
+    WorkflowStep.objects.filter(workflow=wf, tool__in=_NEW_TOOLS).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflow", "0022_create_passive_scan_workflow"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tools, remove_tools),
+    ]

--- a/tests/unit/test_default_workflow.py
+++ b/tests/unit/test_default_workflow.py
@@ -8,6 +8,8 @@ _EXPECTED_FULL_SCAN = {
     "takeover_check", "cloud_assets", "naabu", "nmap", "tls_checker",
     "ssh_checker", "nuclei_network", "httpx", "historical_urls", "katana",
     "nuclei", "web_checker", "cve_intel",
+    # added in 0023 so registry (21) == Full Scan == report tool count
+    "asn_discovery", "js_secrets",
 }
 
 
@@ -53,6 +55,8 @@ def test_forward_is_idempotent_and_fills_gaps():
     _0021.set_full_scan_default(django_apps, None)
 
     tools = set(wf.steps.values_list("tool", flat=True))
-    assert _EXPECTED_FULL_SCAN <= tools
+    # 0021 restores its own canonical 18; asn_discovery/js_secrets are added by
+    # the separate migration 0023, so exclude them from this migration's check.
+    assert (_EXPECTED_FULL_SCAN - {"asn_discovery", "js_secrets"}) <= tools
     # no duplicates introduced
     assert wf.steps.count() == len(set(wf.steps.values_list("tool", flat=True)))

--- a/tests/unit/test_default_workflow.py
+++ b/tests/unit/test_default_workflow.py
@@ -21,6 +21,25 @@ def test_default_is_full_scan():
 
 
 @pytest.mark.django_db
+def test_full_scan_covers_every_registered_tool():
+    """QA invariant: every non-core registered tool must be in the default Full
+    Scan. A tool that's registered but never runs in the default scan is dead
+    weight (the exact 21-vs-19 drift that shipped asn_discovery/js_secrets
+    without wiring them into Full Scan). This fails CI if a new tool is added to
+    the registry but not to the Full Scan workflow migration."""
+    from apps.core.workflows.registry import get_registry
+    from apps.core.workflows.models import Workflow
+    non_core = {n for n, i in get_registry().items() if not i.get("core")}
+    full_scan = set(Workflow.objects.get(name="Full Scan").steps.values_list("tool", flat=True))
+    missing = non_core - full_scan
+    assert not missing, (
+        f"Registered tools missing from the default Full Scan: {missing}. "
+        f"Add them via a workflow migration, or the scan/report/README will "
+        f"under-count. (core tools like service_detection are auto-injected.)"
+    )
+
+
+@pytest.mark.django_db
 def test_exactly_one_default():
     from apps.core.workflows.models import Workflow
     assert Workflow.objects.filter(is_default=True).count() == 1


### PR DESCRIPTION
**Resolves the 21-vs-19 mismatch that held back the website copy.**

asn_discovery (#245) and js_secrets (#248) were registered but never added to the default **Full Scan** workflow — asn_discovery ran only in Passive Scan, js_secrets in no workflow. Since the report/hosted-scan tool count is computed from the **workflow**, not the registry, a scan printed **19** while the registry (and README) claimed **21**.

**Fix:** migration `0023` adds both to Full Scan (additive + idempotent, order-safe — runner groups by phase). README "19-tool" → "21-tool". Test locks both into Full Scan.

Now **registry == Full Scan == report == 21**. Verified: a freshly-rendered sample now prints "6 Vectors, 21 Tools" and lists ASN Discovery + JS Secrets in the methodology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)