### PR TITLE
docs: CONTRIBUTING.md + CODEOWNERS (peer-reviewed PR workflow)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,42 +1,22 @@
-# CODEOWNERS — auto-requests review from the right maintainer per path.
-# Order matters: later rules override earlier ones.
-# Reference: https://docs.github.com/articles/about-code-owners
+# Code owners — GitHub auto-requests a review from the owner(s) of the files a
+# PR touches. This ROUTES review (advisory); it does not by itself block merge
+# unless "Require review from Code Owners" is enabled in branch protection.
+# It splits load along the team's areas instead of funneling everything to one
+# person. Branch protection separately requires 1 approval + passing CI.
 
-# Default reviewer for anything not matched below.
-*                                @rathnakaragn
+# Default: either co-founder can own anything.
+*                       @rathnakaragn @ashok-kamat
 
-# ---------------------------------------------------------------------------
-# Code surfaces (technical — Rathnakar)
-# ---------------------------------------------------------------------------
-/apps/                           @rathnakaragn
-/openeasd/                       @rathnakaragn
-/tests/                          @rathnakaragn
-/frontend/src/                   @rathnakaragn
+# Scanner tools, backend, workflow engine, settings, infra, CI — technical lane.
+/apps/                  @rathnakaragn
+/openeasd/              @rathnakaragn
+/tests/                 @rathnakaragn
+/.github/               @rathnakaragn
+/Dockerfile             @rathnakaragn
+/docker-entrypoint.sh   @rathnakaragn
+/k8s/                   @rathnakaragn
 
-# CI and tool configuration
-/.github/workflows/              @rathnakaragn
-/Dockerfile                      @rathnakaragn
-/docker-entrypoint.sh            @rathnakaragn
-/pyproject.toml                  @rathnakaragn
-/uv.lock                         @rathnakaragn
-/frontend/package.json           @rathnakaragn
-/frontend/package-lock.json      @rathnakaragn
-
-# ---------------------------------------------------------------------------
-# Strategy + community surfaces (shared — Rathnakar + Ashok)
-# ---------------------------------------------------------------------------
-/.github/ISSUE_TEMPLATE/         @rathnakaragn @ashok-kamat
-/.github/PULL_REQUEST_TEMPLATE.md @rathnakaragn @ashok-kamat
-/.github/CODEOWNERS              @rathnakaragn @ashok-kamat
-/.github/FUNDING.yml             @rathnakaragn @ashok-kamat
-/.github/dependabot.yml          @rathnakaragn
-/docs/                           @rathnakaragn @ashok-kamat
-/README.md                       @rathnakaragn @ashok-kamat
-/CHANGELOG.md                    @rathnakaragn @ashok-kamat
-/CONTRIBUTING.md                 @rathnakaragn @ashok-kamat
-/CLAUDE.md                       @rathnakaragn @ashok-kamat
-/PRD.md                          @rathnakaragn @ashok-kamat
-/LICENSE                         @rathnakaragn @ashok-kamat
-
-# Security (technical-leaning — Rathnakar primary, Ashok co-reviewer)
-/SECURITY.md                     @rathnakaragn @ashok-kamat
+# Docs, changelog, community/growth copy — Ashok's lane.
+/docs/                  @ashok-kamat
+/CHANGELOG.md           @ashok-kamat
+/README.md              @ashok-kamat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
       - "**.md"
       - "docs/**"
   pull_request:
+    # No paths-ignore here: CI is a REQUIRED status check, and a PR that only
+    # touches ignored paths would never run it → the required check never reports
+    # → the PR is unmergeable. Run CI on every PR; the `push` paths-ignore above
+    # still avoids republishing the image on docs-only merges to main.
     branches: ["main"]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   # Weekly rebuild so the baked nuclei-templates refresh on cadence — the image
   # sets -disable-update-check (no runtime template fetch), so without this the
   # templates freeze at build time and rot (miss new CVEs). schedule runs on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,306 +1,61 @@
 # Contributing to OpenEASD
 
-Thanks for thinking about contributing. OpenEASD is built by a small team
-and we genuinely want help. This doc covers how to get in.
+Thanks for contributing. **One rule for everyone — internal team and external
+contributors alike: all changes land on `main` through a reviewed pull request.
+Nobody pushes to `main` directly.** Branch protection enforces this.
 
-## Quickest contribution path: add a new tool
+## The flow at a glance
 
-This is the easiest way to make a meaningful PR. The workflow runner is
-plugin-based — tools self-register via their Django `AppConfig.tool_meta`
-and the registry auto-discovers them. **No core files change** when you
-add one.
+1. Branch (or fork) → 2. commit → 3. open a PR → 4. CI must pass → 5. one
+approval from someone other than the author → 6. squash-merge → 7. delete the
+branch.
 
