### PR TITLE
feat: configurable support email for in-app report/feature links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **Configurable support channel for the in-app "Report an issue" / "Request a
+  feature" links** (`SUPPORT_EMAIL` env). When set, the footer buttons become
+  `mailto:` links to that address with the running build pre-filled in the body
+  (a branded deployment routes users to its own support inbox); when empty (OSS
+  default) they fall back to filing a GitHub issue. Surfaced via
+  `GET /api/version/` (`support_email`).
+
 ### Changed
 - **nuclei template severity scoping — the fix for its freeze/timeout/noise.**
   nuclei compiles its entire ~13,500-template set into RAM at startup regardless

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,7 +556,7 @@ POST /api/token/pair                      — JWT login → {access, refresh}
 POST /api/token/blacklist                 — blacklist refresh token (logout)
 POST /api/token/refresh                   — exchange refresh → new access token
 POST /api/token/verify                    — verify token validity
-GET  /api/version/                        — build provenance {version, git_sha, git_sha_short, build_date} (unauthenticated)
+GET  /api/version/                        — build provenance {version, git_sha, git_sha_short, build_date, support_email} (unauthenticated; no-store)
 GET  /api/version/latest/                 — update check {current_version, latest_version, update_available, release_url} (authenticated; cached 6h, fail-graceful)
 GET  /api/user/                           — current user info + must_change_password flag
 POST /api/user/change-password/           — change password; clears must_change_password flag

--- a/apps/core/api/ninja.py
+++ b/apps/core/api/ninja.py
@@ -92,6 +92,9 @@ def version(request, response: HttpResponse):
         "git_sha": sha,
         "git_sha_short": sha[:8],
         "build_date": settings.OPENEASD_BUILD_DATE,
+        # Empty on OSS default → SPA uses GitHub issue links; set on a branded
+        # deployment → SPA routes "Report an issue"/"Request a feature" to mailto.
+        "support_email": getattr(settings, "SUPPORT_EMAIL", ""),
     }
 
 

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenEASD</title>
-    <script type="module" crossorigin src="/static/assets/index-DCaXoYau.js"></script>
+    <script type="module" crossorigin src="/static/assets/index-DA0mVL8B.js"></script>
     <link rel="stylesheet" crossorigin href="/static/assets/index-CPH2I513.css">
   </head>
   <body>

--- a/frontend/src/components/BuildInfo.jsx
+++ b/frontend/src/components/BuildInfo.jsx
@@ -38,12 +38,22 @@ export default function BuildInfo({ className = '', checkUpdates = false }) {
   }
   const buildLine = parts.join(' · ');
 
-  // Pre-fill new-issue reports with the running build so we never have to ask
-  // "what version are you on?". GitHub Issues is the OSS-native report channel.
-  const ISSUES = 'https://github.com/cybersecify/OpenEASD/issues/new';
-  const env = encodeURIComponent(`\n\n---\nBuild (auto-filled): ${buildLine}`);
-  const bugUrl = `${ISSUES}?labels=bug&title=${encodeURIComponent('[Bug] ')}&body=${env}`;
-  const featureUrl = `${ISSUES}?labels=enhancement&title=${encodeURIComponent('[Feature] ')}&body=${env}`;
+  // Pre-fill reports with the running build so we never have to ask "what
+  // version are you on?". When a support email is configured (a branded
+  // deployment), route to mailto: that inbox; otherwise fall back to GitHub
+  // Issues (the OSS-native channel).
+  const body = `\n\n---\nBuild (auto-filled): ${buildLine}`;
+  let bugUrl, featureUrl;
+  if (data.support_email) {
+    const to = data.support_email;
+    bugUrl = `mailto:${to}?subject=${encodeURIComponent('[Bug] ')}&body=${encodeURIComponent(body)}`;
+    featureUrl = `mailto:${to}?subject=${encodeURIComponent('[Feature] ')}&body=${encodeURIComponent(body)}`;
+  } else {
+    const ISSUES = 'https://github.com/cybersecify/OpenEASD/issues/new';
+    const env = encodeURIComponent(body);
+    bugUrl = `${ISSUES}?labels=bug&title=${encodeURIComponent('[Bug] ')}&body=${env}`;
+    featureUrl = `${ISSUES}?labels=enhancement&title=${encodeURIComponent('[Feature] ')}&body=${env}`;
+  }
 
   return (
     <div className={`text-[11px] text-dim/70 text-center select-none space-y-0.5 ${className}`}>

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -391,6 +391,13 @@ OPENEASD_VERSION = config("OPENEASD_VERSION", default="dev")
 OPENEASD_GIT_SHA = config("OPENEASD_GIT_SHA", default="unknown")
 OPENEASD_BUILD_DATE = config("OPENEASD_BUILD_DATE", default="unknown")
 
+# Support/contact address for the in-app "Report an issue" / "Request a feature"
+# links. When set, those buttons become mailto: links to this address (a branded
+# deployment can route them to its own support inbox). When empty (the OSS
+# default), the buttons fall back to filing a GitHub issue with the build
+# auto-attached. Surfaced via GET /api/version/ so the SPA can render either.
+SUPPORT_EMAIL = config("SUPPORT_EMAIL", default="")
+
 # Logging
 LOGGING = {
     "version": 1,

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -880,6 +880,13 @@ class TestBuildProvenance:
         res = client.get("/health/")
         assert res.json()["git_sha"] == "01234567"
 
+    def test_version_support_email_empty_by_default(self, client):
+        assert client.get("/api/version/").json()["support_email"] == ""
+
+    def test_version_support_email_reflects_setting(self, client, settings):
+        settings.SUPPORT_EMAIL = "openeasd@cybersecify.com"
+        assert client.get("/api/version/").json()["support_email"] == "openeasd@cybersecify.com"
+
     def test_version_no_store_header(self, client):
         # Must not be CDN-cached, or the app reports a stale build after redeploy.
         res = client.get("/api/version/")


### PR DESCRIPTION
The in-app "Report an issue" / "Request a feature" footer links pointed at GitHub Issues (OSS-native). A branded/hosted deployment wants inbound reports to reach *its* team instead.

## What
- New `SUPPORT_EMAIL` env. When set, the two footer buttons become `mailto:<addr>` links with the running build pre-filled in the body; when empty (OSS default) they keep the GitHub-issue fallback.
- Exposed via `GET /api/version/` as `support_email` so the SPA renders either mode.

## Tests
- `test_api_endpoints.py`: `support_email` empty by default; reflects the setting when configured.
- Full fast suite: 1286 passed.

Deploy: set `SUPPORT_EMAIL=openeasd@cybersecify.com` on the droplet (the new Google Group) so the buttons route there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)