### PR TITLE
fix: no-store on provenance endpoints + cap nuclei Go heap (low profile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Fixed
+- **Provenance endpoints (`/api/version/`, `/health/`) now send `Cache-Control:
+  no-store`.** **Why:** Cloudflare (and any CDN) was caching the unauthenticated
+  `/api/version/`, so the in-app build line showed a stale version/sha for hours
+  after a redeploy. No-store keeps the displayed build honest on every deploy.
+
+### Changed
+- **nuclei / nuclei_network now honour a Go soft memory limit in the `low`
+  profile** (`NUCLEI_GOMEMLIMIT`, default `600MiB`; `GOGC=50`). **Why:** nuclei
+  loads its whole template set into RAM (the real footprint — independent of the
+  polite request-rate cap), which on a 1 GB host swaps hard and can freeze the
+  whole box, including the web UI, for minutes. `GOMEMLIMIT` makes the Go runtime
+  GC aggressively near the ceiling, holding RSS down while keeping full template
+  coverage. Unset (unbounded, prior behaviour) on the balanced/high profiles.
+
 ### Added
 - **In-app version footer + "update available" check for logged-in users.** The
   build provenance line (`OpenEASD vX.Y.Z · <sha> · <date>`) and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,6 +649,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_default_workflow.py` | 5 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/unit/test_update_check.py` | 22 | Update-available check — version parse/compare, cached GitHub fetch, fail-graceful on timeout/HTTP-error/bad-payload, endpoint shape |
-| `tests/test_api_endpoints.py` | 96 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` + update-check `/api/version/latest/` |
+| `tests/unit/test_proc_env.py` | 4 | `go_memory_env()` — GOMEMLIMIT/GOGC set in low profile, unchanged otherwise, preserves existing env |
+| `tests/test_api_endpoints.py` | 98 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1230 tests** (1179 fast + 51 slow domain_security)
+**Total: 1236 tests** (1185 fast + 51 slow domain_security)

--- a/apps/core/api/ninja.py
+++ b/apps/core/api/ninja.py
@@ -1,7 +1,7 @@
 """Central Django Ninja API instance for OpenEASD."""
 
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError, ValidationError
 from ninja_jwt.routers.obtain import obtain_pair_router   # POST /pair, POST /refresh
@@ -83,8 +83,10 @@ api.add_router("/token", blacklist_router)
 # for local runs ("dev"/"unknown").
 # ---------------------------------------------------------------------------
 @api.get("/version/", auth=None)
-def version(request):
+def version(request, response: HttpResponse):
     sha = settings.OPENEASD_GIT_SHA
+    # no-store so a CDN never serves a stale build line after a redeploy.
+    response["Cache-Control"] = "no-store"
     return {
         "version": settings.OPENEASD_VERSION,
         "git_sha": sha,

--- a/apps/core/workflows/proc_env.py
+++ b/apps/core/workflows/proc_env.py
@@ -1,0 +1,23 @@
+"""Subprocess environment helpers for tool runners."""
+
+import os
+
+from django.conf import settings
+
+
+def go_memory_env():
+    """Env dict for memory-hungry Go tools (nuclei / nuclei_network).
+
+    Starts from the current environment and, when the resource profile sets a
+    soft ceiling (``settings.NUCLEI_GOMEMLIMIT``), adds ``GOMEMLIMIT`` + a lower
+    ``GOGC`` so the Go runtime GCs aggressively instead of letting RSS balloon
+    into swap and freezing a small host. When no limit is configured (balanced/
+    high profiles) the env is returned unchanged, so behaviour there is identical
+    to before.
+    """
+    env = os.environ.copy()
+    limit = getattr(settings, "NUCLEI_GOMEMLIMIT", "")
+    if limit:
+        env["GOMEMLIMIT"] = limit
+        env.setdefault("GOGC", "50")
+    return env

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -44,7 +44,7 @@ CONCURRENCY = 25      # fallback -c; the resource profile overrides it
 _DRAIN_GRACE = 30  # seconds to let a SIGKILL'd process die before we give up
 
 
-def _run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess:
+def _run(cmd: list[str], timeout: int, env: dict | None = None) -> subprocess.CompletedProcess:
     """Run an external tool with a timeout that cannot be defeated by child processes.
 
     Why not subprocess.run / communicate(): communicate() reads stdout/stderr until
@@ -73,6 +73,7 @@ def _run(cmd: list[str], timeout: int) -> subprocess.CompletedProcess:
                 stderr=err_f,
                 stdin=subprocess.DEVNULL,
                 start_new_session=True,
+                env=env,
             )
             try:
                 proc.wait(timeout=timeout)
@@ -145,7 +146,10 @@ def collect(session) -> list[dict]:
     logger.info(f"[nuclei:{session.id}] Scanning {len(targets)} web targets")
 
     try:
-        result = _run(cmd, TIMEOUT)
+        # Cap nuclei's Go heap on low-memory hosts so its template load can't
+        # swap the box into a freeze (env is unchanged on balanced/high).
+        from apps.core.workflows.proc_env import go_memory_env
+        result = _run(cmd, TIMEOUT, env=go_memory_env())
     except FileNotFoundError:
         logger.error(f"[nuclei:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"nuclei binary not found: {binary}")

--- a/apps/nuclei_network/collector.py
+++ b/apps/nuclei_network/collector.py
@@ -107,7 +107,10 @@ def collect(session) -> list[dict]:
     ]
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT, stdin=subprocess.DEVNULL)
+        # Cap nuclei's Go heap on low-memory hosts (unchanged on balanced/high).
+        from apps.core.workflows.proc_env import go_memory_env
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT,
+                                stdin=subprocess.DEVNULL, env=go_memory_env())
     except FileNotFoundError:
         logger.error(f"[nuclei_network:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"nuclei binary not found: {binary}")

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -353,6 +353,15 @@ _PROFILE_TUNING = {
 NUCLEI_CONCURRENCY = _PROFILE_TUNING[PROFILE]["nuclei_c"]
 NUCLEI_RATE_LIMIT = _PROFILE_TUNING[PROFILE]["nuclei_rate"]
 
+# Soft memory ceiling for the nuclei/nuclei_network Go processes. nuclei loads
+# its whole template set into RAM (the real footprint — independent of the polite
+# rate cap), which on a 1 GB box swaps hard and can freeze the whole host,
+# including the web UI, for minutes. GOMEMLIMIT makes the Go runtime GC
+# aggressively as it nears the ceiling, holding RSS down (costs some CPU, keeps
+# full template coverage). Only applied in the low profile; empty = leave Go's
+# default (unbounded) alone. GOGC lowered alongside to trade CPU for memory.
+NUCLEI_GOMEMLIMIT = config("NUCLEI_GOMEMLIMIT", default=("600MiB" if LOW_MEMORY else ""))
+
 # Hudson Rock (Cavalier) OSINT API base — free, keyless infostealer-exposure
 # intelligence. OSS use permitted by Hudson Rock co-founder Alon Gal. Overridable
 # for testing / self-hosting.

--- a/openeasd/urls.py
+++ b/openeasd/urls.py
@@ -11,12 +11,16 @@ from apps.core.api.ninja import api
 
 
 def health(request):
-    return JsonResponse({
+    resp = JsonResponse({
         "status": "ok",
         "version": settings.OPENEASD_VERSION,
         "git_sha": settings.OPENEASD_GIT_SHA[:8],
         "build_date": settings.OPENEASD_BUILD_DATE,
     })
+    # Never let a CDN/proxy cache provenance — a cached response makes the app
+    # report a stale build after a redeploy (Cloudflare cached /api/version/).
+    resp["Cache-Control"] = "no-store"
+    return resp
 
 
 urlpatterns = [

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -855,6 +855,15 @@ class TestBuildProvenance:
         res = client.get("/health/")
         assert res.json()["git_sha"] == "01234567"
 
+    def test_version_no_store_header(self, client):
+        # Must not be CDN-cached, or the app reports a stale build after redeploy.
+        res = client.get("/api/version/")
+        assert res.headers.get("Cache-Control") == "no-store"
+
+    def test_health_no_store_header(self, client):
+        res = client.get("/health/")
+        assert res.headers.get("Cache-Control") == "no-store"
+
     def test_version_latest_requires_auth(self, client):
         assert client.get("/api/version/latest/").status_code == 401
 

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -290,7 +290,7 @@ class TestNucleiCollector:
         sess = self._make_session()
         captured = {}
 
-        def fake_run(cmd, timeout):
+        def fake_run(cmd, timeout, env=None):
             captured["cmd"] = cmd
             captured["timeout"] = timeout
             return MagicMock(stdout="", returncode=0, stderr="")
@@ -316,7 +316,7 @@ class TestNucleiCollector:
         sess = self._make_session()
         captured = {}
 
-        def fake_run(cmd, timeout):
+        def fake_run(cmd, timeout, env=None):
             captured["cmd"] = cmd
             return MagicMock(stdout="", returncode=0, stderr="")
 

--- a/tests/unit/test_proc_env.py
+++ b/tests/unit/test_proc_env.py
@@ -1,0 +1,28 @@
+"""Tests for the Go-tool memory-env helper (apps/core/workflows/proc_env.py)."""
+
+from apps.core.workflows.proc_env import go_memory_env
+
+
+class TestGoMemoryEnv:
+    def test_sets_gomemlimit_and_gogc_when_configured(self, settings):
+        settings.NUCLEI_GOMEMLIMIT = "600MiB"
+        env = go_memory_env()
+        assert env["GOMEMLIMIT"] == "600MiB"
+        assert env["GOGC"] == "50"
+
+    def test_unchanged_when_no_limit(self, settings):
+        settings.NUCLEI_GOMEMLIMIT = ""
+        env = go_memory_env()
+        assert "GOMEMLIMIT" not in env
+
+    def test_preserves_existing_environment(self, settings, monkeypatch):
+        settings.NUCLEI_GOMEMLIMIT = "600MiB"
+        monkeypatch.setenv("PATH", "/custom/path")
+        env = go_memory_env()
+        assert env["PATH"] == "/custom/path"  # inherits real env, just adds limits
+
+    def test_does_not_clobber_preset_gogc(self, settings, monkeypatch):
+        settings.NUCLEI_GOMEMLIMIT = "600MiB"
+        monkeypatch.setenv("GOGC", "off")
+        env = go_memory_env()
+        assert env["GOGC"] == "off"  # setdefault leaves an explicit value alone


### PR DESCRIPTION
## What
Two issues found running the 1 GB droplet:

1. **Cloudflare cached `/api/version/`** → the in-app build line showed a stale sha for hours after a redeploy. Now `/api/version/` and `/health/` send `Cache-Control: no-store`.
2. **nuclei froze the box** — it loads its whole template set into RAM (the real footprint, independent of the polite request-rate cap), swapping a 1 GB host into a multi-minute freeze that also took down the web UI. Apply a Go soft memory limit (`GOMEMLIMIT=600MiB`, `GOGC=50`) to nuclei/nuclei_network **in the low profile only** (`NUCLEI_GOMEMLIMIT`). Runtime GCs hard instead of ballooning RSS; full template coverage kept; balanced/high unchanged.

## Tests
- `tests/unit/test_proc_env.py` (4): `go_memory_env()` sets/omits GOMEMLIMIT+GOGC per profile, preserves env.
- `tests/test_api_endpoints.py` (+2): `no-store` on `/api/version/` + `/health/`.
- Updated 2 `test_nuclei.py` fakes for the new `_run(..., env=)` kwarg.
- Full fast suite: 1185 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)