### PR TITLE
feat: add Shodan passive exposure tool (two-tier BYOK, tool #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **Shodan passive exposure tool (`apps/shodan`) — tool #23.** Reads Shodan's own
+  internet-wide scan dataset for each resolved public IP and reports exposed
+  ports/services + known CVEs, **without sending a packet to the target**
+  (passive, `active=False`, no `DomainAuthorization`). Two-tier, bring-your-own-key:
+  - **Free tier (default, zero config):** Shodan **InternetDB** — ports, CPEs,
+    CVE ids per IP. No key, no credits. Every Docker deployment gets it.
+  - **Enhanced tier:** set `SHODAN_API_KEY` → full host API (service banners +
+    versions + tags). `SHODAN_MAX_IPS` (default 50) caps the paid path's queries
+    to protect plan credits; the free path is uncapped (costs nothing).
+
+  **Why:** completes the "what's already publicly visible about you" picture that
+  the passive report is built on — Shodan shows exposure from an external vantage
+  that active tools (nmap) can't reach when a target blocks or rate-limits our
+  scanner, and it runs in the no-auth **Passive Scan** mode where nmap cannot.
+  **Not a duplicate of nmap:** different *method* (passive/external vs
+  active/first-hand) covering a different failure mode. CVE ids are stored in
+  `extra["cve_ids"]` so the existing `cve_intel` phase enriches them with EPSS +
+  CISA KEV — a Shodan-surfaced KEV CVE is exactly the "worth a pentest" signal.
+  **Key never ships in the image** (that would leak it + breach Shodan's ToS): the
+  key is a per-deployment secret; keyless users get the free tier. In default Full
+  Scan + Passive Scan (migration `0025`). 20 tests.
+
 ### Changed
 - **Tools now run to completion and deliver full output — no output caps.** The
   product's value is complete results in one UI, so instead of *capping* tools to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,7 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 - `get_tool_requires()` — for dependency validation
 - `get_source_choices()` — for finding source filtering
 
-### Tool apps (22 registered tools)
+### Tool apps (23 registered tools)
 
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
@@ -409,6 +409,7 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 | `apps/takeover_check/` | 4 | Surface Enumeration | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
 | `apps/cloud_assets/` | 4 | Surface Enumeration | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
 | `apps/naabu/` | 5 | Port Discovery | No | Port scanning (top 100 TCP) |
+| `apps/shodan/` | 5 | Port Discovery | Yes | Passive exposure intel from Shodan's own scan data — ports/services/CVEs per resolved IP. BYOK: free InternetDB tier (no key, no credits), full host API when `SHODAN_API_KEY` set (`SHODAN_MAX_IPS` caps the paid path). CVEs land in `extra["cve_ids"]` so `cve_intel` enriches them. Passive, fail-graceful |
 | `apps/core/service_detection/` | 6 | Port Discovery | No | nmap -sV enriches Port.service + is_web |
 | `apps/nmap/` | 7 | Network Exposure | Yes | NSE vulners CVE scan (non-web ports); backport-aware CVE matching (`backports.json` registry) |
 | `apps/tls_checker/` | 7 | Network Exposure | Yes | TLS/cert analysis + cipher suite enumeration via `nmap --script ssl-enum-ciphers` (all ports) |
@@ -452,6 +453,7 @@ Phase 3  dnsx               → IPAddress (public-only filter)
 Phase 4  takeover_check     → Finding (subzy — dangling DNS → unclaimed cloud)
 Phase 4  cloud_assets       → Finding (open S3/Azure/GCP buckets — cloud_enum)
 Phase 5  naabu              → Port (top 100 TCP scan)
+Phase 5  shodan             → Finding (passive exposure: ports/services/CVEs from Shodan's data)
 Phase 6  service_detection  → enriches Port.service + Port.is_web
 Phase 7  nmap               → Finding (CVEs on non-web ports, is_web=False)  ┐
 Phase 7  tls_checker        → Finding (cipher/cert/protocol on all ports)    │ parallel
@@ -472,10 +474,11 @@ the registry via `get_tool_active()` and `is_passive_tool_set(tools)`.
 
 - **Passive** (`active=False`): uses ONLY public / third-party data — CT logs and
   other subdomain feeds, DNS resolution via public resolvers, WHOIS/RDAP, web
-  archives, cloud-provider bucket APIs, CVE/EPSS/KEV feeds. Sends **no packets to
-  the target's own systems**. Needs **no `DomainAuthorization`**.
+  archives, cloud-provider bucket APIs, Shodan's own scan dataset, CVE/EPSS/KEV
+  feeds. Sends **no packets to the target's own systems**. Needs **no
+  `DomainAuthorization`**.
   Passive tools: `subfinder`, `alterx`, `dnsx`, `historical_urls`,
-  `cloud_assets`, `cve_intel`, `asn_discovery`, `hudson_rock`.
+  `cloud_assets`, `cve_intel`, `asn_discovery`, `hudson_rock`, `shodan`.
 - **Active** (`active=True`): probes the target directly (port scans, HTTP/TLS/SSH
   connections, crawling, vuln templates, AXFR/SMTP/mta-sts probes). **Requires
   `DomainAuthorization`.**
@@ -619,6 +622,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 16 | JSON parser, Port lookup, Subdomain link, honest UA, tech-detect flag + technology storage/dedup |
 | `tests/unit/test_hudson_rock.py` | 17 | collector (both endpoints keyless + honest UA, fail-graceful on timeout/500/429/bad-JSON, 429 retry), analyzer (severity, counts/families/URLs/attribution, no-finding-when-zero, **no plaintext/email persisted**, URL cap), scanner |
+| `tests/unit/test_shodan.py` | 20 | collector tier selection (free InternetDB vs paid host API, BYO-key), `SHODAN_MAX_IPS` cap on paid path only, fail-graceful (404/timeout/500/429/bad-JSON never raise), analyzer (exposure + CVE findings, `extra["cve_ids"]` for cve_intel enrichment, invalid-CVE filter), scanner |
 | `tests/unit/test_js_secrets.py` | 26 | `.js` URL filter + cap, fetch-error handling, gitleaks JSON parser, analyzer Findings + dedup + secret redaction (full secret never stored), scanner, binary-missing/timeout |
 | `tests/unit/test_k8s_manifests.py` | 59 | k8s manifest structure, envFrom order, probes, secret/configmap split |
 | `tests/unit/test_katana.py` | 19 | JSONL parser, Port/Subdomain FK links, scanner orchestrator, honest UA |
@@ -657,4 +661,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_coverage_regression.py` | 10 | Silent-block coverage counting (probed-vs-reached), coverage-regression finding (high block ratio / findings drop / stable = no flag), partial scan status when a tool fails |
 | `tests/test_api_endpoints.py` | 104 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1350 tests** (1298 fast + 52 slow domain_security)
+**Total: 1370 tests** (1318 fast + 52 slow domain_security)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Use it as a **red teamer** to map external surface fast on targets you're authorised to test. Use it as a **defender** to see what's leaking out of your own infrastructure: subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs, without paying $500-5000/mo for a commercial EASM platform.
 
-OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-two tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, infostealer-log exposure (via Hudson Rock's keyless Cavalier API), technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
+OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-three tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, infostealer-log exposure (via Hudson Rock's keyless Cavalier API), Shodan-sourced exposure (passive; free InternetDB tier out of the box, richer with a bring-your-own Shodan key), technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
 
 Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [Cybersecify](https://cybersecify.com), the same tool we run in engagements and on our own infrastructure.
 
@@ -168,7 +168,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline**: 22-tool scan workflow from domain to findings
+- **Automated pipeline**: 23-tool scan workflow from domain to findings
 - **Network attack surface scanning**: CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **CVE prioritisation**: EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows**: Create custom scan configurations, enable/disable tools per workflow

--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -108,6 +108,7 @@ _CWE_BY_CHECK = {
     "infostealer_exposure": "CWE-522: Insufficiently Protected Credentials",
     "asn": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor",
     "coverage_regression": "CWE-693: Protection Mechanism Failure",
+    "shodan_exposure": "CWE-668: Exposure of Resource to Wrong Sphere",
 }
 
 

--- a/apps/core/workflows/migrations/0025_add_shodan_to_workflows.py
+++ b/apps/core/workflows/migrations/0025_add_shodan_to_workflows.py
@@ -1,0 +1,58 @@
+"""Add shodan (Shodan passive exposure intelligence) to the default workflows.
+
+shodan is a passive, Port-Discovery (phase 5) tool that reads Shodan's own
+internet-wide scan dataset for the session's resolved public IPs — ports,
+services, and known CVEs — without sending a packet to the target. It joins:
+
+  * Full Scan    — the invariant test_full_scan_covers_every_registered_tool
+                   requires every non-core registered tool to be in the default
+                   Full Scan, else the scan/report/README under-count.
+  * Passive Scan — it is passive (active=False), so it belongs in the no-auth
+                   passive recon workflow. This is what powers the "what's already
+                   publicly visible about you" free report without touching the
+                   target: with no key it uses Shodan's free InternetDB endpoint.
+
+Additive and idempotent (skips if already present), matching 0021/0023/0024.
+Execution order is unaffected — the runner regroups steps by registry phase.
+"""
+
+from django.db import migrations
+
+_TOOL = "shodan"
+_WORKFLOWS = ["Full Scan", "Passive Scan"]
+
+
+def add_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None:
+            continue
+        if wf.steps.filter(tool=_TOOL).exists():
+            continue
+        next_order = (
+            wf.steps.order_by("-order").values_list("order", flat=True).first() or 0
+        ) + 1
+        WorkflowStep.objects.create(workflow=wf, tool=_TOOL, order=next_order, enabled=True)
+
+
+def remove_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None:
+            continue
+        WorkflowStep.objects.filter(workflow=wf, tool=_TOOL).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflow", "0024_add_hudson_rock_to_workflows"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tool, remove_tool),
+    ]

--- a/apps/shodan/analyzer.py
+++ b/apps/shodan/analyzer.py
@@ -1,0 +1,116 @@
+"""Shodan analyzer — turns normalized host records into shared Findings.
+
+Up to two Findings per host:
+
+  * ``shodan_exposure`` (info): the ports/services Shodan already sees exposed on
+    the IP — "here is what any external observer can see about you without
+    scanning." This is the passive-report exposure signal.
+  * ``cve`` (medium): the known CVEs Shodan associates with the host. CVE ids are
+    stored in ``extra["cve_ids"]`` so cve_intel (phase 12) enriches this Finding
+    with EPSS scores + CISA KEV flags in place — feeding the prioritisation the
+    report uses to flag pentest-worthy issues.
+
+CVEs from Shodan's banner matching can be version-approximate, so the description
+says so and points at the active nmap results for confirmation.
+"""
+
+import logging
+
+from apps.core.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+_MAX_CVES_IN_DESC = 50
+
+
+def _valid_cve(c) -> bool:
+    return isinstance(c, str) and c.strip().upper().startswith("CVE-")
+
+
+def _service_lines(host: dict) -> str:
+    services = host.get("services") or []
+    if services:
+        lines = []
+        for s in services:
+            if not isinstance(s, dict):
+                continue
+            banner = f"{s.get('product') or ''} {s.get('version') or ''}".strip()
+            port = s.get("port")
+            transport = s.get("transport") or "tcp"
+            lines.append(f"  - {port}/{transport} {banner}".rstrip())
+        return "\n".join(lines)
+    return "\n".join(f"  - {p}" for p in (host.get("ports") or []))
+
+
+def analyze(session, results) -> list[Finding]:
+    findings: list[Finding] = []
+    for host in results or []:
+        if not isinstance(host, dict):
+            continue
+        ip = host.get("ip")
+        if not ip:
+            continue
+        ip = str(ip)
+        ports = host.get("ports") or []
+        services = host.get("services") or []
+        vulns = sorted({c.strip().upper() for c in (host.get("vulns") or []) if _valid_cve(c)})
+        tier = host.get("tier", "internetdb")
+
+        if ports or services:
+            findings.append(Finding(
+                session=session,
+                source="shodan",
+                check_type="shodan_exposure",
+                severity="info",
+                target=ip,
+                title=f"Publicly exposed services on {ip} (via Shodan)",
+                description=(
+                    f"Shodan's internet-wide scan data reports {len(ports)} open "
+                    f"port(s) on {ip} visible to any external observer, without the "
+                    f"target being scanned:\n{_service_lines(host)}"
+                ),
+                remediation=(
+                    "Confirm each exposed service is intended to be internet-facing. "
+                    "Firewall or restrict any that should not be public, and ensure "
+                    "the rest are patched and access-controlled."
+                ),
+                extra={
+                    "ip": ip,
+                    "ports": ports,
+                    "services": services,
+                    "hostnames": host.get("hostnames") or [],
+                    "tags": host.get("tags") or [],
+                    "shodan_tier": tier,
+                    "source_data": "shodan",
+                },
+            ))
+
+        if vulns:
+            shown = ", ".join(vulns[:_MAX_CVES_IN_DESC])
+            overflow = "" if len(vulns) <= _MAX_CVES_IN_DESC else f" (+{len(vulns) - _MAX_CVES_IN_DESC} more)"
+            findings.append(Finding(
+                session=session,
+                source="shodan",
+                check_type="cve",
+                severity="medium",
+                target=ip,
+                title=f"{len(vulns)} known CVE(s) on exposed host {ip} (via Shodan)",
+                description=(
+                    "Shodan associates the following publicly known CVEs with the "
+                    f"services exposed on {ip}. These are derived from Shodan's banner "
+                    f"data and may need version confirmation:\n  {shown}{overflow}"
+                ),
+                remediation=(
+                    "Verify the affected service versions and patch. Cross-check against "
+                    "the active nmap scan, and prioritise using the EPSS/KEV enrichment "
+                    "applied to this finding."
+                ),
+                extra={
+                    "ip": ip,
+                    "cve_ids": vulns,
+                    "shodan_tier": tier,
+                    "source_data": "shodan",
+                },
+            ))
+
+    return findings

--- a/apps/shodan/apps.py
+++ b/apps/shodan/apps.py
@@ -1,0 +1,21 @@
+from django.apps import AppConfig
+
+
+class ShodanConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.shodan"
+    label = "shodan"
+    verbose_name = "Shodan Exposure Intelligence"
+    tool_meta = {
+        "label": "Shodan Exposure (passive)",
+        "runner": "apps.shodan.scanner.run_shodan",
+        "phase": 5,
+        "phase_group": "Port Discovery",
+        "requires": [],
+        "produces_findings": True,
+        # Passive: reads Shodan's own internet-wide scan dataset (InternetDB, or
+        # the host API when a key is set). Sends ZERO packets to the target's own
+        # systems — no DomainAuthorization needed. BYOK is optional: no key falls
+        # back to the free InternetDB endpoint, so the tool always adds value.
+        "active": False,
+    }

--- a/apps/shodan/collector.py
+++ b/apps/shodan/collector.py
@@ -1,0 +1,185 @@
+"""Shodan passive-exposure collector — two-tier, bring-your-own-key.
+
+Queries Shodan's own internet-wide scan dataset for the session's resolved public
+IPs. Sends ZERO packets to the target — this is third-party data, so it works in
+passive mode with no authorization.
+
+Two tiers, chosen automatically by whether a key is configured:
+
+  * FREE (default, no key): Shodan InternetDB — ``https://internetdb.shodan.io/{ip}``.
+    Returns open ports, CPEs, and known CVE ids per IP. No credits, no key. Every
+    Docker deployment gets this out of the box.
+  * ENHANCED (``SHODAN_API_KEY`` set): the full host API —
+    ``https://api.shodan.io/shodan/host/{ip}`` — which adds service banners,
+    product/version, and tags on top of ports + CVEs. Capped by ``SHODAN_MAX_IPS``
+    to protect the paid plan's query credits.
+
+Design contract (mirrors apps/hudson_rock — additive intelligence):
+  * FAIL-GRACEFUL, ALWAYS. Any timeout / non-200 / exhausted 429 / JSON error on
+    an IP is logged and skipped; the collector never raises. There is no binary,
+    so it does NOT raise ToolBinaryMissing / ToolTimeout.
+  * Sends the honest OpenEASD User-Agent.
+  * A 404 from Shodan means "no data for this IP" — normal, not an error.
+"""
+
+import logging
+import time
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 10  # seconds, per call
+_MAX_RETRIES = 2  # extra attempts after a 429
+_DEFAULT_BACKOFF = 2  # seconds, when no Retry-After header
+_MAX_BACKOFF = 10  # cap the honoured Retry-After so we never stall a scan
+
+_INTERNETDB_URL = "https://internetdb.shodan.io"
+_HOST_API_URL = "https://api.shodan.io/shodan/host"
+_DEFAULT_MAX_IPS = 50  # paid-tier query-credit guard
+
+
+def _user_agent() -> str:
+    return getattr(settings, "OPENEASD_USER_AGENT", "OpenEASD/1.0")
+
+
+def _get_json(url: str, params: dict | None = None):
+    """GET a Shodan endpoint. Returns parsed JSON, {} on 404 (no data), or None
+    on any failure. Never raises. Honours 429 / Retry-After with capped backoff.
+    """
+    headers = {"User-Agent": _user_agent(), "Accept": "application/json"}
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=REQUEST_TIMEOUT)
+        except requests.RequestException as exc:
+            logger.warning("shodan: request to %s failed: %s", url, exc)
+            return None
+
+        if resp.status_code == 429:
+            if attempt >= _MAX_RETRIES:
+                logger.warning("shodan: %s rate-limited (429), retries exhausted", url)
+                return None
+            backoff = _DEFAULT_BACKOFF
+            retry_after = resp.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    backoff = min(int(retry_after), _MAX_BACKOFF)
+                except (ValueError, TypeError):
+                    backoff = _DEFAULT_BACKOFF
+            time.sleep(backoff)
+            continue
+
+        if resp.status_code == 404:
+            return {}  # Shodan has no record for this IP — normal.
+
+        if resp.status_code != 200:
+            logger.warning("shodan: %s returned HTTP %s", url, resp.status_code)
+            return None
+
+        try:
+            return resp.json()
+        except ValueError as exc:
+            logger.warning("shodan: %s returned non-JSON body: %s", url, exc)
+            return None
+
+    return None
+
+
+def _session_ips(session) -> list[str]:
+    """Distinct resolved public IPs for the session (dnsx already filtered these
+    to public-only). Sorted for deterministic ordering / capping."""
+    from apps.core.assets.models import IPAddress
+
+    ips = IPAddress.objects.filter(session=session).values_list("address", flat=True)
+    return sorted({ip for ip in ips if ip})
+
+
+def _normalize_internetdb(ip: str, d: dict) -> dict:
+    """Shape an InternetDB response into the common host record."""
+    return {
+        "ip": ip,
+        "tier": "internetdb",
+        "ports": sorted({p for p in (d.get("ports") or []) if isinstance(p, int)}),
+        "cpes": [c for c in (d.get("cpes") or []) if isinstance(c, str)],
+        "hostnames": [h for h in (d.get("hostnames") or []) if isinstance(h, str)],
+        "tags": [t for t in (d.get("tags") or []) if isinstance(t, str)],
+        "vulns": sorted({v for v in (d.get("vulns") or []) if isinstance(v, str)}),
+        "services": [],  # InternetDB carries no banner detail
+    }
+
+
+def _normalize_host(ip: str, d: dict) -> dict:
+    """Shape a full host-API response into the common host record."""
+    services = []
+    for item in (d.get("data") or []):
+        if not isinstance(item, dict):
+            continue
+        services.append({
+            "port": item.get("port"),
+            "product": (item.get("product") or "").strip(),
+            "version": (item.get("version") or "").strip(),
+            "transport": (item.get("transport") or "").strip(),
+        })
+    # The host API's top-level `vulns` may be a dict {cve: {...}} or a list.
+    vulns = d.get("vulns")
+    if isinstance(vulns, dict):
+        vulns = list(vulns.keys())
+    return {
+        "ip": ip,
+        "tier": "host",
+        "ports": sorted({p for p in (d.get("ports") or []) if isinstance(p, int)}),
+        "cpes": [c for c in (d.get("cpes") or []) if isinstance(c, str)],
+        "hostnames": [h for h in (d.get("hostnames") or []) if isinstance(h, str)],
+        "tags": [t for t in (d.get("tags") or []) if isinstance(t, str)],
+        "vulns": sorted({v for v in (vulns or []) if isinstance(v, str)}),
+        "services": services,
+    }
+
+
+def collect(session) -> list[dict]:
+    """Query Shodan for every resolved public IP in the session.
+
+    Returns a list of normalized host records (only IPs Shodan has data for).
+    Always returns a list; never raises.
+    """
+    ips = _session_ips(session)
+    if not ips:
+        logger.info("[shodan:%s] no resolved public IPs — skipping", session.id)
+        return []
+
+    key = getattr(settings, "SHODAN_API_KEY", "")
+    results: list[dict] = []
+
+    if key:
+        cap = getattr(settings, "SHODAN_MAX_IPS", _DEFAULT_MAX_IPS)
+        if cap and len(ips) > cap:
+            logger.warning(
+                "[shodan:%s] capping %d IPs to %d for the paid host API "
+                "(SHODAN_MAX_IPS); %d IP(s) not queried this run",
+                session.id, len(ips), cap, len(ips) - cap,
+            )
+            ips = ips[:cap]
+        for ip in ips:
+            data = _get_json(f"{_HOST_API_URL}/{ip}", params={"key": key})
+            if data:
+                results.append(_normalize_host(ip, data))
+        tier = "host API (keyed)"
+    else:
+        # Free InternetDB path — no key, no credits. The upgrade prompt is a
+        # one-time info log so keyless operators know richer output is available.
+        logger.info(
+            "[shodan:%s] no SHODAN_API_KEY set — using the free InternetDB tier "
+            "(set a key for service banners + versions)", session.id,
+        )
+        for ip in ips:
+            data = _get_json(f"{_INTERNETDB_URL}/{ip}")
+            if data:
+                results.append(_normalize_internetdb(ip, data))
+        tier = "InternetDB (free)"
+
+    logger.info(
+        "[shodan:%s] queried %d IP(s) via %s — %d with exposure data",
+        session.id, len(ips), tier, len(results),
+    )
+    return results

--- a/apps/shodan/models.py
+++ b/apps/shodan/models.py
@@ -1,0 +1,2 @@
+# Shodan writes to the shared apps/core/assets/ and apps/core/findings/ models.
+# No tool-specific models — see analyzer.py for the Finding shapes produced.

--- a/apps/shodan/scanner.py
+++ b/apps/shodan/scanner.py
@@ -1,0 +1,32 @@
+"""Shodan scanner — thin orchestrator: collect -> analyze -> save.
+
+Passive additive intelligence. Any failure inside collect/analyze is swallowed
+and the scan continues with zero findings — this tool must never fail a scan.
+"""
+
+import logging
+
+from apps.core.findings.models import Finding
+
+from .analyzer import analyze
+from .collector import collect
+
+logger = logging.getLogger(__name__)
+
+
+def run_shodan(session) -> list[Finding]:
+    try:
+        results = collect(session)
+        findings = analyze(session, results)
+    except Exception:  # noqa: BLE001 — never let this tool fail a scan
+        logger.exception("[shodan:%s] unexpected error — skipping", session.id)
+        return []
+
+    if not findings:
+        logger.info("[shodan:%s] no Shodan exposure data — nothing to save", session.id)
+        return []
+
+    Finding.objects.bulk_create(findings, ignore_conflicts=True)
+    saved = list(Finding.objects.filter(session=session, source="shodan"))
+    logger.info("[shodan:%s] saved %d Shodan finding(s)", session.id, len(saved))
+    return saved

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -124,6 +124,7 @@ INSTALLED_APPS = [
     "apps.nuclei_network",
     "apps.web_checker",
     "apps.js_secrets",
+    "apps.shodan",
     "apps.cve_intel",
 ]
 
@@ -298,6 +299,16 @@ TOOL_AMASS = config("TOOL_AMASS", default="amass")
 TOOL_ALTERX = config("TOOL_ALTERX", default="alterx")
 TOOL_CLOUD_ENUM = config("TOOL_CLOUD_ENUM", default="cloud_enum")
 TOOL_GITLEAKS = config("TOOL_GITLEAKS", default="gitleaks")
+
+# Shodan passive-exposure tool (apps/shodan). BYOK: with no key it uses Shodan's
+# FREE InternetDB endpoint (ports + CVEs, no credits) — so the tool always adds
+# value out of the box. Set SHODAN_API_KEY (per-deployment secret, NEVER baked
+# into the public image — that would leak the key and breach Shodan's ToS) to
+# upgrade to the full host API (service banners + versions). SHODAN_MAX_IPS caps
+# the paid path's per-scan queries to protect the plan's credit quota (the free
+# InternetDB path is uncapped — it costs no credits).
+SHODAN_API_KEY = config("SHODAN_API_KEY", default="")
+SHODAN_MAX_IPS = config("SHODAN_MAX_IPS", default=50, cast=int)
 
 # Honest scanner identity. Sent as the User-Agent on the tools that probe the
 # target's web surface (httpx, katana, nuclei) so a customer can deliberately

--- a/tests/unit/test_shodan.py
+++ b/tests/unit/test_shodan.py
@@ -1,0 +1,225 @@
+"""Unit tests for apps/shodan — collector (both tiers), analyzer, scanner.
+
+Shodan is a passive, BYOK exposure tool: with no key it uses the free InternetDB
+endpoint; with SHODAN_API_KEY it uses the full host API. It must be fail-graceful
+(never raise), and its CVE findings must carry extra["cve_ids"] so cve_intel
+enriches them.
+"""
+
+import requests
+import pytest
+from unittest.mock import MagicMock, patch
+
+from apps.shodan.analyzer import analyze
+from apps.shodan.collector import collect
+from apps.shodan.scanner import run_shodan
+
+
+def _session():
+    from apps.core.scans.models import ScanSession
+    return ScanSession.objects.create(domain="example.com", scan_type="full")
+
+
+def _add_ips(session, *addrs):
+    from apps.core.assets.models import IPAddress
+    for a in addrs:
+        IPAddress.objects.create(session=session, address=a, version=4)
+
+
+def _resp(status=200, json_body=None, headers=None):
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    r.json.return_value = json_body if json_body is not None else {}
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Collector — tier selection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestShodanCollectorTiers:
+    def test_no_ips_returns_empty(self, settings):
+        settings.SHODAN_API_KEY = ""
+        assert collect(_session()) == []
+
+    def test_free_tier_used_when_no_key(self, settings):
+        settings.SHODAN_API_KEY = ""
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        body = {"ip": "1.2.3.4", "ports": [22, 443], "cpes": [], "hostnames": [],
+                "tags": [], "vulns": ["CVE-2021-1234"]}
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(json_body=body)) as g:
+            results = collect(sess)
+        assert "internetdb.shodan.io" in g.call_args[0][0]
+        assert results[0]["tier"] == "internetdb"
+        assert results[0]["ports"] == [22, 443]
+        assert results[0]["vulns"] == ["CVE-2021-1234"]
+
+    def test_paid_tier_used_when_key_set(self, settings):
+        settings.SHODAN_API_KEY = "testkey"
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        body = {"ip_str": "1.2.3.4", "ports": [443],
+                "data": [{"port": 443, "product": "nginx", "version": "1.18", "transport": "tcp"}],
+                "vulns": ["CVE-2021-1234"], "cpes": [], "hostnames": [], "tags": []}
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(json_body=body)) as g:
+            results = collect(sess)
+        assert "api.shodan.io/shodan/host" in g.call_args[0][0]
+        assert g.call_args.kwargs["params"]["key"] == "testkey"
+        assert results[0]["tier"] == "host"
+        assert results[0]["services"][0]["product"] == "nginx"
+
+    def test_paid_tier_caps_ips(self, settings):
+        settings.SHODAN_API_KEY = "testkey"
+        settings.SHODAN_MAX_IPS = 2
+        sess = _session()
+        _add_ips(sess, "1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4")
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(json_body={})) as g:
+            collect(sess)
+        assert g.call_count == 2  # capped at SHODAN_MAX_IPS
+
+    def test_free_tier_not_capped(self, settings):
+        settings.SHODAN_API_KEY = ""
+        settings.SHODAN_MAX_IPS = 2  # cap must NOT apply to the free path
+        sess = _session()
+        _add_ips(sess, "1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4")
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(json_body={})) as g:
+            collect(sess)
+        assert g.call_count == 4
+
+    def test_host_api_vulns_dict_form(self, settings):
+        settings.SHODAN_API_KEY = "k"
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        body = {"ports": [80], "data": [], "vulns": {"CVE-2020-1": {}, "CVE-2020-2": {}}}
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(json_body=body)):
+            results = collect(sess)
+        assert set(results[0]["vulns"]) == {"CVE-2020-1", "CVE-2020-2"}
+
+
+# ---------------------------------------------------------------------------
+# Collector — fail-graceful contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestShodanCollectorFailGraceful:
+    def test_404_is_skipped_not_error(self, settings):
+        settings.SHODAN_API_KEY = ""
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(status=404)):
+            assert collect(sess) == []  # no data, no crash
+
+    def test_request_exception_skipped(self, settings):
+        settings.SHODAN_API_KEY = ""
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        with patch("apps.shodan.collector.requests.get",
+                   side_effect=requests.RequestException("boom")):
+            assert collect(sess) == []  # must NOT raise
+
+    def test_non_200_skipped(self, settings):
+        settings.SHODAN_API_KEY = ""
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(status=500)):
+            assert collect(sess) == []
+
+    def test_429_retries_then_gives_up(self, settings):
+        settings.SHODAN_API_KEY = ""
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        with patch("apps.shodan.collector.requests.get", return_value=_resp(status=429, headers={"Retry-After": "0"})), \
+             patch("apps.shodan.collector.time.sleep"):
+            assert collect(sess) == []  # exhausts retries, returns empty, no raise
+
+    def test_bad_json_skipped(self, settings):
+        settings.SHODAN_API_KEY = ""
+        sess = _session()
+        _add_ips(sess, "1.2.3.4")
+        r = _resp(status=200)
+        r.json.side_effect = ValueError("not json")
+        with patch("apps.shodan.collector.requests.get", return_value=r):
+            assert collect(sess) == []
+
+
+# ---------------------------------------------------------------------------
+# Analyzer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestShodanAnalyzer:
+    def test_builds_exposure_finding(self):
+        sess = _session()
+        results = [{"ip": "1.2.3.4", "tier": "internetdb", "ports": [22, 443],
+                    "services": [], "vulns": [], "hostnames": [], "tags": []}]
+        findings = analyze(sess, results)
+        exp = [f for f in findings if f.check_type == "shodan_exposure"]
+        assert len(exp) == 1
+        assert exp[0].source == "shodan"
+        assert exp[0].target == "1.2.3.4"
+        assert exp[0].extra["ports"] == [22, 443]
+
+    def test_cve_finding_carries_cve_ids_for_enrichment(self):
+        sess = _session()
+        results = [{"ip": "1.2.3.4", "tier": "internetdb", "ports": [443],
+                    "services": [], "vulns": ["CVE-2021-1", "CVE-2021-2"],
+                    "hostnames": [], "tags": []}]
+        findings = analyze(sess, results)
+        cve = [f for f in findings if f.check_type == "cve"]
+        assert len(cve) == 1
+        # cve_intel enriches via extra["cve_ids"] — this MUST be present.
+        assert cve[0].extra["cve_ids"] == ["CVE-2021-1", "CVE-2021-2"]
+        assert cve[0].severity == "medium"
+
+    def test_no_finding_when_no_ports_and_no_vulns(self):
+        sess = _session()
+        results = [{"ip": "1.2.3.4", "tier": "internetdb", "ports": [],
+                    "services": [], "vulns": [], "hostnames": [], "tags": []}]
+        assert analyze(sess, results) == []
+
+    def test_invalid_cves_filtered(self):
+        sess = _session()
+        results = [{"ip": "1.2.3.4", "tier": "internetdb", "ports": [80],
+                    "services": [], "vulns": ["CVE-2021-1", "not-a-cve", ""],
+                    "hostnames": [], "tags": []}]
+        cve = [f for f in analyze(sess, results) if f.check_type == "cve"]
+        assert cve[0].extra["cve_ids"] == ["CVE-2021-1"]
+
+    def test_skips_non_dict_and_ipless_records(self):
+        sess = _session()
+        results = ["junk", {"tier": "internetdb", "ports": [80]}]  # no ip
+        assert analyze(sess, results) == []
+
+    def test_empty_results(self):
+        assert analyze(_session(), []) == []
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestShodanScanner:
+    def test_saves_findings(self):
+        from apps.core.findings.models import Finding
+        sess = _session()
+        with patch("apps.shodan.scanner.collect", return_value=[
+            {"ip": "1.2.3.4", "tier": "internetdb", "ports": [443],
+             "services": [], "vulns": ["CVE-2021-1"], "hostnames": [], "tags": []},
+        ]):
+            saved = run_shodan(sess)
+        assert len(saved) == 2  # exposure + cve
+        assert Finding.objects.filter(session=sess, source="shodan").count() == 2
+
+    def test_empty_when_no_data(self):
+        sess = _session()
+        with patch("apps.shodan.scanner.collect", return_value=[]):
+            assert run_shodan(sess) == []
+
+    def test_never_raises_on_collect_error(self):
+        sess = _session()
+        with patch("apps.shodan.scanner.collect", side_effect=RuntimeError("boom")):
+            assert run_shodan(sess) == []  # swallowed — must never fail a scan

--- a/tests/unit/test_shodan.py
+++ b/tests/unit/test_shodan.py
@@ -52,7 +52,7 @@ class TestShodanCollectorTiers:
                 "tags": [], "vulns": ["CVE-2021-1234"]}
         with patch("apps.shodan.collector.requests.get", return_value=_resp(json_body=body)) as g:
             results = collect(sess)
-        assert "internetdb.shodan.io" in g.call_args[0][0]
+        assert g.call_args[0][0].startswith("https://internetdb.shodan.io/")
         assert results[0]["tier"] == "internetdb"
         assert results[0]["ports"] == [22, 443]
         assert results[0]["vulns"] == ["CVE-2021-1234"]
@@ -66,7 +66,7 @@ class TestShodanCollectorTiers:
                 "vulns": ["CVE-2021-1234"], "cpes": [], "hostnames": [], "tags": []}
         with patch("apps.shodan.collector.requests.get", return_value=_resp(json_body=body)) as g:
             results = collect(sess)
-        assert "api.shodan.io/shodan/host" in g.call_args[0][0]
+        assert g.call_args[0][0].startswith("https://api.shodan.io/shodan/host/")
         assert g.call_args.kwargs["params"]["key"] == "testkey"
         assert results[0]["tier"] == "host"
         assert results[0]["services"][0]["product"] == "nginx"


### PR DESCRIPTION
## What
New passive tool `apps/shodan` — reads Shodan's own internet-wide scan dataset for each resolved public IP and reports exposed **ports/services + known CVEs**, without sending a packet to the target (`active=False`, no `DomainAuthorization`).

**Two-tier, bring-your-own-key:**
- **Free tier (default, zero config):** Shodan **InternetDB** — ports/CPEs/CVEs, no key, no credits. Every Docker deployment gets value out of the box.
- **Enhanced tier:** `SHODAN_API_KEY` → full host API (banners + versions + tags). `SHODAN_MAX_IPS` (default 50) caps the paid path to protect plan credits; the free path is uncapped.

## Why
Completes the "what's already publicly visible about you" picture the passive report is built on. It's the passive/external counterpart to nmap: it works in **Passive Scan** mode (no auth) where nmap can't, and sees exposure from an outside vantage when a target blocks our scanner. **Not a duplicate of nmap** — different method (passive/external vs active/first-hand), different failure mode.

- Key is a per-deployment secret, **never in the image** (would leak it + breach Shodan ToS); keyless users get the free tier.
- CVE ids stored in `extra["cve_ids"]` → the existing `cve_intel` phase enriches them with **EPSS + CISA KEV** → a Shodan-surfaced KEV CVE is exactly the "worth a pentest" signal.
- In default **Full Scan + Passive Scan** (migration `0025`); fail-graceful like `hudson_rock`.

## Coverage
- 20 unit tests (tier selection, `SHODAN_MAX_IPS` cap on paid path only, fail-graceful 404/timeout/500/429/bad-JSON, analyzer findings + `cve_ids` enrichment path).
- Adds `shodan_exposure` to the report CWE map (satisfies the new emitted-check_type guard test).
- Docs: README + CLAUDE.md tables/pipeline/passive-list (22→23), CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)