### PR TITLE
docs: add THIRD_PARTY_NOTICES + attribution, drop unlicensed waybackurls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Third-party licensing hygiene (attribution + notices).** Added a
+  `THIRD_PARTY_NOTICES.md` covering every bundled binary and data source: MIT
+  notices (ProjectDiscovery ×7, nuclei-templates, gitleaks, gau, cloud_enum),
+  the **Apache-2.0 NOTICE for amass** (was missing), a **GPL-2.0 source offer for
+  subzy**, the **NPSL "uses Nmap Security Scanner" notice**, and EPSS/CISA-KEV/
+  Hudson-Rock/Shodan data-source attributions. Added the EPSS + KEV + Hudson Rock
+  citation to the PDF report's Methodology section. **Why:** the Docker image
+  redistributes these binaries, so their licenses require the notices; this closes
+  the gap flagged by a dependency licence/ToS audit. No license purchase is
+  required for OpenEASD's free/non-commercial use.
+- **Documented Shodan InternetDB's non-commercial restriction** (settings +
+  notices): a *paid* product built on OpenEASD must supply its own Shodan key
+  rather than rely on the free keyless InternetDB tier.
+
+### Removed
+- **Dropped `waybackurls`** from the historical-URL collector and the Docker image.
+  It ships without a declared license (redistribution-ambiguous), and `gau` — which
+  we already run — is a strict superset of its one source (the Wayback Machine),
+  also covering Common Crawl, AlienVault OTX, and URLScan. Zero coverage loss.
+
 ### Added
 - **Exposure Score + trend — one 0–100 executive risk number per scan.** Each
   completed scan now gets a single saturating, severity-weighted score

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,7 +416,7 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 | `apps/ssh_checker/` | 7 | Network Exposure | Yes | SSH config analysis |
 | `apps/nuclei_network/` | 7 | Network Exposure | Yes | Network protocol vuln scan (319 templates, non-web) |
 | `apps/httpx/` | 8 | Web Exposure | No | Web probing, URL discovery, technology fingerprinting (`-tech-detect` → `URL.technologies`) |
-| `apps/historical_urls/` | 9 | Web Exposure | No | Historical URL discovery via gau + waybackurls (Wayback Machine, OTX, Common Crawl) |
+| `apps/historical_urls/` | 9 | Web Exposure | No | Historical URL discovery via gau (Wayback Machine, OTX, Common Crawl, URLScan) |
 | `apps/katana/` | 10 | Web Exposure | No | Web crawling, endpoint discovery |
 | `apps/nuclei/` | 11 | Web Exposure | Yes | Web vuln scan (community templates) |
 | `apps/web_checker/` | 11 | Web Exposure | Yes | Security headers, cookies, CORS |
@@ -460,7 +460,7 @@ Phase 7  tls_checker        → Finding (cipher/cert/protocol on all ports)    �
 Phase 7  ssh_checker        → Finding (SSH config on service="ssh" ports)    │
 Phase 7  nuclei_network     → Finding (network protocol vulns, non-web ports)┘
 Phase 8  httpx              → URL (web probing, CDN-aware via SNI)
-Phase 9  historical_urls    → URL (gau + waybackurls — archived endpoints)
+Phase 9  historical_urls    → URL (gau — archived endpoints)
 Phase 10 katana             → URL (web crawling, endpoint discovery)
 Phase 11 nuclei             → Finding (web vulns via templates on URLs)
 Phase 11 web_checker        → Finding (headers, cookies, CORS on URLs)

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,22 +99,21 @@ RUN go install -ldflags="-s -w" github.com/PentestPad/subzy@${SUBZY_VERSION} \
        fi
 
 # ---------------------------------------------------------------------------
-# Stage 2c: build gau + waybackurls from source (pure-Go, cross-compiles cleanly).
+# Stage 2c: build gau from source (pure-Go, cross-compiles cleanly).
+# (waybackurls was dropped — it ships without a declared license, and gau already
+# covers its one source, the Wayback Machine, plus Common Crawl / OTX / URLScan.)
 # ---------------------------------------------------------------------------
 FROM --platform=$BUILDPLATFORM golang:1.27 AS history-builder
 
 ARG TARGETOS
 ARG TARGETARCH
 ARG GAU_VERSION=v2.2.4
