### PR TITLE
feat: in-app version footer + update-available check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **In-app version footer + "update available" check for logged-in users.** The
+  build provenance line (`OpenEASD vX.Y.Z · <sha> · <date>`) and the
+  Report-an-issue / Request-a-feature links now render in the sidebar of every
+  authenticated page, not only on the login screen. A new authenticated endpoint
+  `GET /api/version/latest/` compares the running build against the latest public
+  GitHub release (cached 6h, fully fail-graceful) and the footer shows an "↑
+  Update available: vX.Y.Z" link when the deployment is behind. **Why:** an
+  operator using the app never saw which version they were running or how to
+  report a problem — both were hidden pre-login — and had no signal that a newer
+  release existed. The app still never self-updates; this is a heads-up + link,
+  so upgrades stay an explicit redeploy.
 - **Infostealer-exposure tool (Hudson Rock)** — a new passive Domain-Intelligence
   tool that surfaces a domain's infostealer-log exposure via Hudson Rock's free,
   keyless Cavalier API (aggregate counts, stealer families, last-seen dates, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ git describe --tags --abbrev=0
 - **Publish triggers:** every push to `main` (`:latest` tag) and `v*` tags (`:vX.Y` tag)
 - Runner: `ubuntu-24.04`, Python 3.12, `uv sync --group dev` for deps, `libcairo2-dev gcc libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0` system deps required (WeasyPrint PDF rendering)
 - `pip-audit --ignore-vuln PYSEC-2025-183` — disputed PyJWT weak-key-length CVE, no fix available
-- **Build provenance:** the `publish` job computes `OPENEASD_VERSION` (git tag for `v*`, else `pyproject.toml` version), `OPENEASD_GIT_SHA` (`github.sha`), and `OPENEASD_BUILD_DATE` (ISO UTC) and passes them as `build-args` to buildx. The Dockerfile bakes them into `ENV` (placed late so they never bust the cache of the heavy layers). Settings read them via `config()` with `dev`/`unknown` defaults for local runs. Surfaced at `GET /health/` + `GET /api/version/`, and shown as a muted footer on the login + change-password pages (`frontend/src/components/BuildInfo.jsx`).
+- **Build provenance:** the `publish` job computes `OPENEASD_VERSION` (git tag for `v*`, else `pyproject.toml` version), `OPENEASD_GIT_SHA` (`github.sha`), and `OPENEASD_BUILD_DATE` (ISO UTC) and passes them as `build-args` to buildx. The Dockerfile bakes them into `ENV` (placed late so they never bust the cache of the heavy layers). Settings read them via `config()` with `dev`/`unknown` defaults for local runs. Surfaced at `GET /health/` + `GET /api/version/`, and shown as a muted footer on the login + change-password pages AND in the authenticated app sidebar (`frontend/src/components/BuildInfo.jsx`). The sidebar footer also does an "update available" check via `GET /api/version/latest/` (authenticated; compares the running build to the latest GitHub release, cached 6h, fail-graceful — logic in `apps/core/api/update_check.py`). The app never self-updates; it only surfaces a heads-up + release link.
 
 ## Commands
 - Always use `uv run python` instead of `python` or `python3`
@@ -554,6 +554,7 @@ POST /api/token/blacklist                 — blacklist refresh token (logout)
 POST /api/token/refresh                   — exchange refresh → new access token
 POST /api/token/verify                    — verify token validity
 GET  /api/version/                        — build provenance {version, git_sha, git_sha_short, build_date} (unauthenticated)
+GET  /api/version/latest/                 — update check {current_version, latest_version, update_available, release_url} (authenticated; cached 6h, fail-graceful)
 GET  /api/user/                           — current user info + must_change_password flag
 POST /api/user/change-password/           — change password; clears must_change_password flag
 GET  /api/dashboard/                      — KPIs, domain status, urgent findings
@@ -647,6 +648,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_workflow_runner.py` | 33 | run_workflow, naabu-gated service_detection injection, step failure, cancellation, phase parallelism |
 | `tests/unit/test_default_workflow.py` | 5 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
-| `tests/test_api_endpoints.py` | 93 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` |
+| `tests/unit/test_update_check.py` | 22 | Update-available check — version parse/compare, cached GitHub fetch, fail-graceful on timeout/HTTP-error/bad-payload, endpoint shape |
+| `tests/test_api_endpoints.py` | 96 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` + update-check `/api/version/latest/` |
 
-**Total: 1205 tests** (1154 fast + 51 slow domain_security)
+**Total: 1230 tests** (1179 fast + 51 slow domain_security)

--- a/apps/core/api/ninja.py
+++ b/apps/core/api/ninja.py
@@ -93,6 +93,16 @@ def version(request):
     }
 
 
+# Update-available check — authenticated. Compares the running build to the
+# latest public GitHub release so a logged-in operator learns when their
+# deployment is behind. The app never self-updates; this is a heads-up + link.
+# Cached (6h) and fully fail-graceful — GitHub being down never breaks the page.
+@api.get("/version/latest/", auth=JWTAuth())
+def version_latest(request):
+    from apps.core.api.update_check import check_for_update
+    return check_for_update()
+
+
 # ---------------------------------------------------------------------------
 # Current user endpoint
 # ---------------------------------------------------------------------------

--- a/apps/core/api/update_check.py
+++ b/apps/core/api/update_check.py
@@ -1,0 +1,106 @@
+"""Update-available check — compares the running build against the latest
+public GitHub release and tells a logged-in operator when their deployment is
+behind.
+
+Design notes:
+  - The app never self-updates. This is a *heads-up* only: it surfaces the
+    latest released version + a link, so the operator can redeploy the image.
+  - The GitHub call is cached (LocMemCache, per worker) so a page load does not
+    hit the API every time, and rate limits (60/hr unauthenticated) are never a
+    problem for a handful of operators.
+  - Fully fail-graceful: any error (offline, timeout, rate limit, bad JSON)
+    returns "no update info", never raises. A version indicator must never be
+    able to break the page it sits on.
+"""
+
+import logging
+
+import requests
+from django.conf import settings
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+RELEASES_URL = "https://api.github.com/repos/cybersecify/OpenEASD/releases/latest"
+_CACHE_KEY = "openeasd:latest_release"
+_CACHE_TTL = 6 * 60 * 60  # 6 hours
+_TIMEOUT = 4              # seconds — a slow GitHub must not stall the page
+
+
+def _parse_version(value):
+    """Parse '0.10.0' or 'v0.10.0' into a comparable (major, minor, patch) tuple.
+
+    Returns None for placeholders ('dev'/'unknown'/'') or anything that does not
+    look like a dotted numeric version — callers treat None as "cannot compare".
+    """
+    if not value:
+        return None
+    s = str(value).strip().lstrip("vV")
+    if not s or s.lower() in ("dev", "unknown"):
+        return None
+    parts = s.split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except (ValueError, TypeError):
+        return None
+
+
+def is_update_available(current, latest):
+    """True only when both versions parse AND latest is strictly newer."""
+    c = _parse_version(current)
+    l = _parse_version(latest)
+    if c is None or l is None:
+        return False
+    return l > c
+
+
+def get_latest_release(force=False):
+    """Return {'version': str, 'url': str} for the newest GitHub release, or None.
+
+    Cached for 6h. Never raises — returns None on any failure so the caller can
+    silently omit the indicator.
+    """
+    if not force:
+        cached = cache.get(_CACHE_KEY)
+        if cached is not None:
+            return cached or None  # cached "" (a prior failure) -> None
+
+    ua = getattr(settings, "OPENEASD_USER_AGENT", "OpenEASD/1.0")
+    try:
+        resp = requests.get(
+            RELEASES_URL,
+            timeout=_TIMEOUT,
+            headers={"Accept": "application/vnd.github+json", "User-Agent": ua},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        tag = data.get("tag_name")
+        if not tag:
+            raise ValueError("no tag_name in release payload")
+        result = {"version": str(tag).lstrip("vV"), "url": data.get("html_url") or ""}
+    except (requests.RequestException, ValueError, KeyError) as exc:
+        logger.info("update check failed (non-fatal): %s", exc)
+        # Cache the failure briefly so a flapping/offline GitHub does not get
+        # hammered on every page load; a short TTL lets it recover soon.
+        cache.set(_CACHE_KEY, "", 300)
+        return None
+
+    cache.set(_CACHE_KEY, result, _CACHE_TTL)
+    return result
+
+
+def check_for_update():
+    """Endpoint-shaped summary: latest version, whether we are behind, and a link.
+
+    Always returns a dict (never raises); missing/uncomparable data yields
+    update_available=False with nulls.
+    """
+    current = getattr(settings, "OPENEASD_VERSION", "dev")
+    latest = get_latest_release()
+    latest_version = latest["version"] if latest else None
+    return {
+        "current_version": current,
+        "latest_version": latest_version,
+        "update_available": is_update_available(current, latest_version),
+        "release_url": (latest["url"] if latest else None) or None,
+    }

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenEASD</title>
-    <script type="module" crossorigin src="/static/assets/index-BdXzkRJ3.js"></script>
-    <link rel="stylesheet" crossorigin href="/static/assets/index-fHOUJMNm.css">
+    <script type="module" crossorigin src="/static/assets/index-DCaXoYau.js"></script>
+    <link rel="stylesheet" crossorigin href="/static/assets/index-CPH2I513.css">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/BuildInfo.jsx
+++ b/frontend/src/components/BuildInfo.jsx
@@ -9,11 +9,22 @@ import { apiGet } from '../api/client.js';
  * runs report "dev"/"unknown" defaults, which are omitted so the line never
  * reads "unknown · unknown".
  */
-export default function BuildInfo({ className = '' }) {
+export default function BuildInfo({ className = '', checkUpdates = false }) {
   const { data } = useQuery({
     queryKey: ['/version/'],
     queryFn: () => apiGet('/version/'),
     staleTime: Infinity,
+  });
+
+  // Only logged-in surfaces pass checkUpdates: the endpoint is authenticated and
+  // hits GitHub (cached server-side). Fail-graceful — on any error we just don't
+  // show the indicator, so the footer never breaks.
+  const { data: latest } = useQuery({
+    queryKey: ['/version/latest/'],
+    queryFn: () => apiGet('/version/latest/'),
+    enabled: checkUpdates,
+    staleTime: 6 * 60 * 60 * 1000,
+    retry: false,
   });
 
   if (!data) return null;
@@ -42,6 +53,18 @@ export default function BuildInfo({ className = '' }) {
         <span aria-hidden="true">·</span>
         <a href={featureUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-dim">Request a feature</a>
       </div>
+      {checkUpdates && latest?.update_available && (
+        <div>
+          <a
+            href={latest.release_url || 'https://github.com/cybersecify/OpenEASD/releases/latest'}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand hover:underline font-medium"
+          >
+            ↑ Update available: v{latest.latest_version}
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { apiGet, apiPost } from '../api/client.js';
 import { auth } from '../auth.js';
+import BuildInfo from './BuildInfo.jsx';
 
 const NAV = [
   { label: 'Dashboard',      path: '/' },
@@ -68,6 +69,7 @@ export function Layout({ children }) {
           >
             Sign out
           </button>
+          <BuildInfo checkUpdates className="mt-3" />
         </div>
       </aside>
       <div className="flex-1 flex flex-col min-w-0">

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -854,3 +854,27 @@ class TestBuildProvenance:
         settings.OPENEASD_GIT_SHA = "0123456789abcdef0123456789abcdef01234567"
         res = client.get("/health/")
         assert res.json()["git_sha"] == "01234567"
+
+    def test_version_latest_requires_auth(self, client):
+        assert client.get("/api/version/latest/").status_code == 401
+
+    def test_version_latest_shape(self, auth_client, settings):
+        from unittest.mock import patch
+        settings.OPENEASD_VERSION = "0.10.0"
+        with patch("apps.core.api.update_check.get_latest_release",
+                   return_value={"version": "9.9.9", "url": "https://gh/rel"}):
+            res = auth_client.get("/api/version/latest/")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["latest_version"] == "9.9.9"
+        assert data["update_available"] is True  # 9.9.9 > running 0.10.0
+        assert set(data) == {
+            "current_version", "latest_version", "update_available", "release_url",
+        }
+
+    def test_version_latest_graceful_when_github_down(self, auth_client):
+        from unittest.mock import patch
+        with patch("apps.core.api.update_check.get_latest_release", return_value=None):
+            res = auth_client.get("/api/version/latest/")
+        assert res.status_code == 200
+        assert res.json()["update_available"] is False

--- a/tests/unit/test_update_check.py
+++ b/tests/unit/test_update_check.py
@@ -1,0 +1,123 @@
+"""Unit tests for the update-available check (apps/core/api/update_check.py)."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+from django.core.cache import cache
+
+from apps.core.api import update_check as uc
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+class TestParseVersion:
+    def test_plain_dotted(self):
+        assert uc._parse_version("0.10.0") == (0, 10, 0)
+
+    def test_v_prefixed(self):
+        assert uc._parse_version("v1.2.3") == (1, 2, 3)
+
+    @pytest.mark.parametrize("bad", ["dev", "unknown", "", None, "DEV"])
+    def test_placeholders_are_none(self, bad):
+        assert uc._parse_version(bad) is None
+
+    def test_non_numeric_is_none(self):
+        assert uc._parse_version("v1.2.x") is None
+
+
+class TestIsUpdateAvailable:
+    def test_newer_latest_true(self):
+        assert uc.is_update_available("0.10.0", "0.11.0") is True
+
+    def test_equal_false(self):
+        assert uc.is_update_available("0.10.0", "0.10.0") is False
+
+    def test_older_latest_false(self):
+        assert uc.is_update_available("0.11.0", "0.10.0") is False
+
+    def test_dev_current_never_available(self):
+        # A local/dev build can't be meaningfully compared -> never nag.
+        assert uc.is_update_available("dev", "0.10.0") is False
+
+    def test_unparseable_latest_false(self):
+        assert uc.is_update_available("0.10.0", None) is False
+
+
+class TestGetLatestRelease:
+    def _resp(self, tag="v0.11.0", url="https://gh/rel"):
+        m = MagicMock()
+        m.raise_for_status.return_value = None
+        m.json.return_value = {"tag_name": tag, "html_url": url}
+        return m
+
+    def test_happy_path_strips_v(self):
+        with patch("apps.core.api.update_check.requests.get", return_value=self._resp()) as g:
+            out = uc.get_latest_release()
+        assert out == {"version": "0.11.0", "url": "https://gh/rel"}
+        g.assert_called_once()
+
+    def test_result_is_cached(self):
+        with patch("apps.core.api.update_check.requests.get", return_value=self._resp()) as g:
+            uc.get_latest_release()
+            uc.get_latest_release()  # second call must hit cache, not network
+        g.assert_called_once()
+
+    def test_timeout_returns_none(self):
+        with patch("apps.core.api.update_check.requests.get",
+                   side_effect=requests.Timeout("slow")):
+            assert uc.get_latest_release() is None
+
+    def test_http_error_returns_none(self):
+        bad = MagicMock()
+        bad.raise_for_status.side_effect = requests.HTTPError("500")
+        with patch("apps.core.api.update_check.requests.get", return_value=bad):
+            assert uc.get_latest_release() is None
+
+    def test_missing_tag_returns_none(self):
+        m = MagicMock()
+        m.raise_for_status.return_value = None
+        m.json.return_value = {"html_url": "x"}
+        with patch("apps.core.api.update_check.requests.get", return_value=m):
+            assert uc.get_latest_release() is None
+
+    def test_failure_is_cached_briefly(self):
+        with patch("apps.core.api.update_check.requests.get",
+                   side_effect=requests.Timeout("slow")) as g:
+            uc.get_latest_release()
+            uc.get_latest_release()  # cached failure -> no second network call
+        g.assert_called_once()
+
+
+class TestCheckForUpdate:
+    def test_shape_when_behind(self, settings):
+        settings.OPENEASD_VERSION = "0.10.0"
+        with patch("apps.core.api.update_check.get_latest_release",
+                   return_value={"version": "0.11.0", "url": "https://gh/rel"}):
+            out = uc.check_for_update()
+        assert out == {
+            "current_version": "0.10.0",
+            "latest_version": "0.11.0",
+            "update_available": True,
+            "release_url": "https://gh/rel",
+        }
+
+    def test_shape_when_up_to_date(self, settings):
+        settings.OPENEASD_VERSION = "0.11.0"
+        with patch("apps.core.api.update_check.get_latest_release",
+                   return_value={"version": "0.11.0", "url": "https://gh/rel"}):
+            out = uc.check_for_update()
+        assert out["update_available"] is False
+
+    def test_graceful_when_github_down(self, settings):
+        settings.OPENEASD_VERSION = "0.10.0"
+        with patch("apps.core.api.update_check.get_latest_release", return_value=None):
+            out = uc.check_for_update()
+        assert out["latest_version"] is None
+        assert out["update_available"] is False
+        assert out["release_url"] is None


### PR DESCRIPTION
## What
- Move the `BuildInfo` footer (version · sha · date + Report-an-issue / Request-a-feature links) into the authenticated app sidebar. It was previously only on the login + change-password pages, so a logged-in operator never saw the running version or how to report a problem.
- Add `GET /api/version/latest/` (authenticated): compares the running build to the latest public GitHub release, cached 6h, fully fail-graceful. The sidebar footer shows an "↑ Update available: vX.Y.Z" link when the deployment is behind.

The app still never self-updates — this is a heads-up + release link only; upgrades stay an explicit redeploy.

## Tests
- `tests/unit/test_update_check.py` (22): version parse/compare, cached fetch, fail-graceful on timeout/HTTP-error/bad-payload.
- `tests/test_api_endpoints.py` (+3): endpoint auth + shape + graceful-when-GitHub-down.
- Full fast suite: 1179 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)