### PR TITLE
fix: deliver partial nuclei findings on wall-timeout instead of a false 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ commits to recover the reasoning.
   - **amass delivers its partial subdomains on a time-limit** instead of
     discarding them and failing the scan — a time-boxed enumeration run is a
     normal, worthwhile result (like subfinder), and it's logged.
+  - **nuclei + nuclei_network deliver the findings they already wrote when the
+    wall-clock still hits** instead of raising and reporting a false 0. The
+    hardened runner (`run_capped`) already captured the partial stdout on
+    `TimeoutExpired.output`; the collectors now parse and return it. **Why:** on a
+    very large surface even the 6h budget can be exceeded — dropping tens of real
+    findings because the run was one template short of done is exactly the
+    "results, not challenges" failure the uncap set out to fix. The truncation is
+    logged, so it's visible, never silent.
   - **All profiles now include `low` severity** in nuclei (only `info` tech-detect
     noise, already covered by httpx, is dropped) — more findings, not fewer.
 

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -15,7 +15,7 @@ import tempfile
 
 from django.conf import settings
 
-from apps.core.workflows.exceptions import ToolBinaryMissing, ToolTimeout
+from apps.core.workflows.exceptions import ToolBinaryMissing
 from apps.core.workflows.proc import run_capped
 
 logger = logging.getLogger(__name__)
@@ -26,8 +26,9 @@ logger = logging.getLogger(__name__)
 # Time is not the constraint here — value and not
 # missing findings are — and this stays under the 4h worker/watchdog budget
 # even with nuclei_network (1h) also in the Full Scan. If a very large target
-# still exceeds it, the collector raises ToolTimeout so the scan reports
-# `partial` honestly rather than a misleading 0.
+# still exceeds it, the collector DELIVERS the partial findings nuclei already
+# wrote (run_capped carries them on TimeoutExpired.output) rather than discarding
+# them — a time-boxed run is a worthwhile result, and its findings are saved.
 TIMEOUT = 21600       # fallback wall-clock cap (6h); settings.NUCLEI_TIMEOUT overrides
 REQUEST_TIMEOUT = 5   # seconds per HTTP request (nuclei -timeout)
 # Lowered 150 -> 100 to be gentler on targets. Observed hosts already self-
@@ -128,28 +129,37 @@ def collect(session) -> list[dict]:
     ]
     logger.info(f"[nuclei:{session.id}] Scanning {len(targets)} web targets")
 
+    stdout, stderr = "", ""
     try:
         # Cap nuclei's Go heap on low-memory hosts (env unchanged on balanced/high).
         from apps.core.workflows.proc_env import go_memory_env
         timeout = getattr(settings, "NUCLEI_TIMEOUT", TIMEOUT)
         result = run_capped(cmd, timeout, env=go_memory_env())
+        stdout, stderr = result.stdout, result.stderr
     except FileNotFoundError:
         logger.error(f"[nuclei:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"nuclei binary not found: {binary}")
-    except subprocess.TimeoutExpired:
-        logger.error(f"[nuclei:{session.id}] Timed out after {timeout}s")
-        raise ToolTimeout(f"nuclei timed out after {timeout}s")
+    except subprocess.TimeoutExpired as exc:
+        # A time-boxed nuclei run is still a worthwhile result on a large surface:
+        # deliver the findings it DID write before the wall (run_capped attaches
+        # the partial stdout to exc.output) instead of discarding them and
+        # reporting a misleading 0. Logged, so the truncation is visible.
+        stdout = exc.output or ""
+        logger.warning(
+            f"[nuclei:{session.id}] Time-limited at {timeout}s — delivering "
+            f"{len(stdout.splitlines())} partial output lines"
+        )
     finally:
         os.unlink(tmp)
 
     # Surface stderr regardless of exit code: nuclei routinely exits 0 while
     # logging "could not load N templates" / interactsh failures to stderr, which
     # is silent under-coverage if only checked on nonzero rc.
-    if result.stderr and result.stderr.strip():
-        logger.warning(f"[nuclei:{session.id}] stderr: {result.stderr[:500]}")
+    if stderr and stderr.strip():
+        logger.warning(f"[nuclei:{session.id}] stderr: {stderr[:500]}")
 
     records = []
-    for line in result.stdout.strip().splitlines():
+    for line in stdout.strip().splitlines():
         if not line:
             continue
         try:

--- a/apps/nuclei_network/collector.py
+++ b/apps/nuclei_network/collector.py
@@ -13,7 +13,7 @@ import tempfile
 
 from django.conf import settings
 from apps.core.assets.models import Port
-from apps.core.workflows.exceptions import ToolBinaryMissing, ToolTimeout
+from apps.core.workflows.exceptions import ToolBinaryMissing
 from apps.core.workflows.proc import run_capped
 
 logger = logging.getLogger(__name__)
@@ -109,28 +109,36 @@ def collect(session) -> list[dict]:
         "-jsonl", "-silent", "-no-color",
     ]
 
