### PR TITLE
fix: passive coverage-regression false positive + cap nuclei target list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
       - "**.md"
       - "docs/**"
   pull_request:
+    # No paths-ignore: CI is now a REQUIRED status check, so a PR touching only
+    # ignored paths (**.md, docs/**) would never run it → the required check never
+    # reports → the PR is unmergeable. Run CI on every PR; the `push` paths-ignore
+    # above still skips the image republish on docs-only merges to main.
     branches: ["main"]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   # Weekly rebuild so the baked nuclei-templates refresh on cadence — the image
   # sets -disable-update-check (no runtime template fetch), so without this the
   # templates freeze at build time and rot (miss new CVEs). schedule runs on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Fixed
+- **Two issues the live cybersecify.com validation run exposed.** (1) A **passive
+  scan spuriously emitted a `scan_coverage` "results incomplete" finding** because
+  the coverage-regression check diffed it against a prior *active* (Full Scan)
+  baseline — a passive scan runs far fewer tools, so it always looked like a
+  collapse. The check now only compares scans of the **same workflow**. (2)
+  **nuclei hit its 2h wall on a large surface** (a Full Scan fed it 368 URLs);
+  its target list is now **capped per profile** (`NUCLEI_MAX_TARGETS`; low=100),
+  live-probed (httpx) URLs first, cap logged (never silent).
+- **CI runs on every PR** (dropped the `pull_request` `paths-ignore`): now that CI
+  is a required status check, a docs-only PR would otherwise never trigger it and
+  be unmergeable. The `push` `paths-ignore` still skips the image republish on
+  docs-only merges.
+
 ### Changed
 - **nuclei hardening (follow-up to the severity scoping).** Three parallel agents
   investigated nuclei's freeze/timeout/value; key finding: `-severity` does NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,4 +657,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_coverage_regression.py` | 10 | Silent-block coverage counting (probed-vs-reached), coverage-regression finding (high block ratio / findings drop / stable = no flag), partial scan status when a tool fails |
 | `tests/test_api_endpoints.py` | 104 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1345 tests** (1293 fast + 52 slow domain_security)
+**Total: 1349 tests** (1297 fast + 52 slow domain_security)

--- a/apps/core/scans/pipeline.py
+++ b/apps/core/scans/pipeline.py
@@ -101,10 +101,15 @@ def _check_coverage_regression(session):
             + (f", consistent with {session.waf_vendor}" if session.waf_vendor else "")
         )
 
