### PR TITLE
feat: low-memory mode for ~1GB hosts (OPENEASD_LOW_MEMORY)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,12 @@ docker run -d \
 ```
 - `--cap-add NET_RAW` — required for nmap raw socket scanning
 - `--restart unless-stopped` — survives server reboots
+- **RAM: 2 GB min / 4 GB recommended.** nuclei + amass are memory-hungry and the
+  kernel will OOM-kill them on an under-provisioned host (silent partial scans).
+  On a **1 GB** box add `-e OPENEASD_LOW_MEMORY=true` — same-phase tools then run
+  sequentially and nuclei uses lower concurrency, so scans complete (slower) on
+  1 GB without OOM. Adding a few GB of swap also helps. Fine for low-volume use
+  (a handful of scans/month with a long completion window).
 - Volumes: `openeasd-data` (SQLite DB) and `openeasd-logs` persist across container replacements
 - Static files served by WhiteNoise (no nginx needed)
 - **Serve it over HTTPS.** Do NOT expose the app on bare HTTP — login sends
@@ -613,7 +619,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_naabu.py` | 10 | JSON parser, FK to IPAddress |
 | `tests/unit/test_nmap.py` | 23 | Severity mapping, vulners XML parser, web/non-web exclusion, backport matching |
 | `tests/unit/test_notifications.py` | 25 | NotificationConfig, Slack/Teams alerts, alert-history API |
-| `tests/unit/test_nuclei.py` | 32 | CVE parsing, severity, dedup, URL linking, collector, honest UA |
+| `tests/unit/test_nuclei.py` | 33 | CVE parsing, severity, dedup, URL linking, collector, honest UA |
 | `tests/unit/test_nuclei_network.py` | 28 | Network-template parsing, non-web targeting, collector |
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
 | `tests/unit/test_qcluster_config.py` | 4 | Django-Q cluster config |
@@ -634,9 +640,9 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_insights_builder.py` | 4 | FindingTypeSummary prune only when aggregation_complete |
 | `tests/unit/test_web_checker.py` | 40 | Headers, cookies, CORS, disclosure, collector |
 | `tests/unit/test_passive_scan.py` | 21 | registry `active` classification, `is_passive_tool_set`, Passive Scan workflow all-passive invariant, passive-scan auth-gate bypass + active-scan gate, subscan gate |
-| `tests/unit/test_workflow_runner.py` | 32 | run_workflow, naabu-gated service_detection injection, step failure, cancellation, phase parallelism |
+| `tests/unit/test_workflow_runner.py` | 33 | run_workflow, naabu-gated service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/unit/test_default_workflow.py` | 5 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 93 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` |
 
-**Total: 1196 tests** (1145 fast + 51 slow domain_security)
+**Total: 1198 tests** (1147 fast + 51 slow domain_security)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,23 @@ docker build -t openeasd .
 
 For vulnerability reporting, see [SECURITY.md](SECURITY.md).
 
+## System requirements
+
+The scan tools (nuclei and amass especially) are memory-hungry. On a host with
+too little RAM the kernel will OOM-kill them mid-scan, so scans finish partial or
+empty.
+
+| | RAM | vCPU | Disk |
+|---|---|---|---|
+| **Minimum** | 2 GB | 1 | 5 GB |
+| **Recommended** | 4 GB | 2 | 10 GB |
+| **1 GB host** | set `OPENEASD_LOW_MEMORY=true` | 1 | 5 GB |
+
+On a **1 GB** box (e.g. the smallest cloud droplet), set `-e OPENEASD_LOW_MEMORY=true`:
+tools then run one-at-a-time per phase and nuclei uses lower concurrency, so it
+completes without OOM — slower, but it finishes. Adding a few GB of swap helps
+too. For faster or concurrent scans, use the recommended spec.
+
 ## Quick start
 
 ```bash

--- a/apps/core/workflows/runner.py
+++ b/apps/core/workflows/runner.py
@@ -114,6 +114,7 @@ def run_workflow(workflow_run_id: int, only_tools: list | None = None):
     only_tools: if provided, restrict execution to these tool keys (subscan use-case).
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
+    from django.conf import settings
 
     run = WorkflowRun.objects.select_related("workflow", "session").get(id=workflow_run_id)
     session = run.session
@@ -166,9 +167,13 @@ def run_workflow(workflow_run_id: int, only_tools: list | None = None):
 
             logger.info(f"[workflow:{run.id}] Starting phase group: {group}")
 
-            if len(group) == 1:
-                _run_single_step(run, session, group[0], order)
-                order += 1
+            if len(group) == 1 or getattr(settings, "LOW_MEMORY", False):
+                # Sequential: one tool at a time. For a single-tool group this is
+                # the normal path; under LOW_MEMORY it also serialises multi-tool
+                # phases so peak memory stays at one tool (no OOM on ~1 GB hosts).
+                for i, tool in enumerate(group):
+                    _run_single_step(run, session, tool, order + i)
+                order += len(group)
             else:
                 step_orders = {tool: order + i for i, tool in enumerate(group)}
                 with ThreadPoolExecutor(max_workers=len(group)) as executor:

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -36,6 +36,10 @@ REQUEST_TIMEOUT = 5   # seconds per HTTP request (nuclei -timeout)
 # large-target worst case (~330k requests) well within the 2h cap.
 RATE_LIMIT = 100      # max requests/sec across all hosts (nuclei -rate-limit)
 CONCURRENCY = 25      # parallel templates (nuclei -c)
