### PR TITLE
fix: surface silent scan degradation (partial status + block counting + regression warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **Silent scan degradation is now surfaced, not hidden.** Three linked fixes so a
+  scan that was blocked/incomplete stops reading as a clean, complete scan (found
+  after the droplet's results quietly dropped from ~50 findings to ~18 when the
+  target began dropping its probes, only noticed by manually comparing reports):
+  - **Scan status reflects the workflow outcome.** `_finalize_session` no longer
+    hard-codes `completed`; if any tool failed or timed out (run is `partial`),
+    the scan is marked **`partial`**. Previously a half-finished scan (e.g. nuclei
+    timing out) still showed `completed`.
+  - **Silent blocks are counted.** httpx records how many endpoints it was asked
+    to probe (`endpoints_probed`); coverage now treats every probed endpoint that
+    did not come back cleanly as blocked/unreachable — so "probed 100, 0 came
+    back" (a silent IP drop that leaves no URL to classify) is visible instead of
+    looking like a clean site. **Why:** the prior logic only classified URLs httpx
+    *returned*, so a total block (zero URLs) read as `probed=0, blocked=0`.
+  - **Coverage-regression warning.** A scan that surfaces far less than the
+    previous one for the same domain (findings or live web endpoints halved, or
+    ≥80% of probes unreachable) now emits an in-report `scan_coverage` finding
+    telling the operator the results are a lower bound and the scanner may be
+    blocked — instead of them having to diff two reports by eye.
 - **Provenance endpoints (`/api/version/`, `/health/`) now send `Cache-Control:
   no-store`.** **Why:** Cloudflare (and any CDN) was caching the unauthenticated
   `/api/version/`, so the in-app build line showed a stale version/sha for hours

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -650,6 +650,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/unit/test_update_check.py` | 22 | Update-available check — version parse/compare, cached GitHub fetch, fail-graceful on timeout/HTTP-error/bad-payload, endpoint shape |
 | `tests/unit/test_proc_env.py` | 4 | `go_memory_env()` — GOMEMLIMIT/GOGC set in low profile, unchanged otherwise, preserves existing env |
+| `tests/unit/test_coverage_regression.py` | 10 | Silent-block coverage counting (probed-vs-reached), coverage-regression finding (high block ratio / findings drop / stable = no flag), partial scan status when a tool fails |
 | `tests/test_api_endpoints.py` | 98 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1236 tests** (1185 fast + 51 slow domain_security)
+**Total: 1246 tests** (1195 fast + 51 slow domain_security)

--- a/apps/core/scans/pipeline.py
+++ b/apps/core/scans/pipeline.py
@@ -74,6 +74,79 @@ def _detect_deltas(session):
         ScanDelta.objects.bulk_create(deltas)
 
 
+def _check_coverage_regression(session):
+    """Emit a loud, in-report warning when this scan's coverage collapsed vs the
+    previous one — the tell for the scanner's IP being blocked/rate-limited.
+
+    Catches what a human otherwise only notices by manually comparing two
+    reports: findings or live web endpoints dropping sharply, or most probes
+    coming back unreachable. Written as a Finding so it shows in the report and
+    flows through the normal alert path.
+    """
+    from apps.core.web_assets.models import URL
+    from apps.core.findings.models import Finding
+
+    def _httpx_urls(s):
+        return URL.objects.filter(session=s, source="httpx").count()
+
+    reasons = []
+
+    # 1. Most probes unreachable this run (silent drops / WAF) — needs no baseline.
+    probed = session.endpoints_probed or 0
+    blocked = session.endpoints_blocked or 0
+    if probed >= 5 and blocked / probed >= 0.8:
+        reasons.append(
+            f"{blocked} of {probed} web endpoints probed were unreachable "
+            f"({round(100 * blocked / probed)}%)"
+            + (f", consistent with {session.waf_vendor}" if session.waf_vendor else "")
+        )
+
+    # 2. Sharp drop vs the previous completed/partial full scan for this domain.
+    previous = (
+        ScanSession.objects.filter(
+            domain=session.domain, status__in=["completed", "partial"]
+        )
+        .exclude(id=session.id)
+        .exclude(scan_type="subscan")
+        .order_by("-start_time")
+        .first()
+    )
+    if previous:
+        pf, cf = previous.total_findings or 0, session.total_findings or 0
+        if pf >= 5 and cf <= 0.5 * pf:
+            reasons.append(f"findings fell from {pf} to {cf} vs the previous scan")
+        pu, cu = _httpx_urls(previous), _httpx_urls(session)
+        if pu >= 3 and cu <= 0.5 * pu:
+            reasons.append(f"live web endpoints fell from {pu} to {cu} vs the previous scan")
+
+    if not reasons:
+        return
+
+    Finding.objects.create(
+        session=session,
+        source="scan_coverage",
+        check_type="coverage_regression",
+        severity="medium",
+        title="Scan coverage dropped sharply — results may be incomplete",
+        description=(
+            "This scan surfaced far less than expected, which usually means the "
+            "scanner could not reach the target rather than that the target is "
+            "clean. Observed: " + "; ".join(reasons) + "."
+        ),
+        remediation=(
+            "Treat these results as a lower bound, not a clean bill of health. "
+            "The target may be blocking or rate-limiting this scanner's IP (WAF), "
+            "or its hosting/DNS changed. Re-run from a different vantage point or "
+            "an allowlisted IP, run a passive scan (public sources, no direct "
+            "probing) to compare, and confirm the host is actually reachable."
+        ),
+        target=session.domain,
+    )
+    logger.warning(
+        f"[scan:{session.id}] Coverage regression flagged: {'; '.join(reasons)}"
+    )
+
+
 def _count_all_findings(session) -> int:
     try:
         from apps.core.findings.models import Finding
@@ -96,19 +169,28 @@ def _compute_coverage(session):
     from apps.core.web_assets.models import URL
     from apps.httpx.waf import INTERFERED, fingerprint_vendor
 
-    probes = list(
+    # `endpoints_probed` is the number of targets httpx was ASKED to probe (set by
+    # the httpx scanner). Hosts that responded become URL rows; hosts that were
+    # silently dropped leave nothing. So "blocked/unreachable" = everything we
+    # probed that did NOT come back as a cleanly reachable URL. This makes a
+    # silent block (0 URLs from N probes) visible instead of reading as "clean".
+    live = list(
         URL.objects.filter(session=session, source="httpx")
-        .exclude(reachability="")
         .values_list("reachability", "title", "web_server")
     )
-    session.endpoints_probed = len(probes)
-    session.endpoints_blocked = sum(1 for r, _, _ in probes if r in INTERFERED)
+    interfered = [(r, t, w) for r, t, w in live if r in INTERFERED]
+    reached_ok = sum(1 for r, _, _ in live if r not in INTERFERED)  # "" counts as reached
+    # The httpx scanner persisted the probe count; re-read it (this may be a
+    # different in-memory instance) rather than trust the in-memory field.
+    session.refresh_from_db(fields=["endpoints_probed"])
+    probed = session.endpoints_probed or len(live)
+    session.endpoints_probed = probed
+    session.endpoints_blocked = max(0, probed - reached_ok)
 
-    # Dominant vendor among interfered probes; "" when nothing was blocked.
+    # Dominant vendor among interfered probes; "" when nothing identifiable blocked.
     vendors = Counter(
         fingerprint_vendor(title, ws) or "unidentified"
-        for r, title, ws in probes
-        if r in INTERFERED
+        for _, title, ws in interfered
     )
     session.waf_vendor = vendors.most_common(1)[0][0] if vendors else ""
 
@@ -119,7 +201,13 @@ def _finalize_session(session):
     total = _count_all_findings(session)
     session.total_findings = total
     _compute_coverage(session)
-    session.status = "completed"
+    # Reflect the workflow run's outcome instead of always claiming "completed":
+    # if any tool failed or timed out, the run is "partial" and the scan must say
+    # so, or the top-line status hides a half-finished scan (a tool that didn't
+    # run produces zero findings, which reads as "clean").
+    from apps.core.workflows.models import WorkflowRun
+    run = WorkflowRun.objects.filter(session=session).order_by("-id").first()
+    session.status = "partial" if run and run.status in ("partial", "failed") else "completed"
     session.end_time = django_tz.now()
     session.save(update_fields=[
         "total_findings", "status", "end_time",
@@ -139,6 +227,10 @@ def _finalize_session(session):
         return
 
     _detect_deltas(session)
+
+    # After deltas (so this meta-warning isn't itself a "new finding" delta) and
+    # before insights (so it's included in the report's finding set).
+    _check_coverage_regression(session)
 
     from apps.core.insights.builder import build_insights
     build_insights(session)

--- a/apps/httpx/scanner.py
+++ b/apps/httpx/scanner.py
@@ -42,6 +42,14 @@ def run_httpx(session) -> list[URL]:
         seen.add(target)
         targets.append(target)
 
+    # Record how many endpoints we actually asked httpx to probe. This is the
+    # denominator for coverage: if we probed 100 and 0 came back, the target is
+    # dropping us — a silent block that leaves no URL to classify, so it is
+    # otherwise invisible. Persisted here (before analyze) so it survives even if
+    # every probe is dropped.
+    session.endpoints_probed = len(targets)
+    session.save(update_fields=["endpoints_probed"])
+
     records = collect(session, targets)
     objs = analyze(session, records)
 

--- a/tests/integration/test_scan_flow.py
+++ b/tests/integration/test_scan_flow.py
@@ -197,7 +197,7 @@ class TestFullScanPipeline:
             run_scan(session.id)
 
         session.refresh_from_db()
-        assert session.status == "completed"
+        assert session.status in ("completed", "partial")
         assert session.end_time is not None
 
     def test_run_scan_builds_insights(self, transactional_db):
@@ -290,8 +290,8 @@ class TestFullScanPipeline:
 
         s1.refresh_from_db()
         s2.refresh_from_db()
-        assert s1.status == "completed"
-        assert s2.status == "completed"
+        assert s1.status in ("completed", "partial")
+        assert s2.status in ("completed", "partial")
         # Delta exists for s2 (compared against s1)
         # Same findings → no "new" deltas
         new_deltas = ScanDelta.objects.filter(session=s2, change_type="new")
@@ -449,7 +449,7 @@ class TestFullPipelineMocked:
             run_scan(session.id)
 
         session.refresh_from_db()
-        assert session.status == "completed"
+        assert session.status in ("completed", "partial")
 
         # Verify the asset graph is intact.
         # Subdomain pool: 1 seed (the apex `pipeline.test`, inserted at pipeline

--- a/tests/unit/test_coverage_regression.py
+++ b/tests/unit/test_coverage_regression.py
@@ -1,0 +1,107 @@
+"""Tests for silent-block coverage counting, coverage-regression flagging, and
+partial scan status (the 'silent degradation' fixes)."""
+
+import pytest
+
+from apps.core.scans.pipeline import (
+    _compute_coverage, _check_coverage_regression, _finalize_session,
+)
+
+
+def _session(**kw):
+    from apps.core.scans.models import ScanSession
+    return ScanSession.objects.create(domain="example.com", scan_type="full", **kw)
+
+
+def _httpx_url(session, host, reachability=""):
+    from apps.core.web_assets.models import URL
+    return URL.objects.create(
+        session=session, url=f"https://{host}:443", host=host, port_number=443,
+        scheme="https", reachability=reachability, source="httpx",
+    )
+
+
+@pytest.mark.django_db
+class TestSilentBlockCounting:
+    def test_all_probes_dropped_counts_as_blocked(self):
+        # httpx probed 10 targets, 0 came back (silent block) -> blocked = 10.
+        s = _session(endpoints_probed=10)
+        _compute_coverage(s)
+        assert s.endpoints_probed == 10
+        assert s.endpoints_blocked == 10
+
+    def test_partial_reach(self):
+        # probed 10, 8 responded cleanly -> 2 unreachable.
+        s = _session(endpoints_probed=10)
+        for i in range(8):
+            _httpx_url(s, f"h{i}.example.com", reachability="reached")
+        _compute_coverage(s)
+        assert s.endpoints_blocked == 2
+
+    def test_interfered_counts_as_blocked(self):
+        s = _session(endpoints_probed=3)
+        _httpx_url(s, "a.example.com", reachability="reached")
+        _httpx_url(s, "b.example.com", reachability="blocked")
+        _httpx_url(s, "c.example.com", reachability="challenged")
+        _compute_coverage(s)
+        assert s.endpoints_blocked == 2  # blocked + challenged
+
+
+@pytest.mark.django_db
+class TestCoverageRegression:
+    def test_high_block_ratio_flags(self):
+        from apps.core.findings.models import Finding
+        s = _session(endpoints_probed=10, endpoints_blocked=10)
+        _check_coverage_regression(s)
+        f = Finding.objects.filter(session=s, check_type="coverage_regression")
+        assert f.count() == 1
+        assert "unreachable" in f.first().description.lower()
+
+    def test_findings_drop_flags(self):
+        from apps.core.findings.models import Finding
+        prev = _session(status="completed", total_findings=50)
+        cur = _session(total_findings=10)
+        _check_coverage_regression(cur)
+        assert Finding.objects.filter(session=cur, check_type="coverage_regression").exists()
+
+    def test_stable_scan_no_flag(self):
+        from apps.core.findings.models import Finding
+        _session(status="completed", total_findings=50)
+        cur = _session(total_findings=48, endpoints_probed=10, endpoints_blocked=1)
+        _check_coverage_regression(cur)
+        assert not Finding.objects.filter(session=cur, check_type="coverage_regression").exists()
+
+    def test_no_previous_and_reachable_no_flag(self):
+        from apps.core.findings.models import Finding
+        cur = _session(total_findings=3, endpoints_probed=4, endpoints_blocked=1)
+        _check_coverage_regression(cur)
+        assert not Finding.objects.filter(session=cur, check_type="coverage_regression").exists()
+
+
+@pytest.mark.django_db
+class TestPartialStatus:
+    def _run(self, session, status):
+        from apps.core.workflows.models import Workflow, WorkflowRun
+        wf = Workflow.objects.create(name="wf")
+        return WorkflowRun.objects.create(workflow=wf, session=session, status=status)
+
+    def test_partial_when_a_tool_failed(self):
+        s = _session()
+        self._run(s, "partial")
+        _finalize_session(s)
+        s.refresh_from_db()
+        assert s.status == "partial"
+
+    def test_completed_when_all_ok(self):
+        s = _session()
+        self._run(s, "completed")
+        _finalize_session(s)
+        s.refresh_from_db()
+        assert s.status == "completed"
+
+    def test_failed_run_marks_partial(self):
+        s = _session()
+        self._run(s, "failed")
+        _finalize_session(s)
+        s.refresh_from_db()
+        assert s.status == "partial"


### PR DESCRIPTION
## Why
On the droplet, results silently dropped from ~50 findings to ~18 when the target began dropping the scanner's probes — and it was only caught by manually comparing two reports. A blocked/incomplete scan was reading as clean and complete. Three linked fixes so degradation announces itself.

## What
1. **Partial status** — `_finalize_session` reflects the workflow run instead of hard-coding `completed`. Any tool that failed/timed out ⇒ scan is `partial`. (nuclei timing out no longer hides behind `completed`.)
2. **Silent-block counting** — httpx records `endpoints_probed` (targets it was asked to probe). Coverage now = every probed endpoint that didn't come back cleanly is blocked/unreachable, so "probed N, 0 URLs" (a silent IP drop that leaves nothing to classify) is visible. Previously only *returned* URLs were classified, so a total block read as `probed=0, blocked=0`.
3. **Coverage-regression finding** — a `scan_coverage` finding fires when findings or live web endpoints halve vs the previous scan, or ≥80% of probes are unreachable, telling the operator the results are a lower bound and the scanner may be blocked.

## Tests
- `tests/unit/test_coverage_regression.py` (10): silent-block counting, regression triggers/non-triggers, partial-status.
- Relaxed 4 integration assertions from `== "completed"` to `in ("completed","partial")` — with tool binaries absent in CI, `partial` is now the honest outcome (that's the point).
- Full fast suite: 1195 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)