### PR TITLE
feat: in-app 'Report an issue / Request a feature' links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Something in OpenEASD isn't working as expected
+title: "[Bug] "
+labels: bug
+---
+
+**What happened**
+A clear description of the bug.
+
+**Steps to reproduce**
+1.
+2.
+
+**Expected behaviour**
+
+**Build**
+The version line from the app footer, or the output of `GET /health/`
+(e.g. `OpenEASD v0.10.0 · a1b2c3d4 · 2026-08-22`). The in-app "Report an issue"
+link fills this in automatically.
+
+**Environment**
+Docker / bare install / k8s; host OS; anything relevant.
+
+**Logs**
+Relevant scan or container logs (redact any real domains/IPs you don't want public).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest a capability or improvement for OpenEASD
+title: "[Feature] "
+labels: enhancement
+---
+
+**The problem / use case**
+What are you trying to do that OpenEASD doesn't support today?
+
+**Proposed solution**
+What you'd like to see. If it's a new scanning capability, note whether it's
+passive (public sources only) or active (touches the target).
+
+**Alternatives considered**
+
+**Scope note**
+OpenEASD is an external attack-surface scanner. Brand-monitoring features
+(typosquatting, brand impersonation, A–F letter grades) are intentionally out of
+scope — see `docs/DECISIONS.md`.

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenEASD</title>
-    <script type="module" crossorigin src="/static/assets/index-D9zC4twm.js"></script>
-    <link rel="stylesheet" crossorigin href="/static/assets/index-B4JzSkbd.css">
+    <script type="module" crossorigin src="/static/assets/index-BdXzkRJ3.js"></script>
+    <link rel="stylesheet" crossorigin href="/static/assets/index-fHOUJMNm.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/BuildInfo.jsx
+++ b/frontend/src/components/BuildInfo.jsx
@@ -25,10 +25,23 @@ export default function BuildInfo({ className = '' }) {
   if (data.build_date && data.build_date !== 'unknown') {
     parts.push(String(data.build_date).split('T')[0]);
   }
+  const buildLine = parts.join(' · ');
+
+  // Pre-fill new-issue reports with the running build so we never have to ask
+  // "what version are you on?". GitHub Issues is the OSS-native report channel.
+  const ISSUES = 'https://github.com/cybersecify/OpenEASD/issues/new';
+  const env = encodeURIComponent(`\n\n---\nBuild (auto-filled): ${buildLine}`);
+  const bugUrl = `${ISSUES}?labels=bug&title=${encodeURIComponent('[Bug] ')}&body=${env}`;
+  const featureUrl = `${ISSUES}?labels=enhancement&title=${encodeURIComponent('[Feature] ')}&body=${env}`;
 
   return (
-    <div className={`text-[11px] text-dim/70 text-center select-none ${className}`}>
-      {parts.join(' · ')}
+    <div className={`text-[11px] text-dim/70 text-center select-none space-y-0.5 ${className}`}>
+      <div>{buildLine}</div>
+      <div className="space-x-2">
+        <a href={bugUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-dim">Report an issue</a>
+        <span aria-hidden="true">·</span>
+        <a href={featureUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-dim">Request a feature</a>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Adds report links to the deployed UI footer (next to the version from #256), the OSS-native way to collect bug reports + feature requests.

- **Footer links** on login + change-password pages: "Report an issue" / "Request a feature" → GitHub Issues, **pre-filled with the running build** (version · SHA · date) so every report carries what version it's on — no more "what version are you on?".
- **Issue templates** (`.github/ISSUE_TEMPLATE/`): bug_report + feature_request; the feature template notes the external-attack-surface scope boundary.
- Frontend + templates only; the Docker image rebuilds `dist` from source, so it ships in the deployed image. Frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)