### PR TITLE
fix: remove dead imports/variables flagged by CodeQL

### DIFF
--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -4,7 +4,6 @@ import base64
 import csv
 import functools
 import logging
-from io import BytesIO
 from pathlib import Path
 
 from django.conf import settings

--- a/apps/nmap/management/commands/refresh_backports.py
+++ b/apps/nmap/management/commands/refresh_backports.py
@@ -1,4 +1,3 @@
-import os
 import json
 from pathlib import Path
 import sys
@@ -44,7 +43,7 @@ def do_refresh():
 
     # Atomic write: write to .tmp first, then replace, so a crash/SIGKILL mid-write
     # never leaves backports.json empty or half-written.
-    import tempfile, os
+    import os
     tmp_path = output_path.with_suffix(".json.tmp")
     print(f"Writing to {output_path} (atomic)...")
     with open(tmp_path, "w", encoding="utf-8") as f:

--- a/tests/test_backports_refresh.py
+++ b/tests/test_backports_refresh.py
@@ -1,4 +1,3 @@
-import pytest
 import json
 from unittest.mock import patch, MagicMock
 from apps.nmap.sources.ubuntu_usn import fetch_ubuntu_backports

--- a/tests/unit/test_alpine_secdb.py
+++ b/tests/unit/test_alpine_secdb.py
@@ -1,5 +1,4 @@
 import json
-import urllib.request
 import pytest
 from unittest.mock import patch, MagicMock
 from apps.nmap.sources.alpine_secdb import fetch_alpine_backports

--- a/tests/unit/test_amass.py
+++ b/tests/unit/test_amass.py
@@ -1,7 +1,7 @@
 """Unit tests for apps/amass — collector, analyzer, and scanner."""
 
 import subprocess
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/unit/test_coverage_regression.py
+++ b/tests/unit/test_coverage_regression.py
@@ -59,7 +59,7 @@ class TestCoverageRegression:
 
     def test_findings_drop_flags(self):
         from apps.core.findings.models import Finding
-        prev = _session(status="completed", total_findings=50)
+        _session(status="completed", total_findings=50)  # baseline the check compares against
         cur = _session(total_findings=10)
         _check_coverage_regression(cur)
         assert Finding.objects.filter(session=cur, check_type="coverage_regression").exists()

--- a/tests/unit/test_cve_intel.py
+++ b/tests/unit/test_cve_intel.py
@@ -180,7 +180,6 @@ class TestRunCveIntel:
     @pytest.mark.django_db
     def test_enriches_and_persists(self):
         from apps.cve_intel.scanner import run_cve_intel
-        from apps.core.findings.models import Finding
         session = self._session()
         f = self._finding(session, cve="CVE-2021-1")
         kev = {"CVE-2021-1": {"date_added": "2022-01-01", "due_date": "2022-01-15"}}

--- a/tests/unit/test_domain_authorization.py
+++ b/tests/unit/test_domain_authorization.py
@@ -3,8 +3,6 @@
 import datetime
 import json
 import pytest
-from django.contrib.auth.models import User
-from ninja_jwt.tokens import AccessToken
 
 
 def post_json(client, path, data):

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -58,7 +58,6 @@ class TestSyncDomainMonitoringJobs:
     def test_stale_schedule_removed_when_domain_deactivated(self, db):
         from django_q.models import Schedule
         from apps.core.scheduler.scheduler import sync_domain_monitoring_jobs
-        from apps.core.domains.models import Domain
 
         domain = self._make_domain("stale.com", interval=12)
         sync_domain_monitoring_jobs()
@@ -72,7 +71,6 @@ class TestSyncDomainMonitoringJobs:
     def test_stale_schedule_removed_when_interval_cleared(self, db):
         from django_q.models import Schedule
         from apps.core.scheduler.scheduler import sync_domain_monitoring_jobs
-        from apps.core.domains.models import Domain
 
         domain = self._make_domain("cleared.com", interval=6)
         sync_domain_monitoring_jobs()

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -7,7 +7,7 @@ PDF rendering is mocked (via _render_pdf) so tests need no WeasyPrint libs.
 
 import csv
 import io
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import User

--- a/tests/unit/test_subscan.py
+++ b/tests/unit/test_subscan.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 class TestCreateSubscanSession:
     def _make_completed_session(self, domain="target.com"):
         from apps.core.scans.models import ScanSession
-        from apps.core.workflows.models import Workflow, WorkflowStep
+        from apps.core.workflows.models import Workflow
         workflow = Workflow.objects.filter(is_default=True).first()
         return ScanSession.objects.create(
             domain=domain,

--- a/tests/unit/test_tools_healthcheck.py
+++ b/tests/unit/test_tools_healthcheck.py
@@ -12,7 +12,6 @@ import subprocess
 from io import StringIO
 from unittest.mock import patch
 
-import pytest
 from django.core.management import call_command
 
 from apps.core.dashboard.management.commands.tools_healthcheck import (


### PR DESCRIPTION
## What
Removes 14 genuinely-unused imports and 1 unused local variable flagged by CodeQL (`py/unused-import`, `py/unused-local-variable`). Every removal cross-checked against ruff `F401`/`F841` so only truly-dead code is touched — zero behaviour change.

The one `F841` (`prev` in `test_coverage_regression.py`) kept its `_session()` call — that call seeds the baseline scan row the regression check compares against — and just dropped the unused binding, matching the sibling `test_stable_scan_no_flag` pattern.

## Not touched (intentional-by-design, dismissed on the alert not the code)
- `js_secrets/collector.py` `verify=False` — deliberately fetches target hosts that may have self-signed certs (already carries `# nosec B501`)
- `tls_checker/collector.py` insecure-protocol — the tool negotiates old TLS versions on purpose to *report* on them

## Verify
- `ruff check --select F401,F841` → clean
- `manage.py check` → no issues
- 169 tests across all touched files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)