### PR TITLE
feat: surface build version/commit/date in app + health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,21 @@ jobs:
             type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Compute build provenance
+        id: prov
+        run: |
+          # Version: git tag for v* builds (strip the leading v), else the
+          # pyproject.toml [project] version for main-branch :latest builds.
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            version="${GITHUB_REF#refs/tags/v}"
+          else
+            version="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')"
+          fi
+          {
+            echo "version=${version}"
+            echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push (amd64 + arm64)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
@@ -130,6 +145,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OPENEASD_VERSION=${{ steps.prov.outputs.version }}
+            OPENEASD_GIT_SHA=${{ github.sha }}
+            OPENEASD_BUILD_DATE=${{ steps.prov.outputs.build_date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Supply-chain transparency: SBOM + SLSA provenance baked into the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ git describe --tags --abbrev=0
 - **Publish triggers:** every push to `main` (`:latest` tag) and `v*` tags (`:vX.Y` tag)
 - Runner: `ubuntu-24.04`, Python 3.12, `uv sync --group dev` for deps, `libcairo2-dev gcc libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0` system deps required (WeasyPrint PDF rendering)
 - `pip-audit --ignore-vuln PYSEC-2025-183` — disputed PyJWT weak-key-length CVE, no fix available
+- **Build provenance:** the `publish` job computes `OPENEASD_VERSION` (git tag for `v*`, else `pyproject.toml` version), `OPENEASD_GIT_SHA` (`github.sha`), and `OPENEASD_BUILD_DATE` (ISO UTC) and passes them as `build-args` to buildx. The Dockerfile bakes them into `ENV` (placed late so they never bust the cache of the heavy layers). Settings read them via `config()` with `dev`/`unknown` defaults for local runs. Surfaced at `GET /health/` + `GET /api/version/`, and shown as a muted footer on the login + change-password pages (`frontend/src/components/BuildInfo.jsx`).
 
 ## Commands
 - Always use `uv run python` instead of `python` or `python3`
@@ -210,7 +211,7 @@ k8s/
 **Key constraints:**
 - `replicas: 1` required — SQLite RWO PVC allows single-node access only
 - Only `worker` container gets `NET_RAW`; `web` does not need it
-- `GET /health/` — unauthenticated endpoint used by K8s readiness/liveness probes
+- `GET /health/` — unauthenticated endpoint used by K8s readiness/liveness probes; JSON body is `{status, version, git_sha (short 8), build_date}` (build provenance)
 - **Real `ALLOWED_HOSTS`/`CSRF_TRUSTED_ORIGINS` live in `openeasd-secret`, never in
   the committed configmap.** `configmap.yaml` carries only placeholders; the real
   hostname is set in the secret, which is applied out-of-band and is intentionally
@@ -540,6 +541,7 @@ POST /api/token/pair                      — JWT login → {access, refresh}
 POST /api/token/blacklist                 — blacklist refresh token (logout)
 POST /api/token/refresh                   — exchange refresh → new access token
 POST /api/token/verify                    — verify token validity
+GET  /api/version/                        — build provenance {version, git_sha, git_sha_short, build_date} (unauthenticated)
 GET  /api/user/                           — current user info + must_change_password flag
 POST /api/user/change-password/           — change password; clears must_change_password flag
 GET  /api/dashboard/                      — KPIs, domain status, urgent findings
@@ -632,6 +634,6 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_workflow_runner.py` | 32 | run_workflow, naabu-gated service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/unit/test_default_workflow.py` | 5 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 89 | Smoke tests for all API endpoints (auth + payload shape) |
+| `tests/test_api_endpoints.py` | 93 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` |
 
 **Total: 1175 tests** (1124 fast + 51 slow domain_security)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,4 +636,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 93 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` |
 
-**Total: 1175 tests** (1124 fast + 51 slow domain_security)
+**Total: 1179 tests** (1128 fast + 51 slow domain_security)

--- a/Dockerfile
+++ b/Dockerfile
@@ -188,6 +188,16 @@ RUN chmod +x docker-entrypoint.sh
 # Pre-collect static files so the image is ready without a volume
 RUN SECRET_KEY=build-time-placeholder python manage.py collectstatic --noinput
 
+# Build provenance — placed late so it never busts the cache of the heavy
+# layers above (these three change on every build). Baked into the running
+# container's env; surfaced via GET /health/ and GET /api/version/. CI supplies
+# real values through build-args (see .github/workflows/ci.yml); local builds
+# fall back to the "dev"/"unknown" defaults, which the UI renders cleanly.
+ARG OPENEASD_VERSION=dev
+ARG OPENEASD_GIT_SHA=unknown
+ARG OPENEASD_BUILD_DATE=unknown
+ENV OPENEASD_VERSION=$OPENEASD_VERSION OPENEASD_GIT_SHA=$OPENEASD_GIT_SHA OPENEASD_BUILD_DATE=$OPENEASD_BUILD_DATE
+
 VOLUME ["/app/data", "/app/logs"]
 EXPOSE 8000
 

--- a/apps/core/api/ninja.py
+++ b/apps/core/api/ninja.py
@@ -1,5 +1,6 @@
 """Central Django Ninja API instance for OpenEASD."""
 
+from django.conf import settings
 from django.http import JsonResponse
 from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError, ValidationError
@@ -73,6 +74,23 @@ def validation_error_handler(request, exc):
 api.add_router("/token", obtain_pair_router)
 api.add_router("/token", verify_router)
 api.add_router("/token", blacklist_router)
+
+
+# ---------------------------------------------------------------------------
+# Build provenance — unauthenticated. Lets a deployer confirm exactly what
+# version/commit/date the running image was built from. Baked into the image
+# at build time (Dockerfile ARG/ENV + CI build-args). Defaults render cleanly
+# for local runs ("dev"/"unknown").
+# ---------------------------------------------------------------------------
+@api.get("/version/", auth=None)
+def version(request):
+    sha = settings.OPENEASD_GIT_SHA
+    return {
+        "version": settings.OPENEASD_VERSION,
+        "git_sha": sha,
+        "git_sha_short": sha[:8],
+        "build_date": settings.OPENEASD_BUILD_DATE,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenEASD</title>
-    <script type="module" crossorigin src="/static/assets/index-CVVmEHM2.js"></script>
-    <link rel="stylesheet" crossorigin href="/static/assets/index-DtCRdgaW.css">
+    <script type="module" crossorigin src="/static/assets/index-D9zC4twm.js"></script>
+    <link rel="stylesheet" crossorigin href="/static/assets/index-B4JzSkbd.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/BuildInfo.jsx
+++ b/frontend/src/components/BuildInfo.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiGet } from '../api/client.js';
+
+/**
+ * Muted footer line showing the running build's provenance, e.g.
+ *   OpenEASD v0.10.0 · a1b2c3d4 · 2026-08-22
+ * Data comes from the unauthenticated GET /api/version/. Local (non-image)
+ * runs report "dev"/"unknown" defaults, which are omitted so the line never
+ * reads "unknown · unknown".
+ */
+export default function BuildInfo({ className = '' }) {
+  const { data } = useQuery({
+    queryKey: ['/version/'],
+    queryFn: () => apiGet('/version/'),
+    staleTime: Infinity,
+  });
+
+  if (!data) return null;
+
+  const parts = [`OpenEASD ${data.version === 'dev' ? 'dev' : `v${data.version}`}`];
+  if (data.git_sha_short && data.git_sha_short !== 'unknown') {
+    parts.push(data.git_sha_short);
+  }
+  if (data.build_date && data.build_date !== 'unknown') {
+    parts.push(String(data.build_date).split('T')[0]);
+  }
+
+  return (
+    <div className={`text-[11px] text-dim/70 text-center select-none ${className}`}>
+      {parts.join(' · ')}
+    </div>
+  );
+}

--- a/frontend/src/pages/ChangePasswordPage.jsx
+++ b/frontend/src/pages/ChangePasswordPage.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Button } from '../components/ui/button.jsx';
 import { apiPost } from '../api/client.js';
 import { useNavigate } from 'react-router-dom';
+import BuildInfo from '../components/BuildInfo.jsx';
 
 export default function ChangePasswordPage() {
   const navigate = useNavigate();
@@ -59,6 +60,7 @@ export default function ChangePasswordPage() {
             {loading ? 'Saving…' : 'Set New Password'}
           </Button>
         </form>
+        <BuildInfo className="mt-6" />
       </div>
     </div>
   );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import { Button } from '../components/ui/button.jsx';
 import { apiPost, apiGet } from '../api/client.js';
 import { auth } from '../auth.js';
 import { useNavigate } from 'react-router-dom';
+import BuildInfo from '../components/BuildInfo.jsx';
 
 export default function LoginPage() {
   const navigate = useNavigate();
@@ -51,6 +52,7 @@ export default function LoginPage() {
             {loading ? 'Signing in…' : 'Sign in'}
           </Button>
         </form>
+        <BuildInfo className="mt-6" />
       </div>
     </div>
   );

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -303,6 +303,14 @@ OPENEASD_USER_AGENT = config(
     default="OpenEASD/1.0 (+https://cybersecify.com/openeasd)",
 )
 
+# Build provenance — baked into the image at build time (see Dockerfile ARG/ENV
+# + the CI publish job's build-args). Lets a deployer verify exactly what
+# version/commit/date the running image was built from, via GET /health/ and
+# GET /api/version/. Defaults render cleanly for local (non-image) runs.
+OPENEASD_VERSION = config("OPENEASD_VERSION", default="dev")
+OPENEASD_GIT_SHA = config("OPENEASD_GIT_SHA", default="unknown")
+OPENEASD_BUILD_DATE = config("OPENEASD_BUILD_DATE", default="unknown")
+
 # Logging
 LOGGING = {
     "version": 1,

--- a/openeasd/urls.py
+++ b/openeasd/urls.py
@@ -11,7 +11,12 @@ from apps.core.api.ninja import api
 
 
 def health(request):
-    return JsonResponse({"status": "ok"})
+    return JsonResponse({
+        "status": "ok",
+        "version": settings.OPENEASD_VERSION,
+        "git_sha": settings.OPENEASD_GIT_SHA[:8],
+        "build_date": settings.OPENEASD_BUILD_DATE,
+    })
 
 
 urlpatterns = [

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -92,7 +92,7 @@ class TestHealthEndpoint:
         assert res.status_code == 200
 
     def test_returns_ok_status(self, client):
-        assert client.get("/health/").json() == {"status": "ok"}
+        assert client.get("/health/").json()["status"] == "ok"
 
     def test_no_auth_required(self, client):
         # Must be accessible without a token — used by K8s liveness/readiness probes
@@ -817,3 +817,40 @@ def scan_summary(db, scan):
         total_findings=1, new_exposures=1, removed_exposures=0,
         tool_breakdown={},
     )
+
+
+# ---------------------------------------------------------------------------
+# Build provenance — /health/ + /api/version/ (both unauthenticated)
+# ---------------------------------------------------------------------------
+
+class TestBuildProvenance:
+    def test_health_includes_provenance(self, client):
+        res = client.get("/health/")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["status"] == "ok"
+        # Settings defaults resolve locally (no image build args set).
+        assert data["version"] == "dev"
+        assert data["git_sha"] == "unknown"
+        assert data["build_date"] == "unknown"
+
+    def test_version_endpoint_no_auth(self, client):
+        res = client.get("/api/version/")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["version"] == "dev"
+        assert data["git_sha"] == "unknown"
+        assert data["git_sha_short"] == "unknown"
+        assert data["build_date"] == "unknown"
+
+    def test_version_short_sha_truncates(self, client, settings):
+        settings.OPENEASD_GIT_SHA = "0123456789abcdef0123456789abcdef01234567"
+        res = client.get("/api/version/")
+        data = res.json()
+        assert data["git_sha"] == "0123456789abcdef0123456789abcdef01234567"
+        assert data["git_sha_short"] == "01234567"
+
+    def test_health_short_sha_truncates(self, client, settings):
+        settings.OPENEASD_GIT_SHA = "0123456789abcdef0123456789abcdef01234567"
+        res = client.get("/health/")
+        assert res.json()["git_sha"] == "01234567"


### PR DESCRIPTION
## What
Adds build provenance so a deployer can verify exactly what version/commit/date the running image was built from.

- **Dockerfile** — `ARG`/`ENV` for `OPENEASD_VERSION`/`GIT_SHA`/`BUILD_DATE`, placed late so they don't bust the cache of the heavy layers above.
- **CI (`publish` job)** — computes version (git tag for `v*`, else `pyproject.toml`), git SHA (`github.sha`), ISO UTC build date; passes them to buildx as `build-args`.
- **Backend** — `settings.py` reads the three vars (`dev`/`unknown` defaults). `GET /health/` gains `version`/`git_sha` (short 8)/`build_date`; new unauthenticated `GET /api/version/` returns `{version, git_sha, git_sha_short, build_date}`.
- **Frontend** — muted footer (`BuildInfo.jsx`) on login + change-password pages. `dev`/`unknown` parts are omitted, so local runs never read "unknown · unknown".

## How to read the running version
- `GET /health/` → `{"status":"ok","version":"0.10.0","git_sha":"a1b2c3d4","build_date":"2026-08-22T…Z"}`
- `GET /api/version/` → `{"version","git_sha","git_sha_short","build_date"}` (no auth)

## Verify
- `makemigrations --check --dry-run` clean
- `cd frontend && npm run build` succeeds
- Fast suite green (added 4 provenance tests; `/health/` equality test updated for new fields)

Out of scope (deliberate follow-up): no "update available" comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)