### PR TITLE
feat: Hudson Rock infostealer-exposure tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **Infostealer-exposure tool (Hudson Rock)** — a new passive Domain-Intelligence
+  tool that surfaces a domain's infostealer-log exposure via Hudson Rock's free,
+  keyless Cavalier API (aggregate counts, stealer families, last-seen dates, and
+  system-level affected login URLs). **Why:** stolen-credential exposure from
+  info-stealer malware is a leading breach vector that no port/web scan can see;
+  it is public-source (passive) intel that complements the active surface scan.
+  OSS use permitted by Hudson Rock co-founder Alon Gal. Privacy: only aggregate
+  counts are stored — the tool never persists or displays plaintext credentials
+  or individual email addresses, and it is fail-graceful so it can never fail a
+  scan. Added to the Full Scan and Passive Scan workflows (tool count 21 → 22).
 - **Passive vs active scan modes** (#251). A "Passive Scan" workflow uses only
   public-source tools and needs no `DomainAuthorization`; any active tool keeps
   the gate. **Why:** lets you scan an inbound inquiry from public data alone

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,11 +382,12 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 - `get_tool_requires()` — for dependency validation
 - `get_source_choices()` — for finding source filtering
 
-### Tool apps (21 registered tools)
+### Tool apps (22 registered tools)
 
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
 | `apps/domain_security/` | 1 | Domain Intelligence | Yes | DNS, email, RDAP checks |
+| `apps/hudson_rock/` | 1 | Domain Intelligence | Yes | Infostealer-log exposure via Hudson Rock's keyless Cavalier API (aggregate counts only, no plaintext); passive, fail-graceful |
 | `apps/subfinder/` | 2 | Surface Enumeration | No | Passive subdomain enumeration |
 | `apps/amass/` | 2 | Surface Enumeration | No | Active subdomain enumeration |
 | `apps/asn_discovery/` | 2 | Surface Enumeration | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
@@ -429,6 +430,7 @@ but not yet in the default set.)
 
 ```
 Phase 1  domain_security    → Finding (DNS/email/RDAP)
+Phase 1  hudson_rock         → Finding (infostealer exposure via Hudson Rock — passive)
 Phase 2  subfinder          → Subdomain (passive enumeration)
 Phase 2  amass              → Subdomain (active enumeration)
 Phase 2  asn_discovery      → Finding (owned ASN/CIDR ranges via amass intel — informational)
@@ -460,7 +462,7 @@ the registry via `get_tool_active()` and `is_passive_tool_set(tools)`.
   archives, cloud-provider bucket APIs, CVE/EPSS/KEV feeds. Sends **no packets to
   the target's own systems**. Needs **no `DomainAuthorization`**.
   Passive tools: `subfinder`, `alterx`, `dnsx`, `historical_urls`,
-  `cloud_assets`, `cve_intel`, `asn_discovery`.
+  `cloud_assets`, `cve_intel`, `asn_discovery`, `hudson_rock`.
 - **Active** (`active=True`): probes the target directly (port scans, HTTP/TLS/SSH
   connections, crawling, vuln templates, AXFR/SMTP/mta-sts probes). **Requires
   `DomainAuthorization`.**
@@ -602,6 +604,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 16 | JSON parser, Port lookup, Subdomain link, honest UA, tech-detect flag + technology storage/dedup |
+| `tests/unit/test_hudson_rock.py` | 17 | collector (both endpoints keyless + honest UA, fail-graceful on timeout/500/429/bad-JSON, 429 retry), analyzer (severity, counts/families/URLs/attribution, no-finding-when-zero, **no plaintext/email persisted**, URL cap), scanner |
 | `tests/unit/test_js_secrets.py` | 26 | `.js` URL filter + cap, fetch-error handling, gitleaks JSON parser, analyzer Findings + dedup + secret redaction (full secret never stored), scanner, binary-missing/timeout |
 | `tests/unit/test_k8s_manifests.py` | 57 | k8s manifest structure, envFrom order, probes, secret/configmap split |
 | `tests/unit/test_katana.py` | 19 | JSONL parser, Port/Subdomain FK links, scanner orchestrator, honest UA |
@@ -636,4 +639,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 93 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` |
 
