### PR TITLE
fix: amass runs light in low-memory mode (no -brute)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -599,7 +599,7 @@ GET  /api/notifications/alerts/           — alert history
 |---|---|---|
 | `tests/unit/test_alerts.py` | 7 | Slack/Teams dispatcher |
 | `tests/unit/test_alterx.py` | 17 | collector (binary missing, timeout, happy path, stdin), analyzer, scanner |
-| `tests/unit/test_amass.py` | 20 | Active subdomain enum collector, analyzer, scanner |
+| `tests/unit/test_amass.py` | 21 | Active subdomain enum collector, analyzer, scanner |
 | `tests/unit/test_asn_discovery.py` | 22 | ASN/CIDR discovery — org derivation, ASN/CIDR parsing, collector (binary missing, timeout, two-step happy path), analyzer (info Finding per ASN, safe-scope remediation), scanner |
 | `tests/unit/test_assets.py` | 12 | Asset model constraints, FK chains, cascade delete |
 | `tests/unit/test_cloud_assets.py` | 20 | cloud_assets collector, analyzer, keyword derivation, scanner |
@@ -645,4 +645,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/test_api_endpoints.py` | 93 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` |
 
-**Total: 1198 tests** (1147 fast + 51 slow domain_security)
+**Total: 1199 tests** (1148 fast + 51 slow domain_security)

--- a/apps/amass/collector.py
+++ b/apps/amass/collector.py
@@ -36,8 +36,16 @@ def collect(session) -> list[dict]:
     # stdout by default. The parser below handles both plain text and JSONL.
     cmd = [binary, "enum", "-d", domain, "-silent"]
 
-    if config.wordlist_file:
+    low_memory = getattr(settings, "LOW_MEMORY", False)
+
+    # Brute-force wordlist expansion is amass's biggest memory driver — it's what
+    # OOM-kills it on a ~1 GB host. In low-memory mode skip -brute (and cap DNS
+    # query concurrency) so amass still enumerates from passive sources + normal
+    # resolution and actually completes, instead of thrashing to death.
+    if config.wordlist_file and not low_memory:
         cmd += ["-brute", "-w", config.wordlist_file.path]
+    if low_memory:
+        cmd += ["-max-dns-queries", "1000"]
 
     cmd += ["-timeout", str(config.scan_timeout)]
 
@@ -57,7 +65,7 @@ def collect(session) -> list[dict]:
             f"[amass:{session.id}] Using providers: {', '.join(provider_names)}"
         )
 
-    brute = f" +brute({config.wordlist_file.name})" if config.wordlist_file else ""
+    brute = f" +brute({config.wordlist_file.name})" if (config.wordlist_file and not low_memory) else (" (low-memory: no brute)" if low_memory else "")
     logger.info(
         f"[amass:{session.id}] Scanning {domain} "
         f"(mode=active{brute}, timeout={config.scan_timeout}m)"

--- a/tests/unit/test_amass.py
+++ b/tests/unit/test_amass.py
@@ -155,6 +155,26 @@ class TestAmassCollector:
         cmd = mock_popen.call_args[0][0]
         assert "-config" not in cmd
 
+    def test_low_memory_skips_brute_and_caps_dns(self, settings):
+        """Low-memory: amass still enumerates but drops the memory-heavy -brute
+        wordlist expansion and caps DNS query concurrency, so it completes on a
+        ~1 GB host instead of thrashing."""
+        settings.LOW_MEMORY = True
+        sess = _session()
+        cfg = MagicMock()
+        cfg.enabled = True
+        cfg.scan_timeout = 30
+        cfg.wordlist_file.name = "wl.txt"   # a wordlist IS configured…
+        cfg.build_datasource_config.return_value = []
+        proc = _mock_proc()
+        with patch("apps.amass.models.AmassConfig.get", return_value=cfg), \
+             patch("apps.amass.collector.subprocess.Popen", return_value=proc) as mock_popen:
+            collect(sess)
+        cmd = mock_popen.call_args[0][0]
+        assert "-brute" not in cmd            # …but brute is skipped in low-memory
+        assert "-max-dns-queries" in cmd      # DNS concurrency capped
+        assert "enum" in cmd                   # still enumerating (tool works)
+
 
 # ---------------------------------------------------------------------------
 # Analyzer


### PR DESCRIPTION
Completes low-memory mode per the principle **'every tool must still work in low-memory, not just avoid being killed.'**

nuclei was already throttled (#259). amass wasn't — and its `-brute` wordlist expansion is the biggest memory driver (what OOM-killed it). Now under `OPENEASD_LOW_MEMORY=true`, amass:
- **skips `-brute`** (even if a wordlist is configured), and
- **caps `-max-dns-queries 1000`**,

so it still enumerates (passive sources + normal resolution) and **completes** on ~1 GB instead of thrashing. Coverage from passive/OSINT sources is unchanged; only the expensive brute-force expansion is dropped. +1 test. So a low-memory scan now runs all 22 tools to completion, just slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)