### PR TITLE
fix: prune dead alterx candidates (subdomain count = live surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **Subdomain count no longer inflated by dead alterx guesses.** alterx generates
+  permutation *candidates* (dev-api.…, api-staging.…); those that don't resolve
+  were stored and counted as real subdomains — a cybersecify.com run showed
+  "1,862 subdomains" for a **5-subdomain** surface (1,857 dead alterx candidates).
+  dnsx now prunes unresolved alterx candidates after resolution, so the count
+  reflects the real, live surface. Discovery-tool names (subfinder/amass) are kept
+  even when unresolved — those are real observed names, not guesses.
 - **Two issues the live cybersecify.com validation run exposed.** (1) A **passive
   scan spuriously emitted a `scan_coverage` "results incomplete" finding** because
   the coverage-regression check diffed it against a prior *active* (Full Scan)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -657,4 +657,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_coverage_regression.py` | 10 | Silent-block coverage counting (probed-vs-reached), coverage-regression finding (high block ratio / findings drop / stable = no flag), partial scan status when a tool fails |
 | `tests/test_api_endpoints.py` | 104 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1349 tests** (1297 fast + 52 slow domain_security)
+**Total: 1350 tests** (1298 fast + 52 slow domain_security)

--- a/apps/dnsx/scanner.py
+++ b/apps/dnsx/scanner.py
@@ -38,6 +38,20 @@ def run_dnsx(session) -> list:
             sub.resolved_at = now
         Subdomain.objects.bulk_update(activated, ["is_active", "resolved_at"])
 
+    # Prune dead alterx permutation candidates. alterx INVENTS subdomain names
+    # (dev-api.example.com, api-staging.example.com, …); a candidate that doesn't
+    # resolve isn't a real subdomain and must not inflate the surface count — a
+    # cybersecify.com run generated 1,858 alterx candidates of which only 1 was
+    # real, showing "1,862 subdomains" for a 5-subdomain surface. Names from the
+    # discovery tools (subfinder/amass) are kept even if unresolved: those are
+    # real observed names, not guesses.
+    pruned, _ = (
+        Subdomain.objects.filter(session=session, source="alterx", is_active=False)
+        .delete()
+    )
+    if pruned:
+        logger.info(f"[dnsx:{session.id}] Pruned {pruned} unresolved alterx candidates")
+
     logger.info(
         f"[dnsx:{session.id}] Resolved {len(activated)}/{len(subs)} subdomains "
         f"to {len(ip_objs)} public IPs"

--- a/tests/unit/test_dnsx.py
+++ b/tests/unit/test_dnsx.py
@@ -317,6 +317,36 @@ class TestDnsxScanner:
         assert sub.is_active is True
         assert sub.resolved_at is not None
 
+    def test_prunes_unresolved_alterx_candidates_only(self):
+        # alterx invents names; a candidate that doesn't resolve must be pruned so
+        # it can't inflate the subdomain count. Discovery-tool names (subfinder)
+        # are kept even when unresolved — those are real observed names.
+        from apps.core.scans.models import ScanSession
+        from apps.core.assets.models import Subdomain
+
+        sess = ScanSession.objects.create(domain="example.com", scan_type="full")
+        Subdomain.objects.create(session=sess, domain="example.com",
+                                 subdomain="real.example.com", source="subfinder")     # resolves
+        Subdomain.objects.create(session=sess, domain="example.com",
+                                 subdomain="dead.example.com", source="subfinder")      # subfinder, no resolve -> KEEP
+        Subdomain.objects.create(session=sess, domain="example.com",
+                                 subdomain="live-guess.example.com", source="alterx")   # alterx, resolves -> KEEP
+        Subdomain.objects.create(session=sess, domain="example.com",
+                                 subdomain="dead-guess.example.com", source="alterx")   # alterx, no resolve -> PRUNE
+
+        with patch("apps.dnsx.scanner.collect", return_value=[
+            {"host": "real.example.com", "a": ["54.23.45.67"], "aaaa": []},
+            {"host": "live-guess.example.com", "a": ["54.23.45.68"], "aaaa": []},
+        ]):
+            run_dnsx(sess)
+
+        remaining = set(Subdomain.objects.filter(session=sess).values_list("subdomain", flat=True))
+        assert "dead-guess.example.com" not in remaining      # pruned
+        assert "real.example.com" in remaining                # resolved subfinder
+        assert "dead.example.com" in remaining                # unresolved subfinder kept
+        assert "live-guess.example.com" in remaining          # resolved alterx kept
+        assert Subdomain.objects.filter(session=sess).count() == 3
+
     def test_run_dnsx_does_not_activate_subdomain_with_only_private_ips(self):
         from apps.core.scans.models import ScanSession
         from apps.core.assets.models import Subdomain


### PR DESCRIPTION
The scan detail showed **1,862 subdomains** for cybersecify.com — but **only 5 are real** (resolve to an IP). **1,857 were dead alterx guesses** (`is_active=False`): permutation candidates (`dev-api.…`, `api-staging.…`) that don't exist. The headline count ignored `is_active` and counted the invented candidates, making a 5-subdomain surface look like 1,862.

## Fix
dnsx now **prunes unresolved alterx candidates** after resolution — alterx *invents* names, so one that doesn't resolve isn't a real subdomain. Discovery-tool names (subfinder/amass) are **kept even when unresolved** — those are real observed names, not guesses.

This is a **product-defaults fix**: every Docker user was seeing inflated counts, not just the droplet. The number now reflects the real, live attack surface.

## Tests
- `test_dnsx.py`: prunes unresolved alterx only; keeps resolved alterx + resolved/unresolved subfinder.
- Full fast suite: 1298 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)