+    stdout, stderr = "", ""
     try:
         # run_capped (not subprocess.run) so an escaped interactsh/resolver helper
         # can't hold the stdout pipe open and wedge the worker on timeout — the
         # same anti-hang fix the web nuclei collector already had.
         from apps.core.workflows.proc_env import go_memory_env
         result = run_capped(cmd, TIMEOUT, env=go_memory_env())
+        stdout, stderr = result.stdout, result.stderr
     except FileNotFoundError:
         logger.error(f"[nuclei_network:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"nuclei binary not found: {binary}")
-    except subprocess.TimeoutExpired:
-        logger.error(f"[nuclei_network:{session.id}] Timed out after {TIMEOUT}s")
-        raise ToolTimeout(f"nuclei_network timed out after {TIMEOUT}s")
+    except subprocess.TimeoutExpired as exc:
+        # Deliver the network findings nuclei wrote before the wall (run_capped
+        # attaches partial stdout to exc.output) instead of discarding them and
+        # reporting a false-clean 0. Logged so the truncation is visible.
+        stdout = exc.output or ""
+        logger.warning(
+            f"[nuclei_network:{session.id}] Time-limited at {TIMEOUT}s — delivering "
+            f"{len(stdout.splitlines())} partial output lines"
+        )
     finally:
         os.unlink(tmp)
 
     # Surface stderr regardless of exit code (nuclei exits 0 with template-load
     # warnings) so silent under-coverage is visible.
-    if result.stderr and result.stderr.strip():
-        logger.warning(f"[nuclei_network:{session.id}] stderr: {result.stderr[:500]}")
+    if stderr and stderr.strip():
+        logger.warning(f"[nuclei_network:{session.id}] stderr: {stderr[:500]}")
 
     records = []
-    for line in result.stdout.strip().splitlines():
+    for line in stdout.strip().splitlines():
         if not line:
             continue
         try:

--- a/docs/SCAN_OPERATIONAL_LEARNINGS.md
+++ b/docs/SCAN_OPERATIONAL_LEARNINGS.md
@@ -18,7 +18,7 @@ gunicorn + qcluster + Django is what tips a 1 GB box; runtime peak is
 | Symptom | Root cause | Fix | Guard |
 |---|---|---|---|
 | **Freeze** (box + web UI unresponsive for minutes) | ~500 MB startup template parse + runtime `c × bulk-size × per-host buffer` on a 1 GB host | `GOMEMLIMIT` soft heap cap **+** small `-bulk-size` per profile (low=5) — NOT `-severity` | `test_nuclei.py::test_go_memory_limit_applied_to_subprocess`, `::test_cmd_includes_memory_and_scope_flags`; `test_settings_security.py::test_bulk_size_scales_down_on_low_profile` |
-| **Timeout** (2 h wall hit, run reported `partial`) | Template *execution*: targets × executed templates ÷ polite rate | Give nuclei TIME to finish (6h `NUCLEI_TIMEOUT`, 24h worker/watchdog) rather than capping its output; `-type http` + `-max-host-error` trim wasted work. Output caps were REMOVED — the product's value is complete results | `test_nuclei.py::test_cmd_scopes_severity_and_drops_info`, `::test_cmd_includes_memory_and_scope_flags` |
+| **Timeout** (wall hit, findings discarded) | Template *execution*: targets × executed templates ÷ polite rate | Give nuclei TIME to finish (6h `NUCLEI_TIMEOUT`, 24h worker/watchdog) rather than capping its output; `-type http` + `-max-host-error` trim wasted work. AND if the wall still hits, **deliver the partial findings** nuclei already wrote (`run_capped` carries them on `TimeoutExpired.output`; both collectors parse + return them) instead of discarding them for a false 0 | `test_nuclei.py::test_timeout_delivers_partial_findings`, `test_nuclei_network.py::test_collect_timeout_delivers_partial_findings`, `::test_cmd_includes_memory_and_scope_flags` |
 | **Low value / noise** | `info` tech-detect templates are already covered by httpx `-tech-detect` + web_checker; they bury real findings | Scope to `critical,high,medium(,low)` per profile (`NUCLEI_SEVERITY`). NOTE: this also drops the unique `exposures` bucket (.git/.env/backups/tokens) — a value gap; re-including it needs a memory-safe second pass (`-include-tags` does NOT override `-severity` on v3.2.9, verified) — deferred | `test_settings_security.py::TestResourceProfile` |
 | **Wedge / lost findings** | `nuclei_network` used plain `subprocess.run` (no process-group kill) → an escaped interactsh helper could hold the pipe and hang the worker | Both nuclei collectors now use the shared `run_capped` (temp-file redirect + `killpg`) | `test_nuclei.py::TestRunProcessGroupKill` |
 | **Empty output** | The target **dropped the scanner's probes** → httpx returned 0 live URLs → nuclei had nothing to scan | Coverage/blocking problem, not nuclei — surfaced by the coverage-regression finding + `partial` status | `test_coverage_regression.py` |
@@ -30,11 +30,10 @@ an old image misses new CVEs. A **weekly CI cron** now rebuilds `:latest` so
 templates refresh on cadence (`.github/workflows/ci.yml`). Do **not** re-enable
 runtime template updates.
 
-**Deferred nuclei follow-ups:** (a) recover partial findings written before a
-wall-timeout (`run_capped` now carries them on the exception's `.output`; the
-scanner does not yet save them); (b) re-include the `exposures` template bucket
-via a memory-safe mechanism; (c) store `info.tags` / `classification.cwe-id` for
-richer report categorisation.
+**Deferred nuclei follow-ups:** (a) re-include the `exposures` template bucket
+via a memory-safe mechanism; (b) store `info.tags` / `classification.cwe-id` for
+richer report categorisation. (Recovering partial findings on a wall-timeout —
+formerly deferred — is now DONE: both collectors parse `TimeoutExpired.output`.)
 
 **What nuclei needs to work properly:** (1) reachable targets (not blocked —
 run a Passive Scan or get the scanner IP allowlisted if coverage collapses),
@@ -44,8 +43,13 @@ small hosts, (4) reasonably fresh templates (image rebuild cadence).
 ## Other tools (guarded by the 2026-08 audit)
 
 - **amass / nmap timeouts** used to be swallowed → scan read `completed` with a
-  truncated surface. Now they raise `ToolTimeout` → scan `partial`. Guards:
-  `test_amass.py`, `test_nmap.py::TestNmapCollectorFailureModes`.
+  truncated surface. Now handled honestly: enumeration/finding tools whose partial
+  output is worthwhile **deliver it** on the wall (amass subdomains, nuclei +
+  nuclei_network findings — a time-boxed run is a normal result); tools where a
+  truncated run is not meaningfully partial raise `ToolTimeout` → scan `partial`
+  (nmap). Guards: `test_amass.py::test_timeout_delivers_partial_results`,
+  `test_nuclei.py::test_timeout_delivers_partial_findings`,
+  `test_nmap.py::TestNmapCollectorFailureModes`.
 - **takeover_check** silently dropped `vulnerable` records it couldn't
   fingerprint → subzy field drift hid real takeovers. Now reported. Guard:
   `test_takeover_check.py`.

--- a/tests/unit/test_nuclei.py
+++ b/tests/unit/test_nuclei.py
@@ -290,16 +290,27 @@ class TestNucleiCollector:
             with pytest.raises(ToolBinaryMissing):
                 collect(sess)
 
-    def test_timeout_raises(self):
-        """A wall-clock timeout must surface as ToolTimeout, not a silent [] —
-        this is the false-green that made nuclei look 'completed' with 0 findings."""
+    def test_timeout_delivers_partial_findings(self):
+        """A wall-clock timeout must DELIVER whatever nuclei already found rather
+        than discard it and report 0. run_capped attaches partial stdout to the
+        TimeoutExpired's .output; the collector parses it and returns the findings,
+        logging that the run was time-limited (visible, never silent)."""
         import subprocess as sp
-        from apps.core.workflows.exceptions import ToolTimeout
         sess = self._make_session()
-        with patch("apps.nuclei.collector.run_capped",
-                   side_effect=sp.TimeoutExpired(cmd="nuclei", timeout=1800)):
-            with pytest.raises(ToolTimeout):
-                collect(sess)
+        exc = sp.TimeoutExpired(cmd="nuclei", timeout=1800)
+        exc.output = json.dumps(_nuclei_record()) + "\n"  # one finding written before the wall
+        with patch("apps.nuclei.collector.run_capped", side_effect=exc):
+            records = collect(sess)   # must NOT raise
+        assert len(records) == 1
+
+    def test_timeout_with_no_partial_output_returns_empty(self):
+        """If nuclei timed out before writing anything, deliver [] (still no raise)."""
+        import subprocess as sp
+        sess = self._make_session()
+        exc = sp.TimeoutExpired(cmd="nuclei", timeout=1800)  # .output is None
+        with patch("apps.nuclei.collector.run_capped", side_effect=exc):
+            records = collect(sess)
+        assert records == []
 
     def test_invalid_json_skipped(self):
         sess = self._make_session()

--- a/tests/unit/test_nuclei_network.py
+++ b/tests/unit/test_nuclei_network.py
@@ -243,16 +243,30 @@ def test_collect_binary_missing_raises(MockPort, mock_run, mock_session):
 
 @patch("apps.nuclei_network.collector.run_capped")
 @patch("apps.nuclei_network.collector.Port")
-def test_collect_timeout_raises(MockPort, mock_run, mock_session):
-    """A wall-clock timeout must surface as ToolTimeout so the scan reports
-    'partial' rather than a false-clean network sweep."""
+def test_collect_timeout_delivers_partial_findings(MockPort, mock_run, mock_session):
+    """A wall-clock timeout must DELIVER the network findings nuclei already wrote
+    (run_capped carries them on TimeoutExpired.output) rather than discard them and
+    report a false-clean 0. Logged so the truncation is visible."""
+    import json
     import subprocess as sp
-    from apps.core.workflows.exceptions import ToolTimeout
     port = MagicMock(address="1.2.3.4", port=6379, service="redis")
     MockPort.objects.filter.return_value = [port]
-    mock_run.side_effect = sp.TimeoutExpired(cmd="nuclei", timeout=3600)
-    with pytest.raises(ToolTimeout):
-        collect(mock_session)
+    exc = sp.TimeoutExpired(cmd="nuclei", timeout=3600)
+    exc.output = json.dumps({"template-id": "redis-unauth", "info": {"severity": "high"}}) + "\n"
+    mock_run.side_effect = exc
+    records = collect(mock_session)   # must NOT raise
+    assert len(records) == 1
+
+
+@patch("apps.nuclei_network.collector.run_capped")
+@patch("apps.nuclei_network.collector.Port")
+def test_collect_timeout_no_output_returns_empty(MockPort, mock_run, mock_session):
+    """Timeout before any output → deliver [] (still no raise)."""
+    import subprocess as sp
+    port = MagicMock(address="1.2.3.4", port=6379, service="redis")
+    MockPort.objects.filter.return_value = [port]
+    mock_run.side_effect = sp.TimeoutExpired(cmd="nuclei", timeout=3600)  # .output is None
+    assert collect(mock_session) == []
 
 
 @patch("apps.nuclei_network.collector.run_capped")


### PR DESCRIPTION
## What
Both nuclei collectors (`apps/nuclei`, `apps/nuclei_network`) raised `ToolTimeout` on a wall-clock timeout, discarding the findings nuclei had already written. `run_capped` already captures the partial stdout on `TimeoutExpired.output`; the collectors now parse and return it, logging the truncation.

## Why
On a large surface even the uncapped 6h budget can be exceeded. Dropping tens of real findings because the run was one template short of done is the "results, not challenges" failure the uncap set out to fix. Mirrors the already-merged amass partial-delivery decision. Closes deferred item (a) in `SCAN_OPERATIONAL_LEARNINGS.md`.

## Tests
- `test_nuclei.py::test_timeout_delivers_partial_findings` + `::test_timeout_with_no_partial_output_returns_empty`
- `test_nuclei_network.py::test_collect_timeout_delivers_partial_findings` + `::test_collect_timeout_no_output_returns_empty`
- Full nuclei/nuclei_network/amass/workflow_runner suites green (141 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)