-```python
-# apps/my_tool/apps.py
-from django.apps import AppConfig
+## Internal team (you have write access)
 
-class MyToolConfig(AppConfig):
-    name = "apps.my_tool"
-    label = "my_tool"
-    verbose_name = "My Tool"
-    tool_meta = {
-        "label": "My Tool",
-        "runner": "apps.my_tool.scanner.run_my_tool",
-        "phase": 7,
-        "phase_group": "Network Exposure",
-        "requires": ["naabu"],          # tools that must run before yours
-        "produces_findings": True,      # False = produces assets, not findings
-    }
-```
+- Create a branch **in this repo**:
+  - `feat/<short-name>` — new user-facing feature
+  - `fix/<short-name>` — bug fix, deps, config, refactor, docs, cleanup
+- Commit with a conventional prefix (`feat:`, `fix:`, `docs:`, `ci:`, `chore:`,
+  `test:` — use the most specific one that fits).
+- Open a PR against `main`. CI runs automatically.
+- Get **one approval from another team member** (you cannot approve your own PR).
+  `CODEOWNERS` auto-requests the right reviewer for the area you touched.
+- **Squash-merge** and delete the branch.
+- Do **not** self-merge without a review, and treat admin-override as an
+  emergency-only escape hatch — the second set of eyes is the point.
 
-Then drop in `models.py` (empty), `collector.py` (run the binary / make
-the probe), `analyzer.py` (parse results → build Finding or asset rows),
-and `scanner.py` (thin orchestrator: `collect → analyze → save`). Add
-`"apps.my_tool"` to `INSTALLED_APPS` in `openeasd/settings.py`. That's
-it — the tool shows up in the workflow editor and runs in pipeline order.
+## External contributors (no write access)
 
