### PR TITLE
fix: production HTTPS/security hardening in settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,14 @@ docker run -d \
 - `--restart unless-stopped` — survives server reboots
 - Volumes: `openeasd-data` (SQLite DB) and `openeasd-logs` persist across container replacements
 - Static files served by WhiteNoise (no nginx needed)
+- **Serve it over HTTPS.** Do NOT expose the app on bare HTTP — login sends
+  credentials and JWTs in cleartext. Put a TLS-terminating reverse proxy in
+  front (Caddy/nginx + Let's Encrypt on a real domain, or Cloudflare) — a bare
+  IP like `http://<ip>/` cannot get a normal cert and must not be used with real
+  credentials. The app already sends `SECURE_PROXY_SSL_HEADER`; once TLS is in
+  front, enable enforcement via env: `SECURE_SSL_REDIRECT=true` and
+  `SECURE_HSTS_SECONDS=31536000`. `SESSION_COOKIE_SECURE`/`CSRF_COOKIE_SECURE`
+  are already on by default when `DEBUG=False`.
 
 ### Kubernetes
 Manifests in `k8s/`. Deploy with `kubectl apply -k k8s/`.
@@ -617,7 +625,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_tls_checker.py` | 87 | Cert parsing, ciphers, protocols, HSTS, collector, scanner, cipher enumeration |
 | `tests/unit/test_tools_healthcheck.py` | 14 | Tool binary preflight / health checks |
 | `tests/unit/test_user_profile.py` | 7 | UserProfile `must_change_password` flag |
-| `tests/unit/test_settings_security.py` | 4 | SECRET_KEY strength guard (DEBUG=False + insecure default) |
+| `tests/unit/test_settings_security.py` | 8 | SECRET_KEY strength guard (DEBUG=False + insecure default) |
 | `tests/unit/test_insights_builder.py` | 4 | FindingTypeSummary prune only when aggregation_complete |
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_passive_scan.py` | 21 | registry `active` classification, `is_passive_tool_set`, Passive Scan workflow all-passive invariant, passive-scan auth-gate bypass + active-scan gate, subscan gate |
@@ -626,4 +634,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
 
-**Total: 1171 tests** (1120 fast + 51 slow domain_security)
+**Total: 1175 tests** (1124 fast + 51 slow domain_security)

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -44,6 +44,34 @@ if "pytest" not in sys.modules:
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="localhost,127.0.0.1").split(",")
 
+# --- Production HTTPS / security hardening (DEBUG=False only) ---
+def _security_settings(debug: bool) -> dict:
+    """Production security flags. Pure + testable (see test_settings_security).
+
+    - SECURE_PROXY_SSL_HEADER is always set: behind a TLS-terminating proxy
+      (Caddy/nginx/Cloudflare) it lets Django see the original HTTPS scheme; with
+      no proxy it is simply never matched, so it is harmless.
+    - The rest apply only outside DEBUG. Cookies are secure-by-default (an
+      HTTP-only deploy should fix TLS, not weaken this). SSL redirect + HSTS
+      default OFF because enabling them before TLS is terminated breaks the site
+      (redirect loop / HSTS pin) — turn them on via env once TLS is in front.
+    """
+    flags = {"SECURE_PROXY_SSL_HEADER": ("HTTP_X_FORWARDED_PROTO", "https")}
+    if not debug:
+        flags.update(
+            SESSION_COOKIE_SECURE=config("SESSION_COOKIE_SECURE", default=True, cast=bool),
+            CSRF_COOKIE_SECURE=config("CSRF_COOKIE_SECURE", default=True, cast=bool),
+            SECURE_CONTENT_TYPE_NOSNIFF=True,
+            SECURE_SSL_REDIRECT=config("SECURE_SSL_REDIRECT", default=False, cast=bool),
+            SECURE_HSTS_SECONDS=config("SECURE_HSTS_SECONDS", default=0, cast=int),
+            SECURE_HSTS_INCLUDE_SUBDOMAINS=config("SECURE_HSTS_INCLUDE_SUBDOMAINS", default=True, cast=bool),
+            SECURE_HSTS_PRELOAD=config("SECURE_HSTS_PRELOAD", default=False, cast=bool),
+        )
+    return flags
+
+
+globals().update(_security_settings(DEBUG))
+
 # Allow Vite dev server to make CSRF-protected POST requests in development
 CSRF_TRUSTED_ORIGINS = config(
     "CSRF_TRUSTED_ORIGINS",

--- a/tests/unit/test_settings_security.py
+++ b/tests/unit/test_settings_security.py
@@ -3,7 +3,31 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
-from openeasd.settings import _validate_secret_key
+from openeasd.settings import _validate_secret_key, _security_settings
+
+
+class TestSecurityHardening:
+    def test_proxy_ssl_header_always_set(self):
+        # Set in both modes so the app works behind a TLS-terminating proxy.
+        assert _security_settings(debug=True)["SECURE_PROXY_SSL_HEADER"] == (
+            "HTTP_X_FORWARDED_PROTO", "https")
+        assert "SECURE_PROXY_SSL_HEADER" in _security_settings(debug=False)
+
+    def test_secure_cookies_default_on_in_production(self):
+        s = _security_settings(debug=False)
+        assert s["SESSION_COOKIE_SECURE"] is True
+        assert s["CSRF_COOKIE_SECURE"] is True
+        assert s["SECURE_CONTENT_TYPE_NOSNIFF"] is True
+
+    def test_ssl_redirect_and_hsts_default_off(self):
+        # Off by default so they don't break a deploy that has no TLS yet.
+        s = _security_settings(debug=False)
+        assert s["SECURE_SSL_REDIRECT"] is False
+        assert s["SECURE_HSTS_SECONDS"] == 0
+
+    def test_debug_mode_applies_no_cookie_hardening(self):
+        s = _security_settings(debug=True)
+        assert "SESSION_COOKIE_SECURE" not in s  # local dev over http stays usable
 
 
 class TestSecretKeyGuard:


### PR DESCRIPTION
**Prompted by the plain-HTTP deploy at 139.59.24.60** — credentials and JWTs were transiting in cleartext, and `settings.py` had *none* of Django's production hardening.

Adds a testable `_security_settings(debug)` applied via `globals().update()`:
- **Always:** `SECURE_PROXY_SSL_HEADER` — so behind a TLS proxy Django sees the real HTTPS scheme (harmless without a proxy).
- **When `DEBUG=False`:** `SESSION_COOKIE_SECURE` + `CSRF_COOKIE_SECURE` (default **on**), `SECURE_CONTENT_TYPE_NOSNIFF`; `SECURE_SSL_REDIRECT` + HSTS **default off** (env-enable once TLS is in front, so we don't cause a redirect loop / HSTS pin on a no-TLS box).

Deploy docs now state HTTPS is required (real domain + Caddy/nginx/Let's-Encrypt or Cloudflare; a bare IP can't get a cert) and how to flip on enforcement.

+4 tests. This is the **app** half; the **deploy** half (put the droplet behind TLS) is ops — flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)