-    # 2. Sharp drop vs the previous completed/partial full scan for this domain.
+    # 2. Sharp drop vs the previous scan of the SAME workflow for this domain.
+    # Must be same-workflow: a Passive Scan runs far fewer tools than a Full Scan,
+    # so diffing a passive run against a prior active baseline always looks like a
+    # collapse and fires a spurious "results incomplete" finding (found live on a
+    # cybersecify.com passive run). Same class as excluding subscans from deltas.
     previous = (
         ScanSession.objects.filter(
-            domain=session.domain, status__in=["completed", "partial"]
+            domain=session.domain, status__in=["completed", "partial"],
+            workflow_id=session.workflow_id,
         )
         .exclude(id=session.id)
         .exclude(scan_type="subscan")

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -46,6 +46,27 @@ CONCURRENCY = 25      # fallback -c; the resource profile overrides it
 # protection instead of a plain subprocess.run that can hang the worker.
 
 
+def _select_targets(session) -> list[str]:
+    """Deduped URL list for nuclei: live-probed (httpx) URLs first, then archived/
+    crawled ones, capped at NUCLEI_MAX_TARGETS. The cap is logged, never silent —
+    a large surface at the polite rate would otherwise blow past the wall-clock.
+    """
+    from apps.core.web_assets.models import URL
+
+    live = list(URL.objects.filter(session=session, source="httpx").values_list("url", flat=True))
+    rest = list(URL.objects.filter(session=session).exclude(source="httpx").values_list("url", flat=True))
+    targets = list(dict.fromkeys(live + rest))  # dedupe, live-probed first
+
+    cap = getattr(settings, "NUCLEI_MAX_TARGETS", 400)
+    if len(targets) > cap:
+        logger.warning(
+            f"[nuclei:{session.id}] Capping {len(targets)} URLs to {cap} "
+            f"(live-probed first); {len(targets) - cap} not scanned this run"
+        )
+        targets = targets[:cap]
+    return targets
+
+
 def collect(session) -> list[dict]:
     """
     Run nuclei against all web URLs from the httpx phase.
@@ -55,17 +76,12 @@ def collect(session) -> list[dict]:
 
     Returns list of raw nuclei JSON records (one per finding).
     """
-    from apps.core.web_assets.models import URL
-
     binary = getattr(settings, "TOOL_NUCLEI", "nuclei")
 
-    urls = list(URL.objects.filter(session=session).values_list("url", flat=True))
-    if not urls:
+    targets = _select_targets(session)
+    if not targets:
         logger.info(f"[nuclei:{session.id}] No URLs to scan")
         return []
-
-    # Deduplicate
-    targets = sorted(set(urls))
 
     with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
         f.write("\n".join(targets))

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -363,13 +363,19 @@ LOW_MEMORY = PROFILE == "low"  # runner serialises + amass skips brute when true
 # bound that actually prevents the FREEZE is GOMEMLIMIT + a small bulk_size.
 # Default bulk_size is 25; we scale it down hard on the low profile.
 _PROFILE_TUNING = {
-    "low":      {"nuclei_c": 10, "nuclei_rate": 40,  "nuclei_sev": "critical,high,medium",     "nuclei_bs": 5},
-    "balanced": {"nuclei_c": 25, "nuclei_rate": 100, "nuclei_sev": "critical,high,medium,low", "nuclei_bs": 15},
-    "high":     {"nuclei_c": 40, "nuclei_rate": 150, "nuclei_sev": "critical,high,medium,low", "nuclei_bs": 25},
+    "low":      {"nuclei_c": 10, "nuclei_rate": 40,  "nuclei_sev": "critical,high,medium",     "nuclei_bs": 5,  "nuclei_max": 100},
+    "balanced": {"nuclei_c": 25, "nuclei_rate": 100, "nuclei_sev": "critical,high,medium,low", "nuclei_bs": 15, "nuclei_max": 400},
+    "high":     {"nuclei_c": 40, "nuclei_rate": 150, "nuclei_sev": "critical,high,medium,low", "nuclei_bs": 25, "nuclei_max": 1000},
 }
 NUCLEI_CONCURRENCY = _PROFILE_TUNING[PROFILE]["nuclei_c"]
 NUCLEI_RATE_LIMIT = _PROFILE_TUNING[PROFILE]["nuclei_rate"]
 NUCLEI_BULK_SIZE = _PROFILE_TUNING[PROFILE]["nuclei_bs"]
+# Cap on the number of URLs nuclei probes in one run. At the polite low-profile
+# rate (40 rps) a large surface (a cybersecify.com Full Scan fed nuclei 368 URLs)
+# blows past the 2h wall and times out. Bound it per profile; the cap is logged
+# (never a silent truncation), and live-probed (httpx) URLs are prioritised over
+# archived/crawled ones. Overridable via env for a box that can afford more.
+NUCLEI_MAX_TARGETS = config("NUCLEI_MAX_TARGETS", default=_PROFILE_TUNING[PROFILE]["nuclei_max"], cast=int)
 # Overridable: set NUCLEI_SEVERITY=critical,high,medium,low,info to widen coverage
 # (at the cost of memory/speed) on a box that can afford it.
 NUCLEI_SEVERITY = config("NUCLEI_SEVERITY", default=_PROFILE_TUNING[PROFILE]["nuclei_sev"])

--- a/tests/unit/test_coverage_regression.py
+++ b/tests/unit/test_coverage_regression.py
@@ -77,6 +77,29 @@ class TestCoverageRegression:
         _check_coverage_regression(cur)
         assert not Finding.objects.filter(session=cur, check_type="coverage_regression").exists()
 
+    def test_different_workflow_not_compared(self):
+        # A Passive Scan (fewer tools) must NOT be diffed against a prior Full
+        # Scan baseline — that always looks like a collapse and fires a spurious
+        # "results incomplete" finding (seen live on a cybersecify.com passive run).
+        from apps.core.findings.models import Finding
+        from apps.core.workflows.models import Workflow
+        full = Workflow.objects.create(name="Full Scan X")
+        passive = Workflow.objects.create(name="Passive Scan X")
+        _session(status="completed", total_findings=50, workflow=full)
+        cur = _session(total_findings=0, workflow=passive, endpoints_probed=0)
+        _check_coverage_regression(cur)
+        assert not Finding.objects.filter(session=cur, check_type="coverage_regression").exists()
+
+    def test_same_workflow_still_flags(self):
+        # Same-workflow drop must still fire (the real signal isn't lost).
+        from apps.core.findings.models import Finding
+        from apps.core.workflows.models import Workflow
+        full = Workflow.objects.create(name="Full Scan Y")
+        _session(status="completed", total_findings=50, workflow=full)
+        cur = _session(total_findings=5, workflow=full)
+        _check_coverage_regression(cur)
+        assert Finding.objects.filter(session=cur, check_type="coverage_regression").exists()
+
 
 @pytest.mark.django_db
 class TestCoverageRegressionReport:

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -533,3 +533,42 @@ class TestNucleiScanner:
         with patch("apps.nuclei.scanner.collect", return_value=[]):
             findings = run_nuclei(sess)
         assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Target selection: live-first prioritisation + cap (added after the
+# cybersecify.com run fed nuclei 368 URLs and it hit the 2h wall)
+# ---------------------------------------------------------------------------
+
+import pytest as _pytest
+
+
+@_pytest.mark.django_db
+class TestSelectTargets:
+    def _session(self):
+        from apps.core.scans.models import ScanSession
+        return ScanSession.objects.create(domain="example.com", scan_type="full")
+
+    def _url(self, session, host, source):
+        from apps.core.web_assets.models import URL
+        return URL.objects.create(
+            session=session, url=f"https://{host}", host=host,
+            scheme="https", source=source,
+        )
+
+    def test_live_httpx_urls_prioritised_over_archived(self):
+        from apps.nuclei.collector import _select_targets
+        s = self._session()
+        self._url(s, "archived.example.com", "historical_urls")
+        self._url(s, "live.example.com", "httpx")
+        targets = _select_targets(s)
+        assert targets[0] == "https://live.example.com"  # httpx first
+
+    def test_caps_target_list(self, settings):
+        from apps.nuclei.collector import _select_targets
+        settings.NUCLEI_MAX_TARGETS = 3
+        s = self._session()
+        for i in range(10):
+            self._url(s, f"h{i}.example.com", "httpx")
+        targets = _select_targets(s)
+        assert len(targets) == 3  # capped, never silently unbounded


### PR DESCRIPTION
Two real issues the live **cybersecify.com** validation run exposed, plus the CI fix I owe.

## Fixes
1. **Passive-scan false positive** — a Passive Scan emitted a spurious `scan_coverage` "results may be incomplete" finding because the coverage-regression check compared it to a prior *active* Full Scan (fewer tools → always looks like a collapse). Now compares **same-workflow only** — same class of fix as excluding subscans from deltas.
2. **nuclei 2h-wall on large surfaces** — a Full Scan fed nuclei **368 URLs**, blowing past the wall → timeout → `partial`. Target list now **capped per profile** (`NUCLEI_MAX_TARGETS`; low=100), **live-probed (httpx) URLs prioritised**, cap **logged not silent**.
3. **CI on every PR** — dropped the `pull_request` `paths-ignore` so a docs-only PR doesn't get stuck now that CI is a required status check (`push` paths-ignore still skips docs-only republish).

## Tests
- `_select_targets`: live-first ordering + cap. Coverage-regression: different-workflow not compared, same-workflow still flags.
- Full fast suite: 1297 passed.

> Note: this is a PR under the new required-review + required-CI rule, so it needs a **non-author approval** (@rathnakaragn / @cybersamarth) before merge — I'm not admin-overriding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)