### PR TITLE
test: regression test + collector guard for takeover_check null records

### DIFF
--- a/apps/takeover_check/collector.py
+++ b/apps/takeover_check/collector.py
@@ -103,7 +103,12 @@ def collect(subdomains: list[str]) -> list[dict]:
             logger.warning("subzy output not valid JSON: %s", e)
             return []
 
-        records = data if isinstance(data, list) else [data]
+        # subzy occasionally emits a JSON array containing a null element; filter
+        # to dicts so a None can never reach the analyzer (which crashed on
+        # record.get() — the bug that flipped scans to `partial`). The analyzer
+        # guards this too (defence in depth).
+        raw_records = data if isinstance(data, list) else [data]
+        records = [r for r in raw_records if isinstance(r, dict)]
         logger.info("subzy returned %d records", len(records))
         return records
 

--- a/docs/SCAN_OPERATIONAL_LEARNINGS.md
+++ b/docs/SCAN_OPERATIONAL_LEARNINGS.md
@@ -55,7 +55,12 @@ small hosts, (4) reasonably fresh templates (image rebuild cadence).
   `test_takeover_check.py`.
 - **Parsers crash on real (not curated) output**: nuclei/nuclei_network on
   `info: null`, katana on non-dict `request`, domain_security RDAP on missing
-  `eventAction`. All guarded by adversarial parser tests.
+  `eventAction`, **takeover_check/subzy on a `null` element in its JSON array**
+  (`None.get()` → whole scan flipped to `partial`, hiding real takeover findings;
+  a live scanme.nmap.org run exposed it). All guarded by adversarial parser tests.
+  takeover_check is now guarded at BOTH layers — the collector filters non-dicts
+  and the analyzer skips them (#292 + follow-up). Guard:
+  `test_takeover_check.py::TestSubzyNullRecordRegression`.
 - **Target blocking is silent**: a blocked scan returns fewer findings but read
   as clean. Now: `endpoints_probed` vs reached counting + a coverage-regression
   finding + `partial` status. Guards: `test_coverage_regression.py`.

--- a/tests/unit/test_takeover_check.py
+++ b/tests/unit/test_takeover_check.py
@@ -306,3 +306,41 @@ class TestScanner:
 
         with patch("apps.takeover_check.scanner.collect", return_value=[]):
             assert run_takeover_check(sess) == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: subzy null / non-dict array elements (scan went `partial` when a
+# subzy JSON array carried a null element → analyzer crashed on None.get()).
+# Fixed in #292 (analyzer guard) + collector filter (defence in depth). Guarded
+# here so it can't come back. See docs/SCAN_OPERATIONAL_LEARNINGS.md.
+# ---------------------------------------------------------------------------
+
+class TestSubzyNullRecordRegression:
+    @patch("apps.takeover_check.collector.shutil.which", return_value="/usr/local/bin/subzy")
+    @patch("apps.takeover_check.collector.subprocess.run")
+    def test_collector_filters_null_and_non_dict_array_elements(self, mock_run, _which):
+        def fake_run(cmd, **kwargs):
+            with open(cmd[cmd.index("--output") + 1], "w") as f:
+                json.dump(
+                    [{"subdomain": "vuln.example.com", "vulnerable": True}, None, "junk"],
+                    f,
+                )
+            return MagicMock(returncode=0, stderr="")
+
+        mock_run.side_effect = fake_run
+        records = collect(["vuln.example.com"])
+        assert all(isinstance(r, dict) for r in records)
+        assert len(records) == 1  # the None and the string are filtered out
+
+    @pytest.mark.django_db
+    def test_analyzer_skips_null_and_non_dict_records(self):
+        """analyze() must skip non-dict records instead of crashing on
+        None.get() — the exact failure that made scans report `partial`."""
+        from apps.core.scans.models import ScanSession
+        sess = ScanSession.objects.create(domain="example.com", scan_type="full")
+        # A None + a bare string mixed with a valid, non-vulnerable dict.
+        result = analyze(
+            sess,
+            [None, "junk", {"subdomain": "x.example.com", "vulnerable": False}],
+        )
+        assert result == []  # no raise, non-dicts skipped


### PR DESCRIPTION
## What
Follow-up to #292 (Vennela's analyzer guard for subzy null records). That fix was correct but shipped without a regression test — so green CI never exercised the null path.

Adds:
- **`TestSubzyNullRecordRegression`** — collector filters null/non-dict array elements; analyzer skips them without raising.
- **Defence in depth**: `collector.py` now filters non-dicts too (a `None` never reaches the analyzer); the analyzer guard from #292 stays as backstop.
- `SCAN_OPERATIONAL_LEARNINGS.md` updated.

## Why
Root cause was found by diagnosing a real **scanme.nmap.org Partial** scan: subzy emitted a JSON array with a `null` element → `None.get()` → the whole scan flipped to `partial`, hiding real takeover findings. Per our rule, every real scan problem becomes a regression test + learning.

39 tests pass in `test_takeover_check.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)