### PR TITLE
fix: real defects from test-suite audit (Batch 1 — live bugs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **Live defects found by a full test-suite audit (silent-failure class).** A
+  7-agent audit of the ~45-file suite found real bugs the 1200+ tests missed
+  because they were shallow on failure modes (and, in two cases, actively
+  codified the bug):
+  - **amass swallowed its own timeout** and returned partial results with no
+    error, so a hung amass made the whole scan read `completed` with a truncated
+    surface. Now raises `ToolTimeout` (→ scan `partial`). The test that asserted
+    the swallow was rewritten to assert the raise.
+  - **takeover_check silently dropped `vulnerable:True` records** whose service
+    it couldn't fingerprint — so any drift in subzy's output fields would make
+    every real subdomain takeover vanish. Now reports them with an "unidentified
+    service" label. The test that blessed the drop was inverted.
+  - **nmap returned a falsely-clean CVE result when every target IP timed out**
+    (per-IP timeouts are still skipped as degraded, but an all-IP timeout now
+    raises `ToolTimeout`).
+  - **The coverage note claimed endpoints "returned block or challenge
+    responses" even for silent drops** that returned nothing; wording now
+    distinguishes a real WAF block-page from a no-response/non-HTTP endpoint.
+  - **domain_security aborted the entire RDAP check** (`KeyError`) on a real
+    registrar event missing `eventAction`; now guarded.
+  - **alterx** no longer silently returns nothing when its binary is missing —
+    it raises `ToolBinaryMissing` like every other tool (dead unreachable branch
+    removed).
 - **Silent scan degradation is now surfaced, not hidden.** Three linked fixes so a
   scan that was blocked/incomplete stops reading as a clean, complete scan (found
   after the droplet's results quietly dropped from ~50 findings to ~18 when the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,7 +611,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_cve_intel.py` | 24 | EPSS/KEV enrichment, CVE extraction (both finding shapes), feed-failure fallback |
 | `tests/unit/test_dnsx.py` | 21 | Public IP filter, analyzer, scanner |
 | `tests/unit/test_domain_authorization.py` | 9 | DomainAuthorization model + scan-entry gating |
-| `tests/unit/test_domain_security.py` | 51 | DNS/email/RDAP — **slow, real network** |
+| `tests/unit/test_domain_security.py` | 52 | DNS/email/RDAP — **slow, real network** |
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 16 | JSON parser, Port lookup, Subdomain link, honest UA, tech-detect flag + technology storage/dedup |
@@ -653,4 +653,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_coverage_regression.py` | 10 | Silent-block coverage counting (probed-vs-reached), coverage-regression finding (high block ratio / findings drop / stable = no flag), partial scan status when a tool fails |
 | `tests/test_api_endpoints.py` | 98 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1246 tests** (1195 fast + 51 slow domain_security)
+**Total: 1251 tests** (1199 fast + 52 slow domain_security)

--- a/apps/alterx/collector.py
+++ b/apps/alterx/collector.py
@@ -1,5 +1,4 @@
 import logging
-import shutil
 import subprocess
 
 from django.conf import settings
@@ -17,9 +16,6 @@ def collect(subdomains: list[str]) -> list[str]:
         return []
 
     binary = getattr(settings, "TOOL_ALTERX", "alterx")
-    if not shutil.which(binary):
-        logger.debug("alterx binary not found at %r — skipping", binary)
-        return []
 
     stdin_data = "\n".join(subdomains)
 

--- a/apps/amass/collector.py
+++ b/apps/amass/collector.py
@@ -9,7 +9,7 @@ import tempfile
 import yaml
 from django.conf import settings
 
-from apps.core.workflows.exceptions import ToolBinaryMissing
+from apps.core.workflows.exceptions import ToolBinaryMissing, ToolTimeout
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +84,17 @@ def collect(session) -> list[dict]:
             stdout, stderr = proc.communicate(timeout=config.scan_timeout * 60 + 30)
         except subprocess.TimeoutExpired:
             proc.kill()
-            stdout, stderr = proc.communicate()
+            proc.communicate()
+            # This fires 30s PAST amass's own scan_timeout — i.e. amass ignored
+            # its internal budget and hung, not a clean time-boxed finish. Raise
+            # so the step is marked failed and the scan reports "partial" instead
+            # of silently presenting a truncated surface as a complete scan.
             logger.warning(
-                f"[amass:{session.id}] Hit timeout after {config.scan_timeout}m "
-                f"— returning partial results"
+                f"[amass:{session.id}] Hung past {config.scan_timeout}m budget "
+                f"— marking step failed (scan will report partial)"
+            )
+            raise ToolTimeout(
+                f"amass hung past its {config.scan_timeout}m scan_timeout"
             )
         else:
             if proc.returncode != 0:

--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -140,20 +140,37 @@ def _coverage_context(session):
     if not blocked:
         return None
     vendor = session.waf_vendor
+    probed = session.endpoints_probed
     if vendor and vendor != "unidentified":
         vendor_phrase = f"fingerprint suggests {_WAF_VENDOR_LABEL.get(vendor, vendor.title())}"
     else:
         vendor_phrase = "WAF/edge, vendor unidentified"
+
+    # Two distinct shapes both land in `endpoints_blocked`:
+    #  - vendor set  -> endpoints RESPONDED with a block/challenge page (real WAF)
+    #  - vendor ""   -> endpoints returned NOTHING (silent drop). Do not claim they
+    #    "returned block/challenge responses" — they didn't respond at all, and the
+    #    count can also include probed ports that simply aren't HTTP services.
+    if vendor:
+        observation = (
+            f"{blocked} of {probed} probed endpoints returned block or challenge "
+            f"responses ({vendor_phrase})"
+        )
+    else:
+        observation = (
+            f"{blocked} of {probed} probed endpoints did not return an HTTP response "
+            f"— probes appear to have been dropped/blocked at the network edge (or "
+            f"the port is not an HTTP service)"
+        )
     return {
-        "endpoints_probed": session.endpoints_probed,
+        "endpoints_probed": probed,
         "endpoints_blocked": blocked,
         "vendor_phrase": vendor_phrase,
         "note": (
-            f"{blocked} of {session.endpoints_probed} probed endpoints returned "
-            f"block or challenge responses ({vendor_phrase}). Findings reflect only "
-            f"reachable endpoints. Absence of findings on blocked surfaces is not "
-            f"evidence they are secure. To obtain full-coverage results, allowlist "
-            f"the scanner (OpenEASD/1.0, source IP on file) in your WAF and re-run."
+            f"{observation}. Findings reflect only reachable endpoints. Absence of "
+            f"findings on unreachable surfaces is not evidence they are secure. To "
+            f"obtain full-coverage results, allowlist the scanner (OpenEASD/1.0, "
+            f"source IP on file) at your edge/WAF and re-run."
         ),
     }
 

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -754,7 +754,14 @@ def _check_rdap(session, domain) -> list:
         return findings
 
     statuses = [s.lower() for s in data.get("status", [])]
-    events = {e["eventAction"]: e["eventDate"] for e in data.get("events", []) if "eventDate" in e}
+    # Guard eventAction too, not just eventDate: real registrar RDAP payloads
+    # sometimes omit eventAction, and an unguarded e["eventAction"] KeyError would
+    # abort the ENTIRE RDAP check (expiry/lock/registrar), silently losing findings.
+    events = {
+        e["eventAction"]: e["eventDate"]
+        for e in data.get("events", [])
+        if e.get("eventAction") and e.get("eventDate")
+    }
 
     # Domain expiry
     expiry_str = events.get("expiration")

--- a/apps/nmap/collector.py
+++ b/apps/nmap/collector.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from django.conf import settings
 
-from apps.core.workflows.exceptions import ToolBinaryMissing
+from apps.core.workflows.exceptions import ToolBinaryMissing, ToolTimeout
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +22,13 @@ def collect(session, ip_to_ports: dict[str, list[int]]) -> dict[str, str]:
 
     binary = getattr(settings, "TOOL_NMAP", "nmap")
     results: dict[str, str] = {}
+    attempted = 0
+    timed_out = 0
 
     for ip, ports in ip_to_ports.items():
         if not ports:
             continue
+        attempted += 1
         port_list = ",".join(str(p) for p in sorted(set(ports)))
         cmd = [
             binary,
@@ -52,7 +55,16 @@ def collect(session, ip_to_ports: dict[str, list[int]]) -> dict[str, str]:
             # One IP timing out is degraded, not a tool failure — skip it and
             # keep scanning the rest.
             logger.warning(f"[nmap:{session.id}] Timeout on {ip}")
+            timed_out += 1
             continue
+
+    # If we had IPs to scan and EVERY one timed out, the CVE scan produced
+    # nothing due to timeouts — surface that as a failure so the scan reports
+    # "partial" rather than an empty (falsely "clean") CVE result.
+    if attempted and timed_out == attempted:
+        raise ToolTimeout(
+            f"nmap timed out on all {attempted} target IP(s) — no CVE results"
+        )
 
     return results
 

--- a/apps/takeover_check/analyzer.py
+++ b/apps/takeover_check/analyzer.py
@@ -75,13 +75,20 @@ def analyze(session, records: list[dict]) -> list[Finding]:
         seen.add(subdomain_name)
 
         service = _service_of(record)
-        if service == "unknown":
-            logger.info(
-                "[takeover_check:%s] Skipping %s — subzy returned no fingerprint",
+        # Do NOT drop a vulnerable record just because we couldn't name the
+        # service: subzy flagged it vulnerable, and silently skipping it would
+        # make every real takeover vanish if subzy's field names ever drift.
+        # Emit the finding with an "unidentified service" label and a note to
+        # verify manually.
+        unfingerprinted = service == "unknown"
+        service_label = "an unidentified service" if unfingerprinted else service
+        if unfingerprinted:
+            logger.warning(
+                "[takeover_check:%s] %s flagged vulnerable but subzy returned no "
+                "service fingerprint — reporting anyway (verify manually)",
                 session.id,
                 subdomain_name,
             )
-            continue
 
         subdomain_fk = subdomain_index.get(subdomain_name)
 
@@ -90,17 +97,19 @@ def analyze(session, records: list[dict]) -> list[Finding]:
             source="takeover_check",
             check_type="subdomain_takeover",
             severity="high",
-            title=f"Subdomain takeover possible: {subdomain_name} ({service})",
+            title=f"Subdomain takeover possible: {subdomain_name} ({service_label})",
             description=(
-                f"{subdomain_name} appears to point at an unclaimed {service} "
+                f"{subdomain_name} appears to point at an unclaimed {service_label} "
                 f"resource. An attacker who registers that resource on the "
                 f"hosting service could serve arbitrary content under your "
                 f"subdomain — credential phishing, malware delivery, or SSO-cookie "
                 f"theft from same-eTLD context."
+                + (" subzy flagged this as vulnerable but did not identify the "
+                   "hosting service — verify manually." if unfingerprinted else "")
             ),
             remediation=(
                 "Either remove the dangling DNS record or reclaim the unused "
-                f"resource on {service}. Verify by manually visiting the subdomain — "
+                f"resource on {service_label}. Verify by manually visiting the subdomain — "
                 "a stale CNAME with an unclaimed third-party target is the "
                 "signature pattern."
             ),

--- a/tests/unit/test_alterx.py
+++ b/tests/unit/test_alterx.py
@@ -24,45 +24,45 @@ class TestCollect:
     def test_empty_input_returns_empty(self):
         assert collect([]) == []
 
-    @patch("apps.alterx.collector.shutil.which", return_value=None)
-    def test_binary_not_found_returns_empty(self, _which):
-        assert collect(["api.example.com"]) == []
-
-    @patch("apps.alterx.collector.shutil.which", return_value="/usr/bin/alterx")
     @patch("apps.alterx.collector.subprocess.run")
-    def test_nonzero_exit_returns_empty(self, mock_run, _which):
+    def test_binary_not_found_raises(self, mock_run):
+        # A missing binary must surface (ToolBinaryMissing -> scan marked partial),
+        # not silently return [] — a silent skip hid a missing tool from the operator.
+        from apps.core.workflows.exceptions import ToolBinaryMissing
+        mock_run.side_effect = FileNotFoundError()
+        with pytest.raises(ToolBinaryMissing):
+            collect(["api.example.com"])
+
+    @patch("apps.alterx.collector.subprocess.run")
+    def test_nonzero_exit_returns_empty(self, mock_run):
         mock_run.return_value = self._mock_run(returncode=1)
         assert collect(["api.example.com"]) == []
 
-    @patch("apps.alterx.collector.shutil.which", return_value="/usr/bin/alterx")
     @patch("apps.alterx.collector.subprocess.run")
-    def test_timeout_raises(self, mock_run, _which):
+    def test_timeout_raises(self, mock_run):
         from apps.core.workflows.exceptions import ToolTimeout
         mock_run.side_effect = subprocess.TimeoutExpired("alterx", 300)
         with pytest.raises(ToolTimeout):
             collect(["api.example.com"])
 
-    @patch("apps.alterx.collector.shutil.which", return_value="/usr/bin/alterx")
     @patch("apps.alterx.collector.subprocess.run")
-    def test_returns_permutations_from_stdout(self, mock_run, _which):
+    def test_returns_permutations_from_stdout(self, mock_run):
         mock_run.return_value = self._mock_run(
             "api-dev.example.com\napi2.example.com\napi-staging.example.com\n"
         )
         result = collect(["api.example.com"])
         assert result == ["api-dev.example.com", "api2.example.com", "api-staging.example.com"]
 
-    @patch("apps.alterx.collector.shutil.which", return_value="/usr/bin/alterx")
     @patch("apps.alterx.collector.subprocess.run")
-    def test_skips_blank_lines(self, mock_run, _which):
+    def test_skips_blank_lines(self, mock_run):
         mock_run.return_value = self._mock_run(
             "api-dev.example.com\n\n\napi2.example.com\n"
         )
         result = collect(["api.example.com"])
         assert len(result) == 2
 
-    @patch("apps.alterx.collector.shutil.which", return_value="/usr/bin/alterx")
     @patch("apps.alterx.collector.subprocess.run")
-    def test_pipes_subdomains_as_stdin(self, mock_run, _which):
+    def test_pipes_subdomains_as_stdin(self, mock_run):
         mock_run.return_value = self._mock_run("")
         collect(["api.example.com", "dev.example.com"])
         call_kwargs = mock_run.call_args[1]

--- a/tests/unit/test_amass.py
+++ b/tests/unit/test_amass.py
@@ -100,20 +100,22 @@ class TestAmassCollector:
             with pytest.raises(ToolBinaryMissing):
                 collect(sess)
 
-    def test_timeout_returns_partial_results_not_exception(self):
-        """Timeout is graceful — returns whatever amass found, no exception raised."""
+    def test_timeout_raises_tooltimeout(self):
+        """Hanging 30s past amass's own scan_timeout is an abnormal hang, not a
+        clean time-boxed finish — it must raise ToolTimeout so the scan is marked
+        'partial', not silently present a truncated surface as complete."""
+        from apps.core.workflows.exceptions import ToolTimeout
         sess = _session()
         _config()
         proc = MagicMock()
-        # First communicate() call raises TimeoutExpired; second (after kill) returns partial output
         proc.communicate.side_effect = [
             subprocess.TimeoutExpired("amass", 30),
-            ("api.example.com\n", ""),
+            ("api.example.com\n", ""),  # partial output after kill
         ]
         with patch("apps.amass.collector.subprocess.Popen", return_value=proc):
-            records = collect(sess)
+            with pytest.raises(ToolTimeout):
+                collect(sess)
         proc.kill.assert_called_once()
-        assert records[0]["host"] == "api.example.com"
 
     def test_tolerates_nonzero_returncode(self):
         sess = _session()

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -72,3 +72,11 @@ class TestCoverageNote:
         s = self._session(endpoints_probed=10, endpoints_blocked=3, waf_vendor="unidentified")
         ctx = _coverage_context(s)
         assert "vendor unidentified" in ctx["note"]
+
+    def test_silent_drop_wording_does_not_claim_block_responses(self):
+        # No vendor => nothing responded; the note must NOT claim endpoints
+        # "returned block or challenge responses" (they returned nothing).
+        s = self._session(endpoints_probed=10, endpoints_blocked=10, waf_vendor="")
+        ctx = _coverage_context(s)
+        assert "did not return an HTTP response" in ctx["note"]
+        assert "returned block or challenge responses" not in ctx["note"]

--- a/tests/unit/test_domain_security.py
+++ b/tests/unit/test_domain_security.py
@@ -355,6 +355,26 @@ class TestRDAPChecks:
         assert len(expiry_findings) == 1
         assert expiry_findings[0].severity == "critical"
 
+    def test_rdap_event_missing_eventaction_does_not_crash(self, db):
+        # Real registrar RDAP payloads sometimes include events without an
+        # eventAction key. An unguarded e["eventAction"] would KeyError and abort
+        # the ENTIRE RDAP check. Assert it survives and still reads the valid event.
+        from apps.domain_security.scanner import _check_rdap
+        import datetime
+        session = self._make_session(db)
+        expiry = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=3)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": ["client transfer prohibited"],
+            "events": [
+                {"eventDate": "2020-01-01T00:00:00Z"},          # no eventAction — must not crash
+                {"eventAction": "expiration", "eventDate": expiry.isoformat()},
+            ],
+        }
+        with patch("apps.domain_security.scanner.requests.get", return_value=mock_resp):
+            findings = _check_rdap(session, "example.com")  # must not raise
+        assert any("expires" in f.title.lower() for f in findings)
+
     def test_domain_expiry_within_30_days_is_high(self, db):
         from apps.domain_security.scanner import _check_rdap
         session = self._make_session(db)

--- a/tests/unit/test_nmap.py
+++ b/tests/unit/test_nmap.py
@@ -363,3 +363,50 @@ class TestNmapScanner:
         called_with = mock_collect.call_args[0][1]
         assert "1.2.3.4" in called_with
         assert called_with["1.2.3.4"] == [22]
+
+
+# ---------------------------------------------------------------------------
+# Collector failure modes (timeout / binary-missing) — added by test audit
+# ---------------------------------------------------------------------------
+
+import types as _types
+from unittest.mock import patch as _patch, MagicMock as _MagicMock
+import subprocess as _subprocess
+
+
+class TestNmapCollectorFailureModes:
+    def _sess(self):
+        return _types.SimpleNamespace(id=1)
+
+    def _ok(self, stdout="<nmaprun/>"):
+        m = _MagicMock()
+        m.returncode = 0
+        m.stdout = stdout
+        m.stderr = ""
+        return m
+
+    def test_all_ips_timeout_raises(self):
+        # Every target IP timing out means the CVE scan produced nothing due to
+        # timeouts — must raise so the scan reports 'partial', not falsely 'clean'.
+        from apps.nmap.collector import collect
+        from apps.core.workflows.exceptions import ToolTimeout
+        with _patch("apps.nmap.collector.subprocess.run",
+                    side_effect=_subprocess.TimeoutExpired("nmap", 360)):
+            with __import__("pytest").raises(ToolTimeout):
+                collect(self._sess(), {"1.2.3.4": [80], "5.6.7.8": [443]})
+
+    def test_partial_timeout_returns_survivors(self):
+        # One IP timing out is degraded, not failure — the reachable IP's result
+        # is still returned and no exception is raised.
+        from apps.nmap.collector import collect
+        with _patch("apps.nmap.collector.subprocess.run",
+                    side_effect=[_subprocess.TimeoutExpired("nmap", 360), self._ok("<nmaprun>ok</nmaprun>")]):
+            out = collect(self._sess(), {"1.1.1.1": [80], "2.2.2.2": [443]})
+        assert list(out.keys()) == ["2.2.2.2"]
+
+    def test_binary_missing_raises(self):
+        from apps.nmap.collector import collect
+        from apps.core.workflows.exceptions import ToolBinaryMissing
+        with _patch("apps.nmap.collector.subprocess.run", side_effect=FileNotFoundError()):
+            with __import__("pytest").raises(ToolBinaryMissing):
+                collect(self._sess(), {"1.2.3.4": [80]})

--- a/tests/unit/test_takeover_check.py
+++ b/tests/unit/test_takeover_check.py
@@ -137,12 +137,17 @@ class TestAnalyze:
         assert findings[0].subdomain is None
         assert findings[0].target == "blog.example.com"
 
-    def test_skips_record_with_unknown_service(self):
+    def test_vulnerable_record_without_fingerprint_still_reported(self):
+        # A vulnerable record with no recognizable service must NOT be silently
+        # dropped — subzy field drift would otherwise make every real takeover
+        # vanish. It is reported with an "unidentified service" label instead.
         sess = self._session()
-        # subzy returned no fingerprint — "unknown" service must not become a finding
         records = [{"subdomain": "blog.example.com", "vulnerable": True}]
         findings = analyze(sess, records)
-        assert findings == []
+        assert len(findings) == 1
+        assert findings[0].target == "blog.example.com"
+        assert findings[0].severity == "high"
+        assert "unidentified" in findings[0].title.lower()
 
     def test_dedupes_by_subdomain_name(self):
         sess = self._session()


### PR DESCRIPTION
First of several PRs from a full 7-agent test-suite audit (prompted by "how did 1200 tests miss a blocked scan reading as clean"). This one fixes the **real live bugs** the audit surfaced — not just weak tests.

## Fixes
| Bug | Before | After |
|---|---|---|
| amass timeout | swallowed → scan `completed` with truncated surface; a test asserted the swallow | raises `ToolTimeout` → scan `partial`; test inverted |
| takeover_check | silently dropped `vulnerable:True` records it couldn't fingerprint → subzy drift hides all takeovers; a test blessed it | reports them ("unidentified service"); test inverted |
| nmap | all-IP timeout → falsely-clean CVE result | all-IP timeout raises `ToolTimeout` (per-IP still skipped) |
| coverage note | claimed "returned block/challenge responses" for silent drops | distinguishes WAF block-page vs no-response/non-HTTP |
| domain_security | `KeyError` aborted whole RDAP check on event missing `eventAction` | guarded |
| alterx | silent `[]` on missing binary | raises `ToolBinaryMissing` (dead branch removed) |

## Tests
- Inverted the two bug-codifying tests (amass, takeover) to assert correct behavior.
- Added nmap failure-mode tests (all-timeout raises, partial-timeout returns survivors, binary-missing raises), coverage silent-drop wording test, domain_security missing-`eventAction` test, alterx missing-binary-raises.
- Full fast suite: 1199 passed.

Batches 2–4 (auth/security test blind spots, parser robustness + tautology removal, orchestration/coverage gaps) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)