-ARG WAYBACKURLS_VERSION=v0.1.0
 
 ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH
 
 RUN go install github.com/lc/gau/v2/cmd/gau@${GAU_VERSION} \
-    && go install github.com/tomnomnom/waybackurls@${WAYBACKURLS_VERSION} \
     && mkdir -p /history-tools \
-    && (mv /go/bin/${TARGETOS}_${TARGETARCH}/gau /history-tools/ 2>/dev/null || mv /go/bin/gau /history-tools/) \
-    && (mv /go/bin/${TARGETOS}_${TARGETARCH}/waybackurls /history-tools/ 2>/dev/null || mv /go/bin/waybackurls /history-tools/)
+    && (mv /go/bin/${TARGETOS}_${TARGETARCH}/gau /history-tools/ 2>/dev/null || mv /go/bin/gau /history-tools/)
 
 # ---------------------------------------------------------------------------
 # Stage 3: runtime

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Use it as a **red teamer** to map external surface fast on targets you're authorised to test. Use it as a **defender** to see what's leaking out of your own infrastructure: subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs, without paying $500-5000/mo for a commercial EASM platform.
 
-OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `waybackurls`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-three tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, infostealer-log exposure (via Hudson Rock's keyless Cavalier API), Shodan-sourced exposure (passive; free InternetDB tier out of the box, richer with a bring-your-own Shodan key), technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
+OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-three tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, infostealer-log exposure (via Hudson Rock's keyless Cavalier API), Shodan-sourced exposure (passive; free InternetDB tier out of the box, richer with a bring-your-own Shodan key), technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
 
 Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [Cybersecify](https://cybersecify.com), the same tool we run in engagements and on our own infrastructure.
 
@@ -47,7 +47,6 @@ its maintainer's official source. No repackaging, no mirroring:
 | `amass` | [github.com/owasp-amass/amass](https://github.com/owasp-amass/amass) (OWASP) |
 | `subzy` | [github.com/PentestPad/subzy](https://github.com/PentestPad/subzy) (Go modules) |
 | `gau` | [github.com/lc/gau](https://github.com/lc/gau) (Go modules) |
-| `waybackurls` | [github.com/tomnomnom/waybackurls](https://github.com/tomnomnom/waybackurls) (Go modules) |
 | `cloud_enum` | [github.com/initstring/cloud_enum](https://github.com/initstring/cloud_enum) |
 | `gitleaks` | [github.com/gitleaks/gitleaks](https://github.com/gitleaks/gitleaks) (MIT, signed releases) |
 | `nmap` | `apt-get install nmap` (Ubuntu 24.04 official) |
@@ -215,7 +214,7 @@ Phase 7  Nuclei Network    - Network protocol vuln templates (non-web ports)
 
 ── Web Exposure ─────────────────────────────────────────────────────────────
 Phase 8  httpx             - Web probing, URL discovery, technology fingerprinting
-Phase 9  Historical URLs   - Archived URL discovery via gau + waybackurls
+Phase 9  Historical URLs   - Archived URL discovery via gau
 Phase 10 Katana            - Deep URL crawl on top of httpx
 Phase 11 Nuclei            - Web vulnerability scanning (community templates)
 Phase 11 Web Checker       - Security headers, cookies, CORS analysis
@@ -262,7 +261,7 @@ apps/                   - Tool apps (add/remove freely)
   ssh_checker/          - SSH configuration audit
   nuclei_network/       - Network protocol vuln scanning
   httpx/                - Web probing
-  historical_urls/      - Archived URL discovery (gau + waybackurls)
+  historical_urls/      - Archived URL discovery (gau)
   katana/               - Deep URL crawl
   nuclei/               - Web vulnerability scanning
   web_checker/          - Security headers, cookies, CORS

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,106 @@
+# Third-Party Notices
+
+OpenEASD is distributed under the MIT License (see `LICENSE`). It orchestrates a
+number of independent third-party tools and public data sources. The OpenEASD
+Docker image **bundles** several of these binaries; this file provides the
+attribution and license notices their licenses require when redistributed.
+
+OpenEASD does not modify these tools — it invokes them as separate processes and
+reads their output. Each remains under its own license, reproduced/attributed
+below.
+
+---
+
+## Bundled binaries (redistributed in the Docker image)
+
+### MIT-licensed
+
+The following are used under the MIT License. Copyright remains with their
+respective authors; the MIT permission notice is preserved by reference to each
+project's `LICENSE`.
+
+| Tool | Project | Copyright |
+|---|---|---|
+| subfinder | github.com/projectdiscovery/subfinder | © ProjectDiscovery, Inc. |
+| dnsx | github.com/projectdiscovery/dnsx | © ProjectDiscovery, Inc. |
+| naabu | github.com/projectdiscovery/naabu | © ProjectDiscovery, Inc. |
+| httpx | github.com/projectdiscovery/httpx | © ProjectDiscovery, Inc. |
+| katana | github.com/projectdiscovery/katana | © ProjectDiscovery, Inc. |
+| nuclei | github.com/projectdiscovery/nuclei | © ProjectDiscovery, Inc. |
+| alterx | github.com/projectdiscovery/alterx | © ProjectDiscovery, Inc. |
+| nuclei-templates | github.com/projectdiscovery/nuclei-templates | © ProjectDiscovery, Inc. |
+| gitleaks | github.com/gitleaks/gitleaks | © Zachary Rice |
+| gau | github.com/lc/gau | © Corben Leo |
+| cloud_enum | github.com/initstring/cloud_enum | © initstring |
+
+> The MIT License permits use, copying, modification, and redistribution provided
+> the copyright notice and permission notice are retained. Full text:
+> https://opensource.org/license/mit — and in each project's `LICENSE` file.
+
+### Apache License 2.0
+
+**amass** — github.com/owasp-amass/amass — © OWASP Amass Project / contributors.
+
+Used under the Apache License, Version 2.0 (https://www.apache.org/licenses/LICENSE-2.0).
+Per Apache-2.0 §4, the project's `NOTICE` is preserved: this product includes
+software developed by the OWASP Amass Project and its contributors. No changes are
+made to the amass source; it is invoked as a separate binary.
+
+### GPL-2.0
+
+**subzy** — github.com/PentestPad/subzy — © PentestPad / Emenalo Chibuzo Alexander.
+
+Licensed under the GNU General Public License, version 2 (GPL-2.0). subzy is
+invoked as a **separate process** (subprocess); OpenEASD's own MIT-licensed code
+is not a derivative of subzy (mere aggregation). Because the compiled subzy binary
+is **redistributed** in the Docker image, per GPL-2.0 §3:
+
+> **Written offer for source.** The complete corresponding source code for the
+> subzy binary distributed in this image is available at
+> https://github.com/PentestPad/subzy . On request, the OpenEASD maintainers will
+> provide the corresponding source (or a pointer to it) for the exact version
+> shipped. GPL-2.0 full text: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+
+### Nmap Public Source License (NPSL)
+
+**nmap** — nmap.org — © Nmap Software LLC / Gordon Lyon.
+
+Used under the Nmap Public Source License (https://nmap.org/npsl/). nmap is
+installed from the OS package repository and invoked as a separate binary by the
+`nmap`, `tls_checker`, and `service_detection` tools.
+
+> **This product uses the Nmap Security Scanner (https://nmap.org).**
+>
+> Note for downstream redistributors: the NPSL restricts embedding nmap in
+> **commercial products/services sold for a fee**. Such use may require an Nmap OEM
+> license (https://nmap.org/oem/). OpenEASD's own use is free/non-commercial; if
+> you build a paid product on top of it, review the NPSL and OEM terms yourself.
+
+---
+
+## Third-party data sources / APIs queried at scan time (not bundled)
+
+| Source | Used by | License / terms | Note |
+|---|---|---|---|
+| EPSS (Exploit Prediction Scoring System) | cve_intel | Free, openly published by FIRST.org | See citation below |
+| CISA KEV (Known Exploited Vulnerabilities) | cve_intel | Public domain (U.S. Government work) | No restriction |
+| Certificate Transparency logs / crt.sh | subfinder feeds | Public data | Read-only |
+| Wayback Machine / AlienVault OTX / Common Crawl | historical_urls (via gau) | Each source's own public terms | Read-only, low volume |
+| Cloud storage APIs (AWS S3 / Azure / GCP) | cloud_assets (cloud_enum) | Public provider endpoints | Unauthenticated existence checks |
+| Shodan InternetDB + host API | shodan | See note below | Passive |
+| Hudson Rock Cavalier API | hudson_rock | Free OSINT API, attribution requested | Counts-only; attributed in report |
+
+**EPSS citation:** Exploit Prediction Scoring System (EPSS), FIRST.org —
+https://www.first.org/epss/ . Jacobs, J., Romanosky, S., et al. EPSS data is used
+to prioritize CVE findings.
+
+**Shodan note:** The `shodan` tool defaults to Shodan's **free InternetDB** API,
+which Shodan makes available for **non-commercial use** ("you can use it at a
+company but you can't use it to build commercial products that you charge money
+for"). Operators building a **paid** product on OpenEASD must instead supply their
+own paid Shodan plan via `SHODAN_API_KEY` (which switches to the licensed host
+API) or disable the tool. See https://www.shodan.io/ .
+
+**Hudson Rock:** infostealer-exposure data is provided by Hudson Rock's Cavalier
+API (https://www.hudsonrock.com/), used with attribution and limited to aggregate
+counts (no plaintext credentials are stored).

--- a/apps/core/scans/management/commands/verify_tools.py
+++ b/apps/core/scans/management/commands/verify_tools.py
@@ -97,8 +97,9 @@ TOOL_BINARY_SETTING = {
     "cloud_assets": "TOOL_CLOUD_ENUM",
 }
 
-# historical_urls shells out to two binaries.
-MULTI_BINARY = {"historical_urls": ["TOOL_GAU", "TOOL_WAYBACKURLS"]}
+# historical_urls shells out to gau (waybackurls was dropped — undeclared license,
+# and gau already covers its sources).
+MULTI_BINARY = {"historical_urls": ["TOOL_GAU"]}
 
 # Below this wall-clock (seconds), a completed-but-empty external-tool run is
 # almost certainly a no-op (missing binary / empty input), not real work.

--- a/apps/historical_urls/analyzer.py
+++ b/apps/historical_urls/analyzer.py
@@ -27,8 +27,8 @@ _DEFAULT_PORTS = {"http": 80, "https": 443}
 # Only http(s) URLs are kept. Archive sources (Wayback/OTX/Common Crawl) are
 # third-party-influenceable and can return non-navigable schemes such as
 # ``javascript:`` or ``data:``; storing those risks rendering them as clickable
-# links in the UI (→ XSS / token theft). gau/waybackurls emit essentially only
-# http(s), so this drops no legitimate endpoints.
+# links in the UI (→ XSS / token theft). gau emits essentially only http(s), so
+# this drops no legitimate endpoints.
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 
 

--- a/apps/historical_urls/apps.py
+++ b/apps/historical_urls/apps.py
@@ -5,9 +5,9 @@ class HistoricalUrlsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.historical_urls"
     label = "historical_urls"
-    verbose_name = "Historical URLs (gau + waybackurls)"
+    verbose_name = "Historical URLs (gau)"
     tool_meta = {
-        "label": "Historical URLs (gau + waybackurls)",
+        "label": "Historical URLs (gau)",
         "runner": "apps.historical_urls.scanner.run_historical_urls",
         "phase": 9,
         "phase_group": "Web Exposure",

--- a/apps/historical_urls/collector.py
+++ b/apps/historical_urls/collector.py
@@ -1,11 +1,11 @@
-"""Historical URL collector — runs gau + waybackurls per subdomain.
+"""Historical URL collector — runs gau per subdomain.
 
-Both tools accept a domain as a positional argument and emit one URL per
-line to stdout. Neither needs credentials or special setup beyond being on
-PATH (or configured via TOOL_GAU / TOOL_WAYBACKURLS in settings).
+gau accepts a domain as a positional argument and emits one URL per line to
+stdout. It needs no credentials or special setup beyond being on PATH (or
+configured via TOOL_GAU in settings), and pulls from the Wayback Machine,
+Common Crawl, AlienVault OTX, and URLScan.
 
 gau CLI:       gau <domain>
-waybackurls:   waybackurls <domain>
 """
 
 import logging
@@ -55,9 +55,12 @@ def _run_tool(binary: str, domain: str, timeout: int = _TIMEOUT) -> list[str]:
 
 
 def collect(subdomains: list[str]) -> list[str]:
-    """Run gau + waybackurls against every subdomain; return deduplicated URL strings.
+    """Run gau against every subdomain; return deduplicated URL strings.
 
-    Both tools are optional — if either binary is missing the other still runs.
+    gau pulls from the Wayback Machine, Common Crawl, AlienVault OTX, and URLScan
+    — a superset of what waybackurls covered — so it is the single historical-URL
+    source. (waybackurls was dropped: it ships without a declared license, and gau
+    already covers its one source, the Wayback Machine.)
     """
     if not subdomains:
         return []
@@ -66,12 +69,11 @@ def collect(subdomains: list[str]) -> list[str]:
     results: list[str] = []
 
     for domain in subdomains:
-        for tool_key, default in (("TOOL_GAU", "gau"), ("TOOL_WAYBACKURLS", "waybackurls")):
-            binary = getattr(settings, tool_key, default)
-            for url in _run_tool(binary, domain):
-                if url not in seen:
-                    seen.add(url)
-                    results.append(url)
+        binary = getattr(settings, "TOOL_GAU", "gau")
+        for url in _run_tool(binary, domain):
+            if url not in seen:
+                seen.add(url)
+                results.append(url)
 
     logger.info(
         "[historical_urls] collected %d unique URLs from %d subdomains",

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -291,7 +291,6 @@ TOOL_DNSX = config("TOOL_DNSX", default="dnsx")
 TOOL_NAABU = config("TOOL_NAABU", default="naabu")
 TOOL_HTTPX = config("TOOL_HTTPX", default="httpx")
 TOOL_GAU = config("TOOL_GAU", default="gau")
-TOOL_WAYBACKURLS = config("TOOL_WAYBACKURLS", default="waybackurls")
 TOOL_KATANA = config("TOOL_KATANA", default="katana")
 TOOL_NMAP = config("TOOL_NMAP", default="nmap")
 TOOL_NUCLEI = config("TOOL_NUCLEI", default="nuclei")
@@ -307,6 +306,11 @@ TOOL_GITLEAKS = config("TOOL_GITLEAKS", default="gitleaks")
 # upgrade to the full host API (service banners + versions). SHODAN_MAX_IPS caps
 # the paid path's per-scan queries to protect the plan's credit quota (the free
 # InternetDB path is uncapped — it costs no credits).
+# NOTE ON COMMERCIAL USE: Shodan's free InternetDB is licensed for NON-COMMERCIAL
+# use ("you can use it at a company but you can't use it to build commercial
+# products that you charge money for"). If you build a PAID product/service on
+# OpenEASD, supply your own paid Shodan plan via SHODAN_API_KEY (which switches to
+# the licensed host API) or disable the shodan tool. See THIRD_PARTY_NOTICES.md.
 SHODAN_API_KEY = config("SHODAN_API_KEY", default="")
 SHODAN_MAX_IPS = config("SHODAN_MAX_IPS", default=50, cast=int)
 

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -249,6 +249,7 @@
   </tbody>
 </table>
 <p class="lead" style="font-style:italic;">Every finding is traceable to a specific tool, check type, and target in Detailed Findings. Automated version-to-CVE matching can over-report where a vendor backports fixes without changing the version banner; such matches should be validated against the actual package build.</p>
+<p class="lead" style="font-size:0.85em;color:#868e96;">Exploitation prioritisation uses the Exploit Prediction Scoring System (EPSS) from <strong>FIRST.org</strong> (first.org/epss) and the <strong>CISA</strong> Known Exploited Vulnerabilities catalogue. Infostealer-exposure data is provided by <strong>Hudson Rock</strong> (hudsonrock.com).</p>
 
 {% if workflow_steps %}
 <div class="h2">Scan Step Diagnostics (Partial Scan)</div>

--- a/tests/unit/test_historical_urls.py
+++ b/tests/unit/test_historical_urls.py
@@ -68,29 +68,26 @@ class TestCollect:
         assert collect([]) == []
 
     @patch("apps.historical_urls.collector._run_tool")
-    def test_combines_gau_and_waybackurls(self, mock_run_tool):
-        mock_run_tool.side_effect = [
-            ["https://example.com/from-gau"],
-            ["https://example.com/from-wb"],
+    def test_collects_gau_urls(self, mock_run_tool):
+        mock_run_tool.return_value = [
+            "https://example.com/a", "https://example.com/b",
         ]
         result = collect(["example.com"])
-        assert "https://example.com/from-gau" in result
-        assert "https://example.com/from-wb" in result
+        assert "https://example.com/a" in result
+        assert "https://example.com/b" in result
 
     @patch("apps.historical_urls.collector._run_tool")
-    def test_deduplicates_across_tools(self, mock_run_tool):
-        mock_run_tool.side_effect = [
-            ["https://example.com/page"],
-            ["https://example.com/page"],
-        ]
-        result = collect(["example.com"])
+    def test_deduplicates_across_subdomains(self, mock_run_tool):
+        # gau run against two subdomains returns the same URL → deduped to one.
+        mock_run_tool.return_value = ["https://example.com/page"]
+        result = collect(["a.example.com", "b.example.com"])
         assert result.count("https://example.com/page") == 1
 
     @patch("apps.historical_urls.collector._run_tool")
-    def test_runs_both_tools_per_subdomain(self, mock_run_tool):
+    def test_runs_gau_once_per_subdomain(self, mock_run_tool):
         mock_run_tool.return_value = []
         collect(["a.example.com", "b.example.com"])
-        assert mock_run_tool.call_count == 4
+        assert mock_run_tool.call_count == 2  # gau only, one call per subdomain
 
     @patch("apps.historical_urls.collector._run_tool")
     def test_both_tools_missing_returns_empty(self, mock_run_tool):


### PR DESCRIPTION
## What
Closes the attribution/redistribution gaps from the dependency licence/ToS audit. The public Docker image redistributes third-party binaries, so their licenses require notices.

- **`THIRD_PARTY_NOTICES.md`** — MIT (ProjectDiscovery ×7, nuclei-templates, gitleaks, gau, cloud_enum), **Apache-2.0 NOTICE for amass** (was missing), **GPL-2.0 source offer for subzy**, **NPSL "uses Nmap Security Scanner"** notice, + EPSS/CISA-KEV/Hudson-Rock/Shodan data-source attributions.
- **EPSS + KEV + Hudson Rock citation** added to the PDF report's Methodology section (where scores surface).
- **Shodan InternetDB non-commercial restriction documented** (settings + notices) — a *paid* product must BYO a Shodan key, not use the free keyless tier.
- **Dropped `waybackurls`** (undeclared license) from collector + Dockerfile + settings + verify_tools + docs. `gau` is a strict superset (Wayback + Common Crawl + OTX + URLScan) → zero coverage loss.

## Why
Per the audit: OpenEASD's **free/non-commercial** use needs **no license purchase** (nmap OEM not triggered, Shodan free tier OK non-commercial). What's required is attribution hygiene for the redistributed binaries — this PR does exactly that.

## Tests
- `test_historical_urls` rewritten for gau-only (43 pass), `test_reports`/`test_tools_healthcheck`/`test_management_commands` pass, `manage.py check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)