-**Total: 1179 tests** (1128 fast + 51 slow domain_security)
+**Total: 1196 tests** (1145 fast + 51 slow domain_security)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Use it as a **red teamer** to map external surface fast on targets you're authorised to test. Use it as a **defender** to see what's leaking out of your own infrastructure: subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs, without paying $500-5000/mo for a commercial EASM platform.
 
-OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-one tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
+OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-two tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, infostealer-log exposure (via Hudson Rock's keyless Cavalier API), technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
 
 Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [Cybersecify](https://cybersecify.com), the same tool we run in engagements and on our own infrastructure.
 
@@ -140,7 +140,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline**: 21-tool scan workflow from domain to findings
+- **Automated pipeline**: 22-tool scan workflow from domain to findings
 - **Network attack surface scanning**: CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **CVE prioritisation**: EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows**: Create custom scan configurations, enable/disable tools per workflow
@@ -163,6 +163,8 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 ── Domain Intelligence ──────────────────────────────────────────────────────
 Phase 1  Domain Security   - DNS, DNSSEC chain-of-trust, email
                              (SPF/DMARC/DKIM/MTA-STS/open-relay), RDAP checks
+Phase 1  Hudson Rock        - Infostealer-log exposure via Hudson Rock's keyless
+                             Cavalier API (aggregate counts only, no plaintext)
 
 ── Surface Enumeration ─────────────────────────────────────────────────────
 Phase 2  Subfinder         - Passive subdomain enumeration
@@ -220,6 +222,7 @@ apps/core/              - Infrastructure (never changes)
 
 apps/                   - Tool apps (add/remove freely)
   domain_security/      - DNS, email, RDAP checks
+  hudson_rock/          - Infostealer-log exposure (Hudson Rock Cavalier API)
   subfinder/            - Passive subdomain enumeration
   amass/                - Active subdomain enumeration
   alterx/               - Subdomain permutation (from discovered subdomains)

--- a/apps/core/workflows/migrations/0024_add_hudson_rock_to_workflows.py
+++ b/apps/core/workflows/migrations/0024_add_hudson_rock_to_workflows.py
@@ -1,0 +1,56 @@
+"""Add hudson_rock (Hudson Rock infostealer exposure) to the default workflows.
+
+hudson_rock is a passive, Domain-Intelligence (phase 1) tool that queries Hudson
+Rock's free keyless Cavalier API for a domain's infostealer-log exposure. It must
+join:
+
+  * Full Scan   — the invariant test_full_scan_covers_every_registered_tool
+                  requires every non-core registered tool to be in the default
+                  Full Scan, else the scan/report/README under-count.
+  * Passive Scan — it is passive (active=False), sends no packets to the target,
+                  so it belongs in the no-auth passive recon workflow.
+
+Additive and idempotent (skips if already present), matching 0021/0023. Execution
+order is unaffected — the runner regroups steps by registry phase.
+"""
+
+from django.db import migrations
+
+_TOOL = "hudson_rock"
+_WORKFLOWS = ["Full Scan", "Passive Scan"]
+
+
+def add_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None:
+            continue
+        if wf.steps.filter(tool=_TOOL).exists():
+            continue
+        next_order = (
+            wf.steps.order_by("-order").values_list("order", flat=True).first() or 0
+        ) + 1
+        WorkflowStep.objects.create(workflow=wf, tool=_TOOL, order=next_order, enabled=True)
+
+
+def remove_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None:
+            continue
+        WorkflowStep.objects.filter(workflow=wf, tool=_TOOL).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflow", "0023_add_asn_jssecrets_to_full_scan"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tool, remove_tool),
+    ]

--- a/apps/hudson_rock/analyzer.py
+++ b/apps/hudson_rock/analyzer.py
@@ -1,0 +1,152 @@
+"""Hudson Rock analyzer — builds a single aggregate infostealer-exposure Finding.
+
+Privacy contract (hard requirement): this tool must NEVER store or display
+plaintext credentials or individual email addresses. Only aggregate counts,
+stealer-family names, last-seen dates, and system-level affected login URLs are
+persisted. If a Cavalier response ever carries per-person data, it is dropped
+here — only the fields explicitly extracted below reach the Finding.
+"""
+
+import logging
+
+from apps.core.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+_MAX_URLS = 10  # cap the affected-URL list stored / shown
+_MAX_FAMILIES = 5  # cap the top stealer families shown
+_ATTRIBUTION = "Source: Hudson Rock (Cavalier)"
+
+
+def _as_int(value) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _extract_urls(urls_raw) -> list[str]:
+    """Pull system-level login URL strings out of the urls-by-domain payload.
+
+    Defensive: the endpoint may return a bare list of strings, a list of dicts
+    with a "url" key, or a dict wrapping the list under "data"/"urls". Only the
+    URL string itself is kept — no other per-record fields are ever read, so no
+    credential/email field can leak through.
+    """
+    if isinstance(urls_raw, dict):
+        urls_raw = urls_raw.get("data") or urls_raw.get("urls") or []
+
+    if not isinstance(urls_raw, list):
+        return []
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in urls_raw:
+        url = None
+        if isinstance(item, str):
+            url = item.strip()
+        elif isinstance(item, dict):
+            candidate = item.get("url")
+            if isinstance(candidate, str):
+                url = candidate.strip()
+        if url and url not in seen:
+            seen.add(url)
+            out.append(url)
+    return out
+
+
+def _top_families(families) -> list[str]:
+    """Return top stealer-family names by count (names only, no counts leaked)."""
+    if not isinstance(families, dict):
+        return []
+    ordered = sorted(
+        families.items(),
+        key=lambda kv: _as_int(kv[1]),
+        reverse=True,
+    )
+    return [str(name) for name, _ in ordered[:_MAX_FAMILIES] if name]
+
+
+def _most_recent(*dates) -> str:
+    """Pick the most recent (lexically max, ISO dates) non-empty date string."""
+    valid = [str(d) for d in dates if d]
+    return max(valid) if valid else ""
+
+
+def analyze(session, domain: str, data: dict) -> list[Finding]:
+    counts = data.get("counts") or {}
+    employees = _as_int(counts.get("employees"))
+    users = _as_int(counts.get("users"))
+    third_parties = _as_int(counts.get("third_parties"))
+
+    # No exposure → no finding.
+    if employees == 0 and users == 0:
+        logger.info("hudson_rock: %s has no employee/user exposure — no finding", domain)
+        return []
+
+    severity = "high" if employees > 0 else "medium"
+
+    families = _top_families(counts.get("stealerFamilies"))
+    last_compromised = _most_recent(
+        counts.get("last_employee_compromised"),
+        counts.get("last_user_compromised"),
+    )
+    affected_urls = _extract_urls(data.get("urls"))[:_MAX_URLS]
+
+    title = (
+        f"Infostealer exposure: {employees} employee + {users} user "
+        f"accounts for {domain}"
+    )
+
+    lines = [
+        f"Hudson Rock's Cavalier dataset shows infostealer-log exposure for "
+        f"{domain}. Devices infected by info-stealing malware had credentials "
+        f"harvested and traded; the counts below are the accounts tied to this "
+        f"domain.",
+        "",
+        f"Employee accounts compromised: {employees}",
+        f"Other/user accounts compromised: {users}",
+        f"Third-party accounts compromised: {third_parties}",
+    ]
+    if families:
+        lines.append(f"Top stealer families: {', '.join(families)}")
+    if last_compromised:
+        lines.append(f"Most recent compromise seen: {last_compromised}")
+    if affected_urls:
+        lines.append("")
+        lines.append("Affected login URLs (system-level):")
+        lines.extend(f"  - {u}" for u in affected_urls)
+    lines.append("")
+    lines.append(
+        "These are aggregate counts only — no plaintext credentials are stored "
+        "or shown here. Retrieving the specific affected accounts requires your "
+        "own follow-up with Hudson Rock."
+    )
+    lines.append(_ATTRIBUTION)
+
+    remediation = (
+        "Force a credential reset on the affected services for the exposed "
+        "accounts and enforce MFA everywhere. Treat the affected hosts as "
+        "potentially compromised: investigate the endpoints the credentials "
+        "came from for active info-stealer infections and re-image if needed."
+    )
+
+    finding = Finding(
+        session=session,
+        source="hudson_rock",
+        check_type="infostealer_exposure",
+        severity=severity,
+        title=title,
+        description="\n".join(lines),
+        remediation=remediation,
+        target=domain,
+        extra={
+            "employees": employees,
+            "users": users,
+            "third_parties": third_parties,
+            "stealer_families": families,
+            "last_compromised": last_compromised,
+            "affected_urls": affected_urls,
+        },
+    )
+    return [finding]

--- a/apps/hudson_rock/apps.py
+++ b/apps/hudson_rock/apps.py
@@ -1,0 +1,19 @@
+from django.apps import AppConfig
+
+
+class HudsonRockConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.hudson_rock"
+    label = "hudson_rock"
+    verbose_name = "Infostealer Exposure (Hudson Rock)"
+    tool_meta = {
+        "label": "Infostealer Exposure (Hudson Rock)",
+        "runner": "apps.hudson_rock.scanner.run_hudson_rock",
+        "phase": 1,
+        "phase_group": "Domain Intelligence",
+        "requires": [],
+        "produces_findings": True,
+        # Passive: queries Hudson Rock's Cavalier API (third-party threat
+        # intel), never sends a packet to the target's own systems.
+        "active": False,
+    }

--- a/apps/hudson_rock/collector.py
+++ b/apps/hudson_rock/collector.py
@@ -1,0 +1,104 @@
+"""Hudson Rock (Cavalier) collector — queries free, keyless OSINT endpoints.
+
+Two endpoints, both keyless (no API key required):
+
+  1. search-by-domain — aggregate infostealer-exposure counts for a domain
+     (employees, users, third_parties, totals, stealer families, last-seen
+     dates). Counts only — no plaintext credentials.
+  2. urls-by-domain — the compromised (system-level) login URLs associated with
+     the domain, e.g. login.<domain>, vpn.<domain>.
+
+Design contract (privacy / safety):
+  * FAIL-GRACEFUL, ALWAYS. Any timeout / non-200 / exhausted 429 / JSON error
+    returns empty and NEVER raises. This tool is additive intelligence — it must
+    never fail a scan. There is no binary, so we do NOT raise ToolBinaryMissing
+    / ToolTimeout; we log and return empty.
+  * Sends the honest OpenEASD User-Agent so Hudson Rock can identify us.
+  * 10s timeout per call; honours HTTP 429 / Retry-After with a short backoff.
+"""
+
+import logging
+import time
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 10  # seconds, per call
+_MAX_RETRIES = 2  # extra attempts after a 429
+_DEFAULT_BACKOFF = 2  # seconds, when no Retry-After header
+_MAX_BACKOFF = 10  # cap the honoured Retry-After so we never stall a scan
+
+
+def _base_url() -> str:
+    return getattr(
+        settings,
+        "HUDSON_ROCK_BASE_URL",
+        "https://cavalier.hudsonrock.com/api/json/v2/osint-tools",
+    ).rstrip("/")
+
+
+def _user_agent() -> str:
+    return getattr(settings, "OPENEASD_USER_AGENT", "OpenEASD/1.0")
+
+
+def _get_json(path: str, domain: str):
+    """GET one Cavalier endpoint, return parsed JSON or None on any failure.
+
+    Never raises. Honours 429 / Retry-After with a short, capped backoff.
+    """
+    url = f"{_base_url()}/{path}"
+    headers = {"User-Agent": _user_agent(), "Accept": "application/json"}
+    params = {"domain": domain}
+
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            resp = requests.get(
+                url, params=params, headers=headers, timeout=REQUEST_TIMEOUT
+            )
+        except requests.RequestException as exc:
+            logger.warning("hudson_rock: request to %s failed: %s", path, exc)
+            return None
+
+        if resp.status_code == 429:
+            if attempt >= _MAX_RETRIES:
+                logger.warning("hudson_rock: %s rate-limited (429), retries exhausted", path)
+                return None
+            backoff = _DEFAULT_BACKOFF
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    backoff = min(int(retry_after), _MAX_BACKOFF)
+                except (ValueError, TypeError):
+                    backoff = _DEFAULT_BACKOFF
+            logger.info("hudson_rock: %s 429, backing off %ss", path, backoff)
+            time.sleep(backoff)
+            continue
+
+        if resp.status_code != 200:
+            logger.warning("hudson_rock: %s returned HTTP %s", path, resp.status_code)
+            return None
+
+        try:
+            return resp.json()
+        except ValueError as exc:
+            logger.warning("hudson_rock: %s returned non-JSON body: %s", path, exc)
+            return None
+
+    return None
+
+
+def collect(domain: str) -> dict:
+    """Return {"counts": dict, "urls": list} for a domain.
+
+    Each part is independent: a failure of one endpoint leaves the other intact.
+    Always returns a dict (never raises).
+    """
+    counts = _get_json("search-by-domain", domain)
+    urls_raw = _get_json("urls-by-domain", domain)
+
+    return {
+        "counts": counts if isinstance(counts, dict) else {},
+        "urls": urls_raw,
+    }

--- a/apps/hudson_rock/models.py
+++ b/apps/hudson_rock/models.py
@@ -1,0 +1,2 @@
+# hudson_rock writes only to the shared apps/core/findings/ model — no
+# tool-local tables, so this module is intentionally empty (no migrations).

--- a/apps/hudson_rock/scanner.py
+++ b/apps/hudson_rock/scanner.py
@@ -1,0 +1,37 @@
+"""Hudson Rock scanner — thin orchestrator: collect → analyze → save.
+
+Additive intelligence. Any failure inside collect/analyze is swallowed and the
+scan continues with zero findings — this tool must never fail a scan.
+"""
+
+import logging
+
+from apps.core.findings.models import Finding
+
+from .analyzer import analyze
+from .collector import collect
+
+logger = logging.getLogger(__name__)
+
+
+def run_hudson_rock(session) -> list[Finding]:
+    domain = session.domain  # CharField: "example.com"
+    if not domain:
+        logger.info("[hudson_rock:%s] no domain — skipping", session.id)
+        return []
+
+    try:
+        data = collect(domain)
+        findings = analyze(session, domain, data)
+    except Exception:  # noqa: BLE001 — never let this tool fail a scan
+        logger.exception("[hudson_rock:%s] unexpected error — skipping", session.id)
+        return []
+
+    if not findings:
+        logger.info("[hudson_rock:%s] no infostealer exposure — nothing to save", session.id)
+        return []
+
+    Finding.objects.bulk_create(findings, ignore_conflicts=True)
+    saved = list(Finding.objects.filter(session=session, source="hudson_rock"))
+    logger.info("[hudson_rock:%s] saved %d infostealer findings", session.id, len(saved))
+    return saved

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -103,6 +103,7 @@ INSTALLED_APPS = [
     "ninja_jwt",
     "ninja_jwt.token_blacklist",
     "apps.domain_security",
+    "apps.hudson_rock",
     "apps.subfinder",
     "apps.amass",
     "apps.asn_discovery",
@@ -301,6 +302,14 @@ TOOL_GITLEAKS = config("TOOL_GITLEAKS", default="gitleaks")
 OPENEASD_USER_AGENT = config(
     "OPENEASD_USER_AGENT",
     default="OpenEASD/1.0 (+https://cybersecify.com/openeasd)",
+)
+
+# Hudson Rock (Cavalier) OSINT API base — free, keyless infostealer-exposure
+# intelligence. OSS use permitted by Hudson Rock co-founder Alon Gal. Overridable
+# for testing / self-hosting.
+HUDSON_ROCK_BASE_URL = config(
+    "HUDSON_ROCK_BASE_URL",
+    default="https://cavalier.hudsonrock.com/api/json/v2/osint-tools",
 )
 
 # Build provenance — baked into the image at build time (see Dockerfile ARG/ENV

--- a/tests/integration/test_scan_flow.py
+++ b/tests/integration/test_scan_flow.py
@@ -153,6 +153,7 @@ def _patch_all_tool_collectors():
     stack.enter_context(patch("apps.ssh_checker.scanner.collect", return_value=[]))
     stack.enter_context(patch("apps.nuclei.scanner.collect", return_value=[]))
     stack.enter_context(patch("apps.web_checker.scanner.collect", return_value=[]))
+    stack.enter_context(patch("apps.hudson_rock.scanner.collect", return_value={"counts": {}, "urls": None}))
     return stack
 
 
@@ -160,7 +161,7 @@ def _patch_all_tool_collectors():
 class TestFullScanPipeline:
     """Tests run_scan orchestration → domain_security → insights."""
 
-    def test_run_scan_completes_session(self, db):
+    def test_run_scan_completes_session(self, transactional_db):
         from apps.core.scans.models import ScanSession
         from apps.core.scans.pipeline import run_scan
 
@@ -199,7 +200,7 @@ class TestFullScanPipeline:
         assert session.status == "completed"
         assert session.end_time is not None
 
-    def test_run_scan_builds_insights(self, db):
+    def test_run_scan_builds_insights(self, transactional_db):
         from apps.core.scans.models import ScanSession
         from apps.core.scans.pipeline import run_scan
         from apps.core.insights.models import ScanSummary
@@ -235,7 +236,7 @@ class TestFullScanPipeline:
         summary = ScanSummary.objects.get(session=session)
         assert summary.total_findings > 0
 
-    def test_run_scan_detects_deltas_on_second_scan(self, db):
+    def test_run_scan_detects_deltas_on_second_scan(self, transactional_db):
         from apps.core.scans.models import ScanSession, ScanDelta
         from apps.core.scans.pipeline import run_scan
 

--- a/tests/unit/test_hudson_rock.py
+++ b/tests/unit/test_hudson_rock.py
@@ -1,0 +1,249 @@
+"""Unit tests for apps/hudson_rock — collector, analyzer, scanner.
+
+Hudson Rock's Cavalier API is mocked throughout; no real network. The privacy
+invariant (never persist plaintext credentials / individual emails) is asserted
+against a synthetic response that deliberately embeds a fake password + email.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from apps.hudson_rock import collector
+from apps.hudson_rock.analyzer import analyze
+from apps.hudson_rock.collector import collect
+
+
+def _resp(status=200, json_data=None, headers=None, raise_json=False):
+    m = MagicMock()
+    m.status_code = status
+    m.headers = headers or {}
+    if raise_json:
+        m.json.side_effect = ValueError("no json")
+    else:
+        m.json.return_value = json_data if json_data is not None else {}
+    return m
+
+
+_COUNTS = {
+    "employees": 3,
+    "users": 12,
+    "third_parties": 1,
+    "total": 16,
+    "totalStealers": 9,
+    "stealerFamilies": {"RedLine": 5, "Raccoon": 3, "Vidar": 1},
+    "last_employee_compromised": "2025-11-02",
+    "last_user_compromised": "2026-01-20",
+}
+
+_URLS = {"data": [{"url": "https://login.example.com"}, {"url": "https://vpn.example.com"}]}
+
+
+# ---------------------------------------------------------------------------
+# Collector — hits both endpoints, keyless, honest UA
+# ---------------------------------------------------------------------------
+
+class TestCollect:
+    def test_hits_both_endpoints_keyless_with_ua(self):
+        calls = []
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            calls.append((url, params, headers, timeout))
+            if "search-by-domain" in url:
+                return _resp(json_data=_COUNTS)
+            return _resp(json_data=_URLS)
+
+        with patch.object(collector.requests, "get", side_effect=fake_get):
+            data = collect("example.com")
+
+        # both endpoints called
+        endpoints = [c[0] for c in calls]
+        assert any("search-by-domain" in u for u in endpoints)
+        assert any("urls-by-domain" in u for u in endpoints)
+        # keyless: only the domain param, no api key
+        for _url, params, headers, timeout in calls:
+            assert params == {"domain": "example.com"}
+            assert "key" not in params and "api_key" not in params
+            # honest UA sent
+            assert "OpenEASD" in headers["User-Agent"]
+            assert timeout == 10
+        assert data["counts"] == _COUNTS
+        assert data["urls"] == _URLS
+
+    def test_timeout_fails_graceful(self):
+        with patch.object(collector.requests, "get", side_effect=requests.Timeout("slow")):
+            data = collect("example.com")  # must not raise
+        assert data == {"counts": {}, "urls": None}
+
+    def test_http_500_fails_graceful(self):
+        with patch.object(collector.requests, "get", return_value=_resp(status=500)):
+            data = collect("example.com")
+        assert data["counts"] == {}
+        assert data["urls"] is None
+
+    def test_bad_json_fails_graceful(self):
+        with patch.object(collector.requests, "get", return_value=_resp(raise_json=True)):
+            data = collect("example.com")
+        assert data["counts"] == {}
+        assert data["urls"] is None
+
+    def test_429_exhausted_fails_graceful(self):
+        resp = _resp(status=429, headers={"Retry-After": "1"})
+        with patch.object(collector.requests, "get", return_value=resp), \
+             patch.object(collector.time, "sleep") as mock_sleep:
+            data = collect("example.com")
+        assert data == {"counts": {}, "urls": None}
+        assert mock_sleep.called  # backoff was honoured before giving up
+
+    def test_429_then_success_retries(self):
+        seq = {"search-by-domain": [_resp(status=429, headers={"Retry-After": "1"}),
+                                    _resp(json_data=_COUNTS)],
+               "urls-by-domain": [_resp(json_data=_URLS)]}
+
+        def fake_get(url, params=None, headers=None, timeout=None):
+            key = "search-by-domain" if "search-by-domain" in url else "urls-by-domain"
+            return seq[key].pop(0)
+
+        with patch.object(collector.requests, "get", side_effect=fake_get), \
+             patch.object(collector.time, "sleep"):
+            data = collect("example.com")
+        assert data["counts"] == _COUNTS
+
+
+# ---------------------------------------------------------------------------
+# Analyzer — one Finding, severity, attribution, privacy
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestAnalyze:
+    def _session(self):
+        from apps.core.scans.models import ScanSession
+        return ScanSession.objects.create(domain="example.com", scan_type="full")
+
+    def test_no_finding_when_counts_zero(self):
+        s = self._session()
+        findings = analyze(s, "example.com", {"counts": {"employees": 0, "users": 0}, "urls": None})
+        assert findings == []
+
+    def test_no_finding_when_counts_missing(self):
+        s = self._session()
+        assert analyze(s, "example.com", {"counts": {}, "urls": None}) == []
+
+    def test_high_severity_when_employees(self):
+        s = self._session()
+        findings = analyze(s, "example.com", {"counts": _COUNTS, "urls": _URLS})
+        assert len(findings) == 1
+        f = findings[0]
+        assert f.severity == "high"
+        assert f.source == "hudson_rock"
+        assert f.check_type == "infostealer_exposure"
+        assert f.target == "example.com"
+
+    def test_medium_severity_users_only(self):
+        s = self._session()
+        counts = dict(_COUNTS, employees=0, users=5)
+        findings = analyze(s, "example.com", {"counts": counts, "urls": None})
+        assert len(findings) == 1
+        assert findings[0].severity == "medium"
+
+    def test_finding_includes_counts_families_urls_attribution(self):
+        s = self._session()
+        f = analyze(s, "example.com", {"counts": _COUNTS, "urls": _URLS})[0]
+        desc = f.description
+        assert "3 employee" in f.title and "12 user" in f.title
+        assert "RedLine" in desc  # top stealer family
+        assert "2026-01-20" in desc  # most recent compromise
+        assert "login.example.com" in desc  # affected URL
+        assert "Hudson Rock (Cavalier)" in desc  # attribution
+        assert "MFA" in f.remediation
+        # extra structured data, no plaintext
+        assert f.extra["employees"] == 3
+        assert f.extra["users"] == 12
+        assert "RedLine" in f.extra["stealer_families"]
+        assert "https://login.example.com" in f.extra["affected_urls"]
+        assert f.extra["last_compromised"] == "2026-01-20"
+
+    def test_affected_urls_capped(self):
+        s = self._session()
+        many = {"data": [{"url": f"https://h{i}.example.com"} for i in range(30)]}
+        f = analyze(s, "example.com", {"counts": _COUNTS, "urls": many})[0]
+        assert len(f.extra["affected_urls"]) == 10
+
+    def test_never_stores_plaintext_credentials_or_emails(self):
+        """Privacy invariant: even if Cavalier returns per-person data with a
+        password + email, none of it may appear in any Finding field."""
+        s = self._session()
+        poisoned_counts = dict(_COUNTS)
+        # simulate a response that leaks per-person records
+        poisoned_counts["data"] = [
+            {
+                "email": "victim@example.com",
+                "password": "SuperSecret123!",
+                "employee": True,
+            }
+        ]
+        poisoned_urls = {
+            "data": [
+                {
+                    "url": "https://login.example.com",
+                    "password": "SuperSecret123!",
+                    "email": "victim@example.com",
+                }
+            ]
+        }
+        f = analyze(s, "example.com", {"counts": poisoned_counts, "urls": poisoned_urls})[0]
+
+        haystack = " ".join([
+            f.title, f.description, f.remediation, f.target, str(f.extra),
+        ])
+        assert "SuperSecret123!" not in haystack
+        assert "victim@example.com" not in haystack
+        # the system-level URL is still surfaced (that's allowed)
+        assert "https://login.example.com" in f.extra["affected_urls"]
+
+    def test_handles_bare_string_url_list(self):
+        s = self._session()
+        f = analyze(s, "example.com", {
+            "counts": _COUNTS,
+            "urls": ["https://login.example.com", "https://vpn.example.com"],
+        })[0]
+        assert "https://login.example.com" in f.extra["affected_urls"]
+
+
+# ---------------------------------------------------------------------------
+# Scanner — orchestration + persistence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestScanner:
+    def _session(self):
+        from apps.core.scans.models import ScanSession
+        return ScanSession.objects.create(domain="example.com", scan_type="full")
+
+    def test_saves_finding(self):
+        from apps.hudson_rock.scanner import run_hudson_rock
+        from apps.core.findings.models import Finding
+        s = self._session()
+        with patch("apps.hudson_rock.scanner.collect",
+                   return_value={"counts": _COUNTS, "urls": _URLS}):
+            saved = run_hudson_rock(s)
+        assert len(saved) == 1
+        assert Finding.objects.filter(session=s, source="hudson_rock").count() == 1
+
+    def test_no_exposure_saves_nothing(self):
+        from apps.hudson_rock.scanner import run_hudson_rock
+        from apps.core.findings.models import Finding
+        s = self._session()
+        with patch("apps.hudson_rock.scanner.collect",
+                   return_value={"counts": {"employees": 0, "users": 0}, "urls": None}):
+            saved = run_hudson_rock(s)
+        assert saved == []
+        assert Finding.objects.filter(session=s).count() == 0
+
+    def test_collector_exception_never_fails_scan(self):
+        from apps.hudson_rock.scanner import run_hudson_rock
+        s = self._session()
+        with patch("apps.hudson_rock.scanner.collect", side_effect=RuntimeError("boom")):
+            saved = run_hudson_rock(s)  # must not raise
+        assert saved == []


### PR DESCRIPTION
## What
A new passive Domain-Intelligence tool, `apps/hudson_rock/`, that surfaces a domain's **infostealer-log exposure** via Hudson Rock's free, keyless **Cavalier** API:

- `search-by-domain` -> aggregate counts (employees, users, third parties, stealer families, last-seen dates)
- `urls-by-domain` -> system-level affected login URLs (e.g. `login.<domain>`, `vpn.<domain>`)

One `infostealer_exposure` Finding per domain. Severity: **high** when employee accounts are exposed, **medium** when only user accounts. No finding when counts are zero.

## Why
Credential exposure from info-stealer malware is a leading breach vector that no port/web scan can see. This is public-source (passive) intel that complements the active surface scan, and it needs no `DomainAuthorization`.

## Privacy / safety (deliberately conservative)
- Stores **only** aggregate counts, stealer-family names, last-seen dates, and system-level affected URLs. **Never** plaintext credentials or individual email addresses — a synthetic-poison test asserts a fake password/email in the API response never reaches any Finding field.
- **Fail-graceful, always**: any timeout / non-200 / exhausted 429 / bad-JSON returns empty and never raises. There is no binary, so it does not raise `ToolBinaryMissing`/`ToolTimeout` — this tool can never fail a scan.
- Honest `OPENEASD_USER_AGENT`, 10s timeout per call, honours `429`/`Retry-After` with a short capped backoff.
- Attribution "Source: Hudson Rock (Cavalier)" in every Finding.

## Permission
OSS use permitted by Hudson Rock co-founder **Alon Gal**, who specifically recommended the `urls-by-domain` endpoint.

## Wiring
- Added to `INSTALLED_APPS` + `HUDSON_ROCK_BASE_URL` setting.
- Migration `0024` adds `hudson_rock` to **Full Scan** (invariant `test_full_scan_covers_every_registered_tool`) and **Passive Scan** (it's passive). Additive/idempotent.
- Tool count 21 -> 22 across README, CHANGELOG, CLAUDE.md.

## Notes for reviewer
- Adding a 2nd phase-1 tool makes phase 1 run in parallel, so `domain_security` now executes in a worker thread. The three threaded `run_scan` tests in `TestFullScanPipeline` were switched from `db` to `transactional_db` (matching the existing `TestFullPipelineMocked` pattern) — WAL is a no-op inside pytest's per-test transaction, so threaded writers need `transactional_db`. Production is unaffected (WAL + 30s busy timeout).

## Tests
17 new tests in `tests/unit/test_hudson_rock.py`. Full fast suite: **1145 passed**. `makemigrations --check` clean.

Generated with [Claude Code](https://claude.com/claude-code)