+# Low-memory host (settings.LOW_MEMORY): fewer parallel templates keeps nuclei's
+# peak memory well under a 1 GB ceiling, at the cost of a slower run.
+LOW_MEM_RATE_LIMIT = 40
+LOW_MEM_CONCURRENCY = 10
 
 
 _DRAIN_GRACE = 30  # seconds to let a SIGKILL'd process die before we give up
@@ -133,8 +137,8 @@ def collect(session) -> list[dict]:
         "-disable-update-check",
         "-timeout", str(REQUEST_TIMEOUT),
         "-retries", "1",
-        "-rate-limit", str(RATE_LIMIT),
-        "-c", str(CONCURRENCY),
+        "-rate-limit", str(LOW_MEM_RATE_LIMIT if getattr(settings, "LOW_MEMORY", False) else RATE_LIMIT),
+        "-c", str(LOW_MEM_CONCURRENCY if getattr(settings, "LOW_MEMORY", False) else CONCURRENCY),
         # Honest scanner identity so a target can allowlist us deliberately.
         # Note: templates that hard-set their own User-Agent are not overridden.
         "-H", f"User-Agent: {getattr(settings, 'OPENEASD_USER_AGENT', 'OpenEASD/1.0')}",

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -304,6 +304,12 @@ OPENEASD_USER_AGENT = config(
     default="OpenEASD/1.0 (+https://cybersecify.com/openeasd)",
 )
 
+# Low-memory mode for small hosts (≈1 GB RAM). When true, same-phase tools run
+# sequentially instead of concurrently (bounds peak memory) and nuclei uses a
+# lower concurrency/rate-limit. Prevents the kernel OOM-killing nuclei/amass on
+# a 1 GB droplet, at the cost of a slower scan. See the deploy docs.
+LOW_MEMORY = config("OPENEASD_LOW_MEMORY", default=False, cast=bool)
+
 # Hudson Rock (Cavalier) OSINT API base — free, keyless infostealer-exposure
 # intelligence. OSS use permitted by Hudson Rock co-founder Alon Gal. Overridable
 # for testing / self-hosting.

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -239,6 +239,19 @@ class TestNucleiCollector:
         ua = cmd[cmd.index("-H") + 1]
         assert ua.startswith("User-Agent: OpenEASD/")
 
+    def test_low_memory_reduces_concurrency(self, settings):
+        settings.LOW_MEMORY = True
+        sess = self._make_session()
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.returncode = 0
+        mock_result.stderr = ""
+        with patch("apps.nuclei.collector._run", return_value=mock_result) as mock_run:
+            collect(sess)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[cmd.index("-c") + 1] == "10"          # LOW_MEM_CONCURRENCY
+        assert cmd[cmd.index("-rate-limit") + 1] == "40"  # LOW_MEM_RATE_LIMIT
+
     def test_binary_not_found_raises(self):
         """A missing binary must surface as ToolBinaryMissing, not a silent [] —
         otherwise the runner marks the step 'completed' and the failure hides."""

--- a/tests/unit/test_workflow_runner.py
+++ b/tests/unit/test_workflow_runner.py
@@ -456,6 +456,32 @@ class TestPhaseParallelExecution:
             "Run is not 'completed' — tools likely ran serially (barrier never satisfied)"
         )
 
+    def test_low_memory_runs_phase_sequentially(self, transactional_db, settings):
+        """Under LOW_MEMORY a multi-tool phase runs one tool at a time — all tools
+        still execute and the run completes (bounds peak memory on small hosts)."""
+        settings.LOW_MEMORY = True
+        from apps.core.scans.models import ScanSession
+        session = ScanSession.objects.create(
+            domain="lowmem.example.com", scan_type="full", status="running"
+        )
+        wf = Workflow.objects.create(name="LowMem Phase 7")
+        WorkflowStep.objects.create(workflow=wf, tool="nmap",        order=1, enabled=True)
+        WorkflowStep.objects.create(workflow=wf, tool="tls_checker", order=2, enabled=True)
+        run = WorkflowRun.objects.create(workflow=wf, session=session)
+
+        def seq_runner(tool_name):
+            def runner(sess):
+                return []
+            return runner
+
+        with patch("apps.core.workflows.runner._get_runner", side_effect=seq_runner):
+            run_workflow(run.id)
+
+        run.refresh_from_db()
+        assert run.status == "completed"
+        ran = set(WorkflowStepResult.objects.filter(run=run).values_list("tool", flat=True))
+        assert {"nmap", "tls_checker"} <= ran
+
     def test_phase_boundary_respected(self, transactional_db):
         """All phase-7 tools must finish before any phase-10 tool starts.
 


### PR DESCRIPTION
Lets OpenEASD run on a **1 GB droplet without OOM-killing** nuclei/amass — observed on the prod test box (5 OOM kills). Answers 'why pay for a bigger box for a free tool' with 'you don't have to.'

When `OPENEASD_LOW_MEMORY=true`:
- **Same-phase tools run sequentially** (peak memory = one tool, not the whole phase).
- **nuclei uses `-c 10 / -rate-limit 40`** (vs 25/100).

Slower but completes — ideal for low-volume use (a handful of scans/month, long window). Adds a **System Requirements** section (2 GB min / 4 GB recommended; 1 GB with this flag) — the docs previously implied the 1 GB tier was fine. +2 tests (nuclei low-mem values; runner runs a multi-tool phase sequentially and completes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)