### PR TITLE
fix: nuclei hardening — bulk-size memory bound, nuclei_network wedge, template freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ on:
     paths-ignore:
       - "**.md"
       - "docs/**"
+  # Weekly rebuild so the baked nuclei-templates refresh on cadence — the image
+  # sets -disable-update-check (no runtime template fetch), so without this the
+  # templates freeze at build time and rot (miss new CVEs). schedule runs on the
+  # default branch, so the publish job pushes a fresh :latest. See
+  # docs/SCAN_OPERATIONAL_LEARNINGS.md.
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **nuclei hardening (follow-up to the severity scoping).** Three parallel agents
+  investigated nuclei's freeze/timeout/value; key finding: `-severity` does NOT
+  cut the ~500 MB startup template parse (nuclei parses all templates then
+  filters) — it only fixes the TIMEOUT. So the FREEZE is now bounded by
+  `GOMEMLIMIT` **+ `-bulk-size`** scaled per profile (low=5) — the real
+  peak-memory lever, previously left at the default 25. Also: `-type http` on the
+  web run (skips dns/tcp/ssl already covered by nuclei_network/tls_checker),
+  `-max-host-error` (abandon dead hosts), `-exclude-tags dos,fuzzing,intrusive`,
+  and stderr surfaced regardless of exit code. **Fixed:** `nuclei_network` used a
+  plain `subprocess.run` with no process-group kill — the exact worker-wedging
+  hang the web collector was rewritten to avoid; both now share `run_capped`
+  (`apps/core/workflows/proc.py`). Added a **weekly CI cron** so baked
+  nuclei-templates refresh on cadence. Learnings + the corrected freeze
+  attribution recorded in `docs/SCAN_OPERATIONAL_LEARNINGS.md`.
+
 ### Added
 - **Configurable support channel for the in-app "Report an issue" / "Request a
   feature" links** (`SUPPORT_EMAIL` env). When set, the footer buttons become

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,4 +657,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_coverage_regression.py` | 10 | Silent-block coverage counting (probed-vs-reached), coverage-regression finding (high block ratio / findings drop / stable = no flag), partial scan status when a tool fails |
 | `tests/test_api_endpoints.py` | 104 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1341 tests** (1289 fast + 52 slow domain_security)
+**Total: 1345 tests** (1293 fast + 52 slow domain_security)

--- a/apps/core/workflows/proc.py
+++ b/apps/core/workflows/proc.py
@@ -1,0 +1,75 @@
+"""Shared subprocess runner for tools that spawn escape-prone helper processes.
+
+nuclei (and nuclei_network — the same binary) spawn helpers (interactsh poller,
+resolvers, headless) that can escape the process group and inherit the stdout
+pipe. With subprocess.run/communicate() that means: even after we SIGKILL the
+group on timeout, the pipe never reaches EOF and communicate() blocks forever —
+the timeout fires but the call never returns, wedging the worker thread until the
+session watchdog reaps it.
+
+The fix (originally in apps/nuclei/collector.py, extracted here so nuclei_network
+gets it too): redirect stdout/stderr to temp FILES (no pipe) and wait() on the
+direct child. wait() returns the moment the child exits regardless of inherited
+FDs, so a SIGKILL always unblocks us. An escaped grandchild can leak but can no
+longer hang the scan.
+"""
+
+import os
+import signal
+import subprocess
+import tempfile
+
+_DRAIN_GRACE = 30  # seconds to let a SIGKILL'd process die before we give up
+
+
+def run_capped(cmd: list[str], timeout: int, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Run an external tool with a timeout that child processes cannot defeat.
+
+    Mirrors subprocess.run's contract: returns CompletedProcess, raises
+    FileNotFoundError if the binary is missing, re-raises TimeoutExpired after the
+    process group is killed. On timeout the raised TimeoutExpired carries whatever
+    the tool had already written to stdout in `.output` (so callers can recover
+    partial results instead of discarding them).
+    """
+    out_fd, out_path = tempfile.mkstemp(suffix=".tool.out")
+    err_fd, err_path = tempfile.mkstemp(suffix=".tool.err")
+    try:
+        with os.fdopen(out_fd, "wb") as out_f, os.fdopen(err_fd, "wb") as err_f:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=out_f,
+                stderr=err_f,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+                env=env,
+            )
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired as exc:
+                try:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    proc.kill()
+                try:
+                    proc.wait(timeout=_DRAIN_GRACE)
+                except subprocess.TimeoutExpired:
+                    pass
+                # Attach whatever was written before the wall so callers can save
+                # partial findings rather than report a misleading 0.
+                try:
+                    with open(out_path, "r", errors="replace") as f:
+                        exc.output = f.read()
+                except OSError:
+                    pass
+                raise
+        with open(out_path, "r", errors="replace") as f:
+            stdout = f.read()
+        with open(err_path, "r", errors="replace") as f:
+            stderr = f.read()
+        return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+    finally:
+        for p in (out_path, err_path):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -10,13 +10,13 @@ Nuclei scans for web vulnerabilities using community templates:
 import json
 import logging
 import os
-import signal
 import subprocess
 import tempfile
 
 from django.conf import settings
 
 from apps.core.workflows.exceptions import ToolBinaryMissing, ToolTimeout
+from apps.core.workflows.proc import run_capped
 
 logger = logging.getLogger(__name__)
 
@@ -41,63 +41,9 @@ CONCURRENCY = 25      # fallback -c; the resource profile overrides it
 # stays polite even on 'high' — a big box is no licence to hammer the target.
 
 
-_DRAIN_GRACE = 30  # seconds to let a SIGKILL'd process die before we give up
-
-
-def _run(cmd: list[str], timeout: int, env: dict | None = None) -> subprocess.CompletedProcess:
-    """Run an external tool with a timeout that cannot be defeated by child processes.
-
-    Why not subprocess.run / communicate(): communicate() reads stdout/stderr until
-    pipe EOF, which only happens once EVERY writer closes the pipe. nuclei spawns
-    helpers (interactsh poller, resolvers, headless) that can escape the process
-    group and inherit the stdout pipe, so even after we SIGKILL the group the pipe
-    never reaches EOF and communicate() blocks forever — the timeout fires but the
-    call never returns, wedging the worker thread until the session watchdog reaps it.
-
-    The fix: redirect stdout/stderr to temp FILES (no pipe), and wait() on the
-    process itself. wait() returns the moment the direct child exits — it does not
-    care about inherited file descriptors — so a SIGKILL always unblocks us. An
-    escaped grandchild can leak but can no longer hang the scan.
-
-    Mirrors subprocess.run's contract: returns CompletedProcess, raises
-    FileNotFoundError if the binary is missing, re-raises TimeoutExpired after the
-    group is killed.
-    """
-    out_fd, out_path = tempfile.mkstemp(suffix=".nuclei.out")
-    err_fd, err_path = tempfile.mkstemp(suffix=".nuclei.err")
-    try:
-        with os.fdopen(out_fd, "wb") as out_f, os.fdopen(err_fd, "wb") as err_f:
-            proc = subprocess.Popen(
-                cmd,
-                stdout=out_f,
-                stderr=err_f,
-                stdin=subprocess.DEVNULL,
-                start_new_session=True,
-                env=env,
-            )
-            try:
-                proc.wait(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                try:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                except (ProcessLookupError, PermissionError):
-                    proc.kill()
-                try:
-                    proc.wait(timeout=_DRAIN_GRACE)
-                except subprocess.TimeoutExpired:
-                    pass
-                raise
-        with open(out_path, "r", errors="replace") as f:
-            stdout = f.read()
-        with open(err_path, "r", errors="replace") as f:
-            stderr = f.read()
-        return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
-    finally:
-        for p in (out_path, err_path):
-            try:
-                os.unlink(p)
-            except OSError:
-                pass
+# The hardened, child-escape-proof runner lives in apps.core.workflows.proc
+# (run_capped) so nuclei_network — the same binary — gets the same anti-wedge
+# protection instead of a plain subprocess.run that can hang the worker.
 
 
 def collect(session) -> list[dict]:
@@ -139,11 +85,25 @@ def collect(session) -> list[dict]:
         "-retries", "1",
         "-rate-limit", str(getattr(settings, "NUCLEI_RATE_LIMIT", RATE_LIMIT)),
         "-c", str(getattr(settings, "NUCLEI_CONCURRENCY", CONCURRENCY)),
-        # Scope templates by severity: compiling all ~13.5k templates into RAM is
-        # what freezes a small box AND makes the run time out. Dropping `info`
-        # (~38% of templates, mostly recon noise already covered by httpx/web
-        # checks) cuts both. Resolved per resource profile; overridable via env.
+        # -bulk-size is the REAL peak-memory bound (runtime ≈ c × bulk × per-host
+        # buffer). nuclei parses ALL ~13.5k templates up front regardless (~500 MB
+        # fixed), so -severity does NOT shrink that startup parse — it cuts the
+        # EXECUTED set (fewer requests → no TIMEOUT). What keeps the box from
+        # FREEZING is GOMEMLIMIT + a small bulk-size, not -severity.
+        "-bulk-size", str(getattr(settings, "NUCLEI_BULK_SIZE", 15)),
+        # Scope executed templates by severity (drops ~38% info noise already
+        # covered by httpx tech-detect + web_checker). Fixes timeout, not freeze.
         "-severity", getattr(settings, "NUCLEI_SEVERITY", "critical,high,medium"),
+        # This run only probes web URLs, so only http templates apply. dns/tcp/ssl
+        # are covered by nuclei_network + tls_checker — skipping them here trims the
+        # executed set with zero coverage loss.
+        "-type", "http",
+        # Abandon a host after this many errors instead of retrying every template
+        # against a dead/filtered host (cuts wall-clock on blocked targets).
+        "-max-host-error", "10",
+        # Explicit safety: never run request-heavy fuzzing / DoS / intrusive
+        # templates (also excluded by nuclei's default .nuclei-ignore).
+        "-exclude-tags", "dos,fuzzing,intrusive",
         # Honest scanner identity so a target can allowlist us deliberately.
         # Note: templates that hard-set their own User-Agent are not overridden.
         "-H", f"User-Agent: {getattr(settings, 'OPENEASD_USER_AGENT', 'OpenEASD/1.0')}",
@@ -151,10 +111,9 @@ def collect(session) -> list[dict]:
     logger.info(f"[nuclei:{session.id}] Scanning {len(targets)} web targets")
 
     try:
-        # Cap nuclei's Go heap on low-memory hosts so its template load can't
-        # swap the box into a freeze (env is unchanged on balanced/high).
+        # Cap nuclei's Go heap on low-memory hosts (env unchanged on balanced/high).
         from apps.core.workflows.proc_env import go_memory_env
-        result = _run(cmd, TIMEOUT, env=go_memory_env())
+        result = run_capped(cmd, TIMEOUT, env=go_memory_env())
     except FileNotFoundError:
         logger.error(f"[nuclei:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"nuclei binary not found: {binary}")
@@ -164,7 +123,10 @@ def collect(session) -> list[dict]:
     finally:
         os.unlink(tmp)
 
-    if result.returncode != 0 and result.stderr:
+    # Surface stderr regardless of exit code: nuclei routinely exits 0 while
+    # logging "could not load N templates" / interactsh failures to stderr, which
+    # is silent under-coverage if only checked on nonzero rc.
+    if result.stderr and result.stderr.strip():
         logger.warning(f"[nuclei:{session.id}] stderr: {result.stderr[:500]}")
 
     records = []

--- a/apps/nuclei_network/collector.py
+++ b/apps/nuclei_network/collector.py
@@ -14,6 +14,7 @@ import tempfile
 from django.conf import settings
 from apps.core.assets.models import Port
 from apps.core.workflows.exceptions import ToolBinaryMissing, ToolTimeout
+from apps.core.workflows.proc import run_capped
 
 logger = logging.getLogger(__name__)
 
@@ -103,14 +104,17 @@ def collect(session) -> list[dict]:
         "-pt", "network,ssl",
         "-tags", ",".join(sorted(tags)),
         "-severity", "critical,high,medium,low",
+        # Same peak-memory bound as the web run (see apps/nuclei/collector.py).
+        "-bulk-size", str(getattr(settings, "NUCLEI_BULK_SIZE", 15)),
         "-jsonl", "-silent", "-no-color",
     ]
 
     try:
-        # Cap nuclei's Go heap on low-memory hosts (unchanged on balanced/high).
+        # run_capped (not subprocess.run) so an escaped interactsh/resolver helper
+        # can't hold the stdout pipe open and wedge the worker on timeout — the
+        # same anti-hang fix the web nuclei collector already had.
         from apps.core.workflows.proc_env import go_memory_env
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT,
-                                stdin=subprocess.DEVNULL, env=go_memory_env())
+        result = run_capped(cmd, TIMEOUT, env=go_memory_env())
     except FileNotFoundError:
         logger.error(f"[nuclei_network:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"nuclei binary not found: {binary}")
@@ -120,7 +124,9 @@ def collect(session) -> list[dict]:
     finally:
         os.unlink(tmp)
 
-    if result.returncode != 0 and result.stderr:
+    # Surface stderr regardless of exit code (nuclei exits 0 with template-load
+    # warnings) so silent under-coverage is visible.
+    if result.stderr and result.stderr.strip():
         logger.warning(f"[nuclei_network:{session.id}] stderr: {result.stderr[:500]}")
 
     records = []

--- a/docs/SCAN_OPERATIONAL_LEARNINGS.md
+++ b/docs/SCAN_OPERATIONAL_LEARNINGS.md
@@ -7,22 +7,34 @@ recur. Add to this list whenever a scan misbehaves.
 
 ## nuclei (the biggest source of pain)
 
-nuclei compiles its **entire template set (~13,500 templates) into RAM at
-startup**, before it touches a single target. This one fact causes three of the
-four symptoms:
+**Key correction (verified against ProjectDiscovery maintainers):** nuclei parses
+**all** ~13,500 templates into RAM up front (~500 MB, fixed) and *then* applies
+`-severity`/`-tags` filters. So severity scoping does **NOT** shrink the startup
+parse — it only cuts the *executed* set. The startup parse (~500 MB) on top of
+gunicorn + qcluster + Django is what tips a 1 GB box; runtime peak is
+`concurrency × bulk-size × per-host buffer`. The levers that actually prevent the
+**freeze** are `GOMEMLIMIT` + a small **`-bulk-size`**, not `-severity`.
 
 | Symptom | Root cause | Fix | Guard |
 |---|---|---|---|
-| **Freeze** (box + web UI unresponsive for minutes) | Template *loading* swaps a small (1 GB) host | `GOMEMLIMIT` soft heap cap on the Go process (low profile) **+** severity scoping to load fewer templates | `test_nuclei.py::test_go_memory_limit_applied_to_subprocess`; `test_proc_env.py` |
-| **Timeout** (2 h wall hit, run reported `partial`) | Template *execution*: targets × ~13.5k templates ÷ polite rate | Severity scoping (drop `info` ≈ 38%, `low` ≈ 4% on low profile) → far fewer requests | `test_nuclei.py::test_cmd_scopes_severity_and_drops_info` |
-| **Low value / noise** | `info` templates are mostly recon (tech-detect), already covered by httpx `-tech-detect` + web_checker; they bury real findings | Scope to `critical,high,medium(,low)` per profile; overridable via `NUCLEI_SEVERITY` | `test_settings_security.py::TestResourceProfile` |
-| **Empty output** | The target **dropped the scanner's probes** → httpx returned 0 live URLs → nuclei had nothing to scan | This is a coverage/blocking problem, not a nuclei problem — surfaced by the coverage-regression finding + `partial` status | `test_coverage_regression.py` |
+| **Freeze** (box + web UI unresponsive for minutes) | ~500 MB startup template parse + runtime `c × bulk-size × per-host buffer` on a 1 GB host | `GOMEMLIMIT` soft heap cap **+** small `-bulk-size` per profile (low=5) — NOT `-severity` | `test_nuclei.py::test_go_memory_limit_applied_to_subprocess`, `::test_cmd_includes_memory_and_scope_flags`; `test_settings_security.py::test_bulk_size_scales_down_on_low_profile` |
+| **Timeout** (2 h wall hit, run reported `partial`) | Template *execution*: targets × executed templates ÷ polite rate | Severity scoping (drop `info` ≈ 38%) + `-type http` (web run skips dns/tcp/ssl) + `-max-host-error` (abandon dead hosts) → far fewer requests | `test_nuclei.py::test_cmd_scopes_severity_and_drops_info`, `::test_cmd_includes_memory_and_scope_flags` |
+| **Low value / noise** | `info` tech-detect templates are already covered by httpx `-tech-detect` + web_checker; they bury real findings | Scope to `critical,high,medium(,low)` per profile (`NUCLEI_SEVERITY`). NOTE: this also drops the unique `exposures` bucket (.git/.env/backups/tokens) — a value gap; re-including it needs a memory-safe second pass (`-include-tags` does NOT override `-severity` on v3.2.9, verified) — deferred | `test_settings_security.py::TestResourceProfile` |
+| **Wedge / lost findings** | `nuclei_network` used plain `subprocess.run` (no process-group kill) → an escaped interactsh helper could hold the pipe and hang the worker | Both nuclei collectors now use the shared `run_capped` (temp-file redirect + `killpg`) | `test_nuclei.py::TestRunProcessGroupKill` |
+| **Empty output** | The target **dropped the scanner's probes** → httpx returned 0 live URLs → nuclei had nothing to scan | Coverage/blocking problem, not nuclei — surfaced by the coverage-regression finding + `partial` status | `test_coverage_regression.py` |
 
-**Template freshness caveat:** templates are baked into the image and
+**Template freshness:** templates are baked into the image and
 `-disable-update-check` is set (a mid-scan template download once wedged a scan
 for hours). Consequence: templates are frozen at image-build time and **rot** —
-an old image misses new CVEs. Rebuild the image on a cadence to refresh them;
-do **not** re-enable runtime template updates.
+an old image misses new CVEs. A **weekly CI cron** now rebuilds `:latest` so
+templates refresh on cadence (`.github/workflows/ci.yml`). Do **not** re-enable
+runtime template updates.
+
+**Deferred nuclei follow-ups:** (a) recover partial findings written before a
+wall-timeout (`run_capped` now carries them on the exception's `.output`; the
+scanner does not yet save them); (b) re-include the `exposures` template bucket
+via a memory-safe mechanism; (c) store `info.tags` / `classification.cwe-id` for
+richer report categorisation.
 
 **What nuclei needs to work properly:** (1) reachable targets (not blocked —
 run a Passive Scan or get the scanner IP allowlisted if coverage collapses),

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -355,13 +355,21 @@ LOW_MEMORY = PROFILE == "low"  # runner serialises + amass skips brute when true
 # recon noise for a prioritised attack-surface report and are already covered by
 # httpx tech-detect + web_checker, so dropping them raises signal, not lowers it.
 # low profile is tightest (critical/high/medium); bigger boxes also run `low`.
+#
+# nuclei_bs (-bulk-size) is the REAL peak-memory lever. nuclei parses all ~13.5k
+# templates up front regardless (~500 MB fixed — so -severity does NOT shrink the
+# startup parse; it only cuts the executed set → fewer requests → no TIMEOUT).
+# Runtime peak ≈ c × bulk_size × per-host response buffer, so on a 1 GB box the
+# bound that actually prevents the FREEZE is GOMEMLIMIT + a small bulk_size.
+# Default bulk_size is 25; we scale it down hard on the low profile.
 _PROFILE_TUNING = {
-    "low":      {"nuclei_c": 10, "nuclei_rate": 40,  "nuclei_sev": "critical,high,medium"},
-    "balanced": {"nuclei_c": 25, "nuclei_rate": 100, "nuclei_sev": "critical,high,medium,low"},
-    "high":     {"nuclei_c": 40, "nuclei_rate": 150, "nuclei_sev": "critical,high,medium,low"},
+    "low":      {"nuclei_c": 10, "nuclei_rate": 40,  "nuclei_sev": "critical,high,medium",     "nuclei_bs": 5},
+    "balanced": {"nuclei_c": 25, "nuclei_rate": 100, "nuclei_sev": "critical,high,medium,low", "nuclei_bs": 15},
+    "high":     {"nuclei_c": 40, "nuclei_rate": 150, "nuclei_sev": "critical,high,medium,low", "nuclei_bs": 25},
 }
 NUCLEI_CONCURRENCY = _PROFILE_TUNING[PROFILE]["nuclei_c"]
 NUCLEI_RATE_LIMIT = _PROFILE_TUNING[PROFILE]["nuclei_rate"]
+NUCLEI_BULK_SIZE = _PROFILE_TUNING[PROFILE]["nuclei_bs"]
 # Overridable: set NUCLEI_SEVERITY=critical,high,medium,low,info to widen coverage
 # (at the cost of memory/speed) on a box that can afford it.
 NUCLEI_SEVERITY = config("NUCLEI_SEVERITY", default=_PROFILE_TUNING[PROFILE]["nuclei_sev"])

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -237,7 +237,7 @@ class TestNucleiCollector:
         mock_result.returncode = 0
         mock_result.stderr = ""
 
-        with patch("apps.nuclei.collector._run", return_value=mock_result) as mock_run:
+        with patch("apps.nuclei.collector.run_capped", return_value=mock_result) as mock_run:
             records = collect(sess)
 
         assert mock_run.called
@@ -247,7 +247,7 @@ class TestNucleiCollector:
         from apps.core.scans.models import ScanSession
         sess = ScanSession.objects.create(domain="empty.com", scan_type="full")
 
-        with patch("apps.nuclei.collector._run") as mock_run:
+        with patch("apps.nuclei.collector.run_capped") as mock_run:
             records = collect(sess)
 
         assert records == []
@@ -259,7 +259,7 @@ class TestNucleiCollector:
         mock_result.stdout = ""
         mock_result.returncode = 0
         mock_result.stderr = ""
-        with patch("apps.nuclei.collector._run", return_value=mock_result) as mock_run:
+        with patch("apps.nuclei.collector.run_capped", return_value=mock_result) as mock_run:
             collect(sess)
         cmd = mock_run.call_args[0][0]
         assert "-H" in cmd
@@ -275,7 +275,7 @@ class TestNucleiCollector:
         mock_result.stdout = ""
         mock_result.returncode = 0
         mock_result.stderr = ""
-        with patch("apps.nuclei.collector._run", return_value=mock_result) as mock_run:
+        with patch("apps.nuclei.collector.run_capped", return_value=mock_result) as mock_run:
             collect(sess)
         cmd = mock_run.call_args[0][0]
         assert cmd[cmd.index("-c") + 1] == "10"
@@ -286,7 +286,7 @@ class TestNucleiCollector:
         otherwise the runner marks the step 'completed' and the failure hides."""
         from apps.core.workflows.exceptions import ToolBinaryMissing
         sess = self._make_session()
-        with patch("apps.nuclei.collector._run", side_effect=FileNotFoundError):
+        with patch("apps.nuclei.collector.run_capped", side_effect=FileNotFoundError):
             with pytest.raises(ToolBinaryMissing):
                 collect(sess)
 
@@ -296,7 +296,7 @@ class TestNucleiCollector:
         import subprocess as sp
         from apps.core.workflows.exceptions import ToolTimeout
         sess = self._make_session()
-        with patch("apps.nuclei.collector._run",
+        with patch("apps.nuclei.collector.run_capped",
                    side_effect=sp.TimeoutExpired(cmd="nuclei", timeout=1800)):
             with pytest.raises(ToolTimeout):
                 collect(sess)
@@ -308,7 +308,7 @@ class TestNucleiCollector:
         mock_result.returncode = 0
         mock_result.stderr = ""
 
-        with patch("apps.nuclei.collector._run", return_value=mock_result):
+        with patch("apps.nuclei.collector.run_capped", return_value=mock_result):
             records = collect(sess)
         assert len(records) == 1
 
@@ -322,7 +322,7 @@ class TestNucleiCollector:
             captured["timeout"] = timeout
             return MagicMock(stdout="", returncode=0, stderr="")
 
-        with patch("apps.nuclei.collector._run", side_effect=fake_run):
+        with patch("apps.nuclei.collector.run_capped", side_effect=fake_run):
             collect(sess)
 
         cmd = captured["cmd"]
@@ -344,7 +344,7 @@ class TestNucleiCollector:
             captured["cmd"] = cmd
             return MagicMock(stdout="", returncode=0, stderr="")
 
-        with patch("apps.nuclei.collector._run", side_effect=fake_run):
+        with patch("apps.nuclei.collector.run_capped", side_effect=fake_run):
             collect(sess)
 
         cmd = captured["cmd"]
@@ -352,6 +352,24 @@ class TestNucleiCollector:
         sev = cmd[cmd.index("-severity") + 1]
         assert "info" not in sev.split(",")
         assert "critical" in sev and "high" in sev
+
+    def test_cmd_includes_memory_and_scope_flags(self, settings):
+        # bulk-size (real peak-memory bound), http-only type, and host-error cap.
+        settings.NUCLEI_BULK_SIZE = 5
+        sess = self._make_session()
+        captured = {}
+
+        def fake_run(cmd, timeout, env=None):
+            captured["cmd"] = cmd
+            return MagicMock(stdout="", returncode=0, stderr="")
+
+        with patch("apps.nuclei.collector.run_capped", side_effect=fake_run):
+            collect(sess)
+        cmd = captured["cmd"]
+        assert cmd[cmd.index("-bulk-size") + 1] == "5"
+        assert cmd[cmd.index("-type") + 1] == "http"
+        assert "-max-host-error" in cmd
+        assert "dos,fuzzing,intrusive" in cmd[cmd.index("-exclude-tags") + 1]
 
     def test_severity_is_settings_driven(self, settings):
         settings.NUCLEI_SEVERITY = "critical,high"
@@ -362,7 +380,7 @@ class TestNucleiCollector:
             captured["cmd"] = cmd
             return MagicMock(stdout="", returncode=0, stderr="")
 
-        with patch("apps.nuclei.collector._run", side_effect=fake_run):
+        with patch("apps.nuclei.collector.run_capped", side_effect=fake_run):
             collect(sess)
         cmd = captured["cmd"]
         assert cmd[cmd.index("-severity") + 1] == "critical,high"
@@ -377,7 +395,7 @@ class TestNucleiCollector:
             captured["env"] = env
             return MagicMock(stdout="", returncode=0, stderr="")
 
-        with patch("apps.nuclei.collector._run", side_effect=fake_run):
+        with patch("apps.nuclei.collector.run_capped", side_effect=fake_run):
             collect(sess)
         assert captured["env"] is not None
         assert captured["env"].get("GOMEMLIMIT") == "600MiB"
@@ -396,7 +414,7 @@ class TestNucleiCollector:
             captured["cmd"] = cmd
             return MagicMock(stdout="", returncode=0, stderr="")
 
-        with patch("apps.nuclei.collector._run", side_effect=fake_run):
+        with patch("apps.nuclei.collector.run_capped", side_effect=fake_run):
             collect(sess)
 
         assert "-disable-update-check" in captured["cmd"]
@@ -413,7 +431,7 @@ class TestRunProcessGroupKill:
         use wait() (not communicate()) so an escaped child holding the stdout pipe
         can't block us — the bug that wedged the scan past the timeout."""
         import subprocess as sp
-        from apps.nuclei import collector
+        from apps.core.workflows import proc
 
         fake_proc = MagicMock()
         fake_proc.pid = 4242
@@ -424,11 +442,11 @@ class TestRunProcessGroupKill:
             0,
         ]
 
-        with patch("apps.nuclei.collector.subprocess.Popen", return_value=fake_proc), \
-             patch("apps.nuclei.collector.os.getpgid", return_value=4242), \
-             patch("apps.nuclei.collector.os.killpg") as mock_killpg:
+        with patch("apps.core.workflows.proc.subprocess.Popen", return_value=fake_proc), \
+             patch("apps.core.workflows.proc.os.getpgid", return_value=4242), \
+             patch("apps.core.workflows.proc.os.killpg") as mock_killpg:
             with pytest.raises(sp.TimeoutExpired):
-                collector._run(["nuclei"], timeout=1)
+                proc.run_capped(["nuclei"], timeout=1)
 
         mock_killpg.assert_called_once()
         # the post-kill drain wait() must run so the dead process is reaped
@@ -437,15 +455,15 @@ class TestRunProcessGroupKill:
         assert not fake_proc.communicate.called
 
     def test_returns_completed_process_on_success(self):
-        from apps.nuclei import collector
+        from apps.core.workflows import proc
 
         fake_proc = MagicMock()
         fake_proc.pid = 99
         fake_proc.returncode = 0
         fake_proc.wait.return_value = 0
 
-        with patch("apps.nuclei.collector.subprocess.Popen", return_value=fake_proc):
-            result = collector._run(["nuclei"], timeout=10)
+        with patch("apps.core.workflows.proc.subprocess.Popen", return_value=fake_proc):
+            result = proc.run_capped(["nuclei"], timeout=10)
 
         assert result.returncode == 0
         # stdout/stderr come from the temp output files (empty under a mocked Popen)
@@ -453,8 +471,8 @@ class TestRunProcessGroupKill:
         assert not fake_proc.communicate.called
 
     def test_real_run_captures_output(self):
-        from apps.nuclei import collector
-        result = collector._run(["printf", "hello\nworld\n"], timeout=10)
+        from apps.core.workflows import proc
+        result = proc.run_capped(["printf", "hello\nworld\n"], timeout=10)
         assert result.returncode == 0
         assert "hello" in result.stdout and "world" in result.stdout
 
@@ -466,7 +484,7 @@ class TestRunProcessGroupKill:
         import sys
         import time
         import subprocess as sp
-        from apps.nuclei import collector
+        from apps.core.workflows import proc
 
         script = (
             "import os, sys, time\n"
@@ -478,10 +496,10 @@ class TestRunProcessGroupKill:
         )
         start = time.monotonic()
         with pytest.raises(sp.TimeoutExpired):
-            collector._run([sys.executable, "-c", script], timeout=1)
+            proc.run_capped([sys.executable, "-c", script], timeout=1)
         elapsed = time.monotonic() - start
-        # If _run still used communicate(), this would block ~45s. It must not.
-        assert elapsed < collector._DRAIN_GRACE, f"hung for {elapsed:.1f}s"
+        # If run_capped still used communicate(), this would block ~45s. It must not.
+        assert elapsed < proc._DRAIN_GRACE, f"hung for {elapsed:.1f}s"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_nuclei_network.py
+++ b/tests/unit/test_nuclei_network.py
@@ -191,7 +191,7 @@ def mock_session():
     return s
 
 
-@patch("apps.nuclei_network.collector.subprocess.run")
+@patch("apps.nuclei_network.collector.run_capped")
 @patch("apps.nuclei_network.collector.Port")
 def test_collect_builds_correct_command(MockPort, mock_run, mock_session):
     port = MagicMock()
@@ -219,7 +219,7 @@ def test_collect_builds_correct_command(MockPort, mock_run, mock_session):
     assert "info" not in sev_val
 
 
-@patch("apps.nuclei_network.collector.subprocess.run")
+@patch("apps.nuclei_network.collector.run_capped")
 @patch("apps.nuclei_network.collector.Port")
 def test_collect_no_ports_returns_empty(MockPort, mock_run, mock_session):
     MockPort.objects.filter.return_value = []
@@ -228,7 +228,7 @@ def test_collect_no_ports_returns_empty(MockPort, mock_run, mock_session):
     mock_run.assert_not_called()
 
 
-@patch("apps.nuclei_network.collector.subprocess.run")
+@patch("apps.nuclei_network.collector.run_capped")
 @patch("apps.nuclei_network.collector.Port")
 def test_collect_binary_missing_raises(MockPort, mock_run, mock_session):
     """A missing nuclei binary must surface as ToolBinaryMissing, not a silent []
@@ -241,7 +241,7 @@ def test_collect_binary_missing_raises(MockPort, mock_run, mock_session):
         collect(mock_session)
 
 
-@patch("apps.nuclei_network.collector.subprocess.run")
+@patch("apps.nuclei_network.collector.run_capped")
 @patch("apps.nuclei_network.collector.Port")
 def test_collect_timeout_raises(MockPort, mock_run, mock_session):
     """A wall-clock timeout must surface as ToolTimeout so the scan reports
@@ -255,7 +255,7 @@ def test_collect_timeout_raises(MockPort, mock_run, mock_session):
         collect(mock_session)
 
 
-@patch("apps.nuclei_network.collector.subprocess.run")
+@patch("apps.nuclei_network.collector.run_capped")
 @patch("apps.nuclei_network.collector.Port")
 def test_collect_skips_non_json_lines(MockPort, mock_run, mock_session):
     """Log noise / partial lines in stdout must be skipped, not crash the parse."""

--- a/tests/unit/test_settings_security.py
+++ b/tests/unit/test_settings_security.py
@@ -29,6 +29,12 @@ class TestResourceProfile:
         assert "low" not in _PROFILE_TUNING["low"]["nuclei_sev"].split(",")
         assert "low" in _PROFILE_TUNING["balanced"]["nuclei_sev"].split(",")
 
+    def test_bulk_size_scales_down_on_low_profile(self):
+        # -bulk-size is the real peak-memory lever: smallest on the 1 GB box.
+        assert _PROFILE_TUNING["low"]["nuclei_bs"] < _PROFILE_TUNING["balanced"]["nuclei_bs"]
+        assert _PROFILE_TUNING["balanced"]["nuclei_bs"] <= _PROFILE_TUNING["high"]["nuclei_bs"]
+        assert _PROFILE_TUNING["low"]["nuclei_bs"] <= 5
+
     def test_high_rate_stays_polite(self):
         # Per-target request rate must scale politely, NOT with local specs —
         # cranking it just trips WAFs. Keep 'high' within a sane ceiling.


### PR DESCRIPTION
Follow-up to the nuclei severity scoping (#267), driven by a 3-agent investigation into nuclei's freeze/timeout/value/output.

## Key correction to the earlier fix
`-severity` does **NOT** cut nuclei's ~500 MB startup template parse — nuclei parses *all* ~13.5k templates then filters (verified vs ProjectDiscovery maintainers). So severity scoping only fixes the **timeout**. The **freeze** is bounded by `GOMEMLIMIT` **+ `-bulk-size`** (runtime peak ≈ `c × bulk-size × per-host buffer`), which was left at the default 25.

## Changes
- **`-bulk-size` per profile** (low=5, balanced=15, high=25) — the real peak-memory lever, on both collectors.
- **`-type http`** on the web run (dns/tcp/ssl already covered by nuclei_network + tls_checker) → trims executed templates (7256→6301 verified).
- **`-max-host-error 10`** (abandon dead/blocked hosts), **`-exclude-tags dos,fuzzing,intrusive`**, **stderr surfaced regardless of exit code** (nuclei exits 0 with "could not load N templates").
- **Fixed real bug:** `nuclei_network` used a plain `subprocess.run` with no process-group kill — the exact worker-wedging hang the web collector was rewritten to avoid. Extracted the hardened runner to `apps/core/workflows/proc.py` (`run_capped`); both collectors now use it.
- **Weekly CI cron** so the baked nuclei-templates refresh on cadence (they're frozen at build time with `-disable-update-check`).
- Corrected the freeze attribution in `docs/SCAN_OPERATIONAL_LEARNINGS.md`.

## Deferred (documented in the learnings doc)
Partial-findings recovery on wall-timeout (`run_capped` now carries partial stdout on the exception, scanner doesn't save it yet), exposures-bucket value recovery (the `-include-tags` override doesn't work on v3.2.9 — verified), `info.tags`/`cwe-id` storage.

## Tests
- New flag assertions + bulk-size profile invariant; the `run_capped` process-group-kill tests moved to cover the shared module; nuclei_network patches updated.
- Full fast suite: 1293 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)