-Look at `apps/web_checker/` or `apps/ssh_checker/` for working examples
-of the five-file pattern (`apps.py`, `models.py`, `collector.py`,
-`analyzer.py`, `scanner.py` — plus the standard `__init__.py` Python
-package marker). `apps/subfinder/` is a good asset-producing example
-(`produces_findings: False`).
+- **Fork** the repo, branch in your fork, and open a PR from your fork against
+  `main`. (You cannot push branches to this repo — that's the security boundary.)
+- A maintainer will review. External PRs get extra scrutiny; CI runs without
+  access to repository secrets (by design), so it validates safely.
+- A maintainer merges once CI is green and the review is done.
+- For anything non-trivial, open an issue first so we can agree on the approach
+  before you invest the work.
 
-### Phase numbers
+## What every PR must satisfy (branch-protection rules on `main`)
 
-Phases are sequential integers 1–11 matching the pipeline order in `CLAUDE.md`. Pick the phase that correctly places your tool relative to its dependencies. Tools with the same phase number run in parallel. Do **not** use fractional phases (e.g. `3.5`) — use the next integer and renumber if needed.
+- Opened as a PR (no direct pushes to `main`).
+- **CI status checks pass** — Test & Security Scan, Frontend Build, Docker Build,
+  and the CodeQL Analyze jobs.
+- **At least 1 approving review** from a non-author. Stale approvals are
+  dismissed when new commits are pushed.
+- Branch is up to date with `main` before merging.
 
-The `requires` list is advisory — it documents which earlier-phase tools
-your tool depends on (e.g. `["subfinder"]` if you read `Subdomain`
-rows). Use the tool's `label` value from its `AppConfig`, not the app
-path.
-
-### Writing good findings
-
-Every finding your tool emits should be actionable by a security
-engineer who has never seen your tool before. Three things matter:
-
-**Severity calibration**
-
-| Severity | When to use |
-|---|---|
-| `critical` | Immediate exploitation possible with no preconditions (unauthenticated RCE, full data exposure) |
-| `high` | High-impact, straightforward to exploit (subdomain takeover, valid CVE with public PoC, expired TLS) |
-| `medium` | Meaningful risk but requires additional conditions (weak cipher suites, missing HSTS, DMARC not enforced) |
-| `low` | Defence-in-depth issue, low direct exploitability (informational header leak, SPF ~all vs -all) |
-| `info` | Observation only, no exploitability (banner version, open port with no known CVEs) |
-
-When in doubt, go one severity lower rather than one higher — alert
-fatigue from over-reported highs is worse than under-reporting a medium.
-
-**Description**
-
-Explain *why this is a problem* for this specific target. Avoid generic
-CVE copy-paste. One or two sentences is enough:
-
-```
-# Good
-"blog.example.com resolves to an unclaimed Heroku dyno. An attacker who
-registers that dyno name can serve arbitrary content under your subdomain,
-including credential phishing pages that inherit its TLS certificate."
-
-# Too generic
-"Subdomain takeover vulnerabilities allow attackers to take control of subdomains."
-```
-
-**Remediation**
-
-Tell the operator exactly what to do, not just that something is wrong:
-
-```
-# Good
-"Remove the CNAME record for blog.example.com or reclaim the Heroku dyno
-at old-app.herokuapp.com. Verify by running: dig CNAME blog.example.com"
-
-# Too vague
-"Fix the subdomain configuration."
-```
-
-Store tool-specific data (CVE IDs, cipher names, service fingerprints,
-raw tool output) in the `extra` JSONField — not in the description text.
-This keeps the description human-readable and makes the raw data
-queryable.
-
-**Common field mistakes to avoid**
-
-- `extra=` not `extras=` — the JSONField is named `extra` (no `s`)
-- `port=` takes a `Port` FK instance, not an integer — use `port_number=` for the integer
-- `url=` takes a `URL` FK instance from `apps.web_assets`
-
-### Required tests for new tool PRs
-
-Every tool app needs a `tests/unit/test_<tool>.py`. PRs without tests
-will be asked to add them before merge. Cover at minimum:
-
-**Collector**
-- Empty input returns `[]`
-- Binary not found (`shutil.which` returns `None`) returns `[]`
-- Non-zero exit code returns `[]`
-- Timeout returns `[]`
-- Happy path: valid output returns parsed records
-
-**Analyzer**
-- Empty records returns `[]`
-- Record that should not produce a finding (e.g. `vulnerable=False`) is skipped
-- Happy path: correct finding fields (`source`, `check_type`, `severity`, `title`, `extra`)
-- Deduplication works if your tool can emit duplicate records
-
-**Scanner**
-- No assets to scan returns `[]` without calling the binary
-- Happy path: findings are persisted to DB and returned
-
-Use `@pytest.mark.django_db` for tests that touch the database.
-See `tests/unit/test_ssh_checker.py` (33 tests) or
-`tests/unit/test_takeover_check.py` (35 tests) as reference.
-
-## Other ways to help
-
-- **Bug reports.** Open an issue using the "Bug report" template — exact
-  reproducer + version (image tag or git SHA) + what you ran.
-- **Feature requests.** Use the "Feature request" template. Tell us the
-  problem first, the solution second.
-- **Docs.** README/CHANGELOG/CLAUDE.md fixes are welcome PRs. Typo fixes
-  go straight in; structural rewrites — open an issue first so we can
-  agree on direction before you write.
-- **Frontend tweaks.** React 19 + Vite 8 + Tailwind + shadcn/ui in
-  `frontend/`. Run `npm run dev` against a Django backend on `:8000`.
-- **Tests.** We're at ~910 tests excluding slow DNS; raising that
-  number always helps. `tests/unit/test_<thing>.py` matches the app it
-  tests.
-
-## What to grep first (avoid re-discovery)
-
-- `CLAUDE.md` — project conventions, architecture rules, gotchas. Read
-  this before opening a non-trivial PR.
-- `CHANGELOG.md` — explains *why* recent changes were made, not just what.
-- `apps/core/workflows/registry.py` — the auto-registration plumbing.
-- `apps/core/findings/models.py` — the unified Finding model every
-  tool writes to.
-
-## Fork and contribute
-
-OpenEASD uses a fork-based workflow for external contributors — you won't
-have write access to the main repo, so work happens in your fork.
+## Local checks before you push
 
 ```bash
-# 1. Fork the repo on GitHub (click "Fork" top-right)
-
-# 2. Clone your fork
-git clone https://github.com/<your-username>/OpenEASD.git
-cd OpenEASD
-
-# 3. Add the upstream remote so you can stay in sync
-git remote add upstream https://github.com/cybersecify/OpenEASD.git
-
-# 4. Before starting work, sync your fork's main with upstream
-git fetch upstream
-git checkout main
-git merge upstream/main
-
-# 5. Create a branch
-git checkout -b feat/my-feature   # or fix/my-fix
-
-# 6. Push to your fork and open a PR against cybersecify/OpenEASD main
-git push origin feat/my-feature
+uv run manage.py check
+uv run pytest tests/ --ignore=tests/unit/test_domain_security.py   # fast suite
+cd frontend && npm run build                                       # if you touched the SPA
 ```
 
-Maintainers with write access can branch directly on the main repo — same
-branch naming rules apply.
+## Definition of done for adding/removing a scan tool
 
-## Development setup
-
-```bash
-# Install Python deps (uv handles the lockfile)
-uv sync --group dev
-
-# Install frontend deps
-cd frontend && npm install && cd ..
-
-# Run migrations
-uv run manage.py migrate
-
-# Quickest: starts Django (:8001) + Vite dev server + qcluster worker together
-make dev
-
-# Or manually in three terminals:
-# Terminal 1 — Django
-uv run manage.py runserver 8001
-
-# Terminal 2 — Vite dev server (proxies /api/ to Django at :8001)
-cd frontend && npm run dev
-
-# Terminal 3 — Background worker (required for scans to execute)
-uv run manage.py qcluster
-```
-
-App runs at `http://localhost:5173` in dev. Default login on a fresh DB
-is `admin` / `admin`, force-change-password kicks in.
-
-External tools (`subfinder`, `dnsx`, `naabu`, `httpx`, `nuclei`,
-`amass`, `nmap`) need to be on `PATH`. Easiest install is the
-ProjectDiscovery `pdtm` (`pdtm -i subfinder,dnsx,naabu,httpx,nuclei`)
-plus `brew install nmap` and `go install github.com/owasp-amass/amass/v4/...@master`.
-
-## Tests before you push
-
-```bash
-# Fast suite (excludes slow real-network DNS tests)
-uv run pytest tests/ --ignore=tests/unit/test_domain_security.py
-```
-
-CI runs the same. PR will block if anything fails. If your change
-touches a tool collector, add or update a unit test in
-`tests/unit/test_<tool>.py`.
-
-## Commit messages
-
-Use the most specific prefix that fits:
-
-| Prefix | When to use |
-|---|---|
-| `feat:` | New user-facing feature |
-| `fix:` | Bug fix |
-| `docs:` | Documentation only (README, CHANGELOG, CONTRIBUTING) |
-| `ci:` | GitHub Actions, CI config, Dockerfile, dependabot |
-| `chore:` | Deps, tooling, config — no behavior change |
-| `test:` | Tests only — no production code change |
-
-Examples:
-
-```
-feat: add nuclei_network tool for non-web protocol vuln scanning
-fix: findings_count no longer counts asset rows as findings
-docs: update CONTRIBUTING with fork workflow
-ci: pin actions/setup-python to v6
-chore: bump pypdf 4.x → 6.x
-test: add missing collector timeout case to test_ssh_checker
-```
-
-Body explains the *why*, not just the what — see existing commits for
-the format. Scope is optional: `fix(runner): ...` is fine if it helps
-locate the change.
-
-### DCO — sign off your commits
-
-OpenEASD uses the [Developer Certificate of Origin (DCO)](https://developercertificate.org/)
-to confirm you have the right to submit your contribution under the
-MIT License. Add a `Signed-off-by` line to every commit:
-
-```bash
-git commit -s -m "fix: correct TLS severity mapping"
-# produces: Signed-off-by: Your Name <you@example.com>
-```
-
-If you forgot to sign off past commits before opening the PR, fix them with:
-
-```bash
-git rebase HEAD~<n> --signoff
-git push --force-with-lease
-```
-
-Maintainers will ask you to add sign-offs before merging if they're missing.
-
-## Code style
-
-- Python: follow what's there. We use Django 5+ idioms. No formatter
-  enforced in CI yet; please don't reformat unrelated lines in your PR.
-- JS: ES modules + JSX. Tailwind utility classes for styling.
-- Comments: only when the *why* is non-obvious. Don't restate the code.
-- Don't introduce new dependencies in a small PR — flag it in the
-  description and we'll talk through it.
-
-## Security issues
-
-**Do not open a public issue for security vulnerabilities.** See
-[SECURITY.md](SECURITY.md) for the private reporting channel (GitHub
-PVR preferred, `contact@cybersecify.com` as fallback).
-
-## License
-
-By contributing, you agree your contribution is licensed under the
-[MIT License](LICENSE) — same as the rest of the project.
-
-## Code of Conduct
-
-Be reasonable. Don't be a jerk in issues, PRs, or discussions. We'll
-adopt the Contributor Covenant 2.1 if anything needs formal arbitration
-— for now, common sense.
+Adding a tool touches more than its own app — see the checklist in `CLAUDE.md`
+("Definition of done for adding (or removing) a tool"): register it, add it to
+the default Full Scan migration, update the tool count + list + pipeline diagram
+in `README.md`, update `CHANGELOG.md` and `CLAUDE.md`. CI's
+`test_default_workflow.py` invariant fails if a registered tool isn't in Full
+Scan, so keep them in sync.


### PR DESCRIPTION
Codifies the contribution model now that the team has multiple write-access members.

- **One rule for all:** changes land via a reviewed PR; no direct pushes to `main`.
- **Internal** team branches in-repo (`feat/`,`fix/`); **external** contributors fork.
- **CODEOWNERS** routes review by area (scanner/backend/CI → @rathnakaragn, docs/growth → @ashok-kamat) — advisory routing, not a merge blocker.
- Documents the branch-protection requirements: CI green + 1 non-author approval.

Paired with a branch-protection change (adding CI as a **required status check** — peer review at 1 approval was already required; CI passing was not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)