### PR TITLE
feat: add github_recon passive GitHub org recon tool (tool #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **GitHub Org Recon tool (`github_recon`, tool #25) — passive.** Enumerates the
+  target org's PUBLIC GitHub repos via GitHub's official REST API and surfaces
+  exposed infrastructure references in that public code/config: internal
+  hostnames/subdomains of the target domain, cloud-storage bucket URLs
+  (S3/Azure/GCP), and API endpoints. Emits one `info` summary Finding ("N public
+  repos discovered for org X") plus one `low` `github_infra_exposure` Finding per
+  unique reference (deduped, capped at 200), naming the repo + file it came from.
+  Two-tier BYO-token: unauthenticated works keyless at GitHub's 60 req/hr public
+  limit (we cap total requests + repos to stay under it), a `GITHUB_TOKEN` raises
+  the ceiling to 5000 req/hr. Passive (`active=False`) — it queries GitHub, never
+  the target, so it needs no `DomainAuthorization` and joins both the Full Scan and
+  the no-auth Passive Scan (migration 0027). Fail-graceful throughout: any
+  API/network/JSON error or rate-limit returns empty and never fails a scan.
+  - **Why:** an org's public source is part of its external attack surface, and
+    developers routinely commit internal hostnames, bucket names, and API base URLs
+    into public repos, READMEs, and CI config — recon an attacker would otherwise
+    have to earn. This widens the discovered surface *from source*, complementing
+    the secret-focused `js_secrets`/`github_secrets` tools (this one finds infra
+    exposure, not secrets — and never stores secrets).
+  - **Hypothesis (user-driven):** the highest-signal, lowest-noise GitHub recon for
+    a defender is "which of our own infrastructure did we accidentally publish,"
+    surfaced as aggregate low/info findings rather than a raw grep dump.
+  - **Provenance/ToS:** uses ONLY GitHub's official REST API (no scraping), sends
+    the honest OpenEASD User-Agent, and honours GitHub's documented rate limits
+    (403/429 + `X-RateLimit-*`) with capped backoff. `GITHUB_TOKEN`/`GITHUB_ORG` are
+    per-deployment secrets, never baked into the image.
+
 ### Changed
 - **Third-party licensing hygiene (attribution + notices).** Added a
   `THIRD_PARTY_NOTICES.md` covering every bundled binary and data source: MIT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,7 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 - `get_tool_requires()` — for dependency validation
 - `get_source_choices()` — for finding source filtering
 
-### Tool apps (24 registered tools)
+### Tool apps (25 registered tools)
 
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
@@ -406,6 +406,7 @@ The registry (`apps/core/workflows/registry.py`) auto-discovers all `tool_meta` 
 | `apps/amass/` | 2 | Surface Enumeration | No | Active subdomain enumeration |
 | `apps/asn_discovery/` | 2 | Surface Enumeration | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
 | `apps/alterx/` | 2 | Surface Enumeration | No | Subdomain permutation via alterx (generates candidates from discovered subdomains) |
+| `apps/github_recon/` | 2 | Surface Enumeration | Yes | GitHub Org Recon — enumerates the target org's PUBLIC GitHub repos via GitHub's official REST API and surfaces exposed infra references (internal hostnames/subdomains, cloud-bucket URLs, API endpoints) in that public code/config. Two-tier BYO-token: keyless unauthenticated API (60 req/hr, request-capped) works out of the box, `GITHUB_TOKEN` raises to 5000 req/hr. Complements `js_secrets`/`github_secrets` (secrets) — this finds infra exposure. Passive (queries GitHub, never the target), fail-graceful |
 | `apps/dnsx/` | 3 | Surface Enumeration | No | DNS resolution, public IP filtering |
 | `apps/takeover_check/` | 4 | Surface Enumeration | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
 | `apps/cloud_assets/` | 4 | Surface Enumeration | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
@@ -451,6 +452,7 @@ Phase 2  subfinder          → Subdomain (passive enumeration)
 Phase 2  amass              → Subdomain (active enumeration)
 Phase 2  asn_discovery      → Finding (owned ASN/CIDR ranges via amass intel — informational)
 Phase 2  alterx             → Subdomain (permutation candidates from existing subdomains)
+Phase 2  github_recon       → Finding (infra refs in the org's PUBLIC GitHub repos — passive)
 Phase 3  dnsx               → IPAddress (public-only filter)
 Phase 4  takeover_check     → Finding (subzy — dangling DNS → unclaimed cloud)
 Phase 4  cloud_assets       → Finding (open S3/Azure/GCP buckets — cloud_enum)
@@ -481,7 +483,7 @@ the registry via `get_tool_active()` and `is_passive_tool_set(tools)`.
   `DomainAuthorization`**.
   Passive tools: `subfinder`, `alterx`, `dnsx`, `historical_urls`,
   `cloud_assets`, `cve_intel`, `asn_discovery`, `hudson_rock`, `shodan`,
-  `typosquat`.
+  `typosquat`, `github_recon`.
 - **Active** (`active=True`): probes the target directly (port scans, HTTP/TLS/SSH
   connections, crawling, vuln templates, AXFR/SMTP/mta-sts probes). **Requires
   `DomainAuthorization`.**
@@ -624,6 +626,7 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
 | `tests/unit/test_httpx.py` | 16 | JSON parser, Port lookup, Subdomain link, honest UA, tech-detect flag + technology storage/dedup |
+| `tests/unit/test_github_recon.py` | 39 | Org resolution (domain-derived + `GITHUB_ORG` override), collector (org/user confirm + fallback, repo enumeration/pagination, fork skip, `GITHUB_MAX_REPOS`/`GITHUB_MAX_REQUESTS` caps, config-file base64 decode + size cap, BYO-token auth header + honest UA), fail-graceful (timeout/500/rate-limit-backoff/hard-403/bad-JSON never raise), infra-reference extraction (hostname/api-endpoint/cloud-bucket, apex excluded), analyzer (summary + per-ref low Findings, dedup), scanner never-raises |
 | `tests/unit/test_hudson_rock.py` | 17 | collector (both endpoints keyless + honest UA, fail-graceful on timeout/500/429/bad-JSON, 429 retry), analyzer (severity, counts/families/URLs/attribution, no-finding-when-zero, **no plaintext/email persisted**, URL cap), scanner |
 | `tests/unit/test_shodan.py` | 20 | collector tier selection (free InternetDB vs paid host API, BYO-key), `SHODAN_MAX_IPS` cap on paid path only, fail-graceful (404/timeout/500/429/bad-JSON never raise), analyzer (exposure + CVE findings, `extra["cve_ids"]` for cve_intel enrichment, invalid-CVE filter), scanner |
 | `tests/unit/test_js_secrets.py` | 26 | `.js` URL filter + cap, fetch-error handling, gitleaks JSON parser, analyzer Findings + dedup + secret redaction (full secret never stored), scanner, binary-missing/timeout |
@@ -666,4 +669,4 @@ GET  /api/notifications/alerts/           — alert history
 | `tests/unit/test_coverage_regression.py` | 10 | Silent-block coverage counting (probed-vs-reached), coverage-regression finding (high block ratio / findings drop / stable = no flag), partial scan status when a tool fails |
 | `tests/test_api_endpoints.py` | 104 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 
-**Total: 1437 tests** (1385 fast + 52 slow domain_security)
+**Total: 1481 tests** (1429 fast + 52 slow domain_security)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Use it as a **red teamer** to map external surface fast on targets you're authorised to test. Use it as a **defender** to see what's leaking out of your own infrastructure: subdomains, exposed ports, dangling CNAMEs, missing TLS, known CVEs, without paying $500-5000/mo for a commercial EASM platform.
 
-OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-four tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, infostealer-log exposure (via Hudson Rock's keyless Cavalier API), Shodan-sourced exposure (passive; free InternetDB tier out of the box, richer with a bring-your-own Shodan key), lookalike / typosquat domain detection (passive; phishing infrastructure and brand abuse targeting your domain), technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
+OpenEASD wraps the open-source recon tools security teams already use: `subfinder`, `amass`, `alterx`, `dnsx`, `subzy`, `cloud_enum`, `naabu`, `nmap`, `httpx`, `gau`, `katana`, `nuclei`, `gitleaks`, behind a single web UI with scheduling, alerts, and findings tracking. Twenty-five tools across DNS/DNSSEC, email (SPF/DMARC/DKIM/MTA-STS/open-relay), TLS, SSH, ports, CVEs, subdomain takeover, ASN/IP-range discovery, historical URLs, cloud assets, exposed secrets in JavaScript, public-source infrastructure exposure (passive; internal hostnames, cloud buckets, and API endpoints leaked in the org's public GitHub repos), infostealer-log exposure (via Hudson Rock's keyless Cavalier API), Shodan-sourced exposure (passive; free InternetDB tier out of the box, richer with a bring-your-own Shodan key), lookalike / typosquat domain detection (passive; phishing infrastructure and brand abuse targeting your domain), technology fingerprinting, web hygiene, and CVE prioritisation (EPSS + CISA KEV). Run a **passive scan** (public-source only, no authorization needed) or an **active scan** (probes the target, authorization required). Self-hosted, MIT-licensed, one `docker run`. Results stay on your machine.
 
 Built by [Rathnakara G N](https://www.linkedin.com/in/rathnakaragn/) and [Ashok S Kamat](https://www.linkedin.com/in/ashokskamat/) of [Cybersecify](https://cybersecify.com), the same tool we run in engagements and on our own infrastructure.
 
@@ -167,7 +167,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline**: 23-tool scan workflow from domain to findings
+- **Automated pipeline**: 25-tool scan workflow from domain to findings
 - **Network attack surface scanning**: CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **CVE prioritisation**: EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows**: Create custom scan configurations, enable/disable tools per workflow
@@ -200,6 +200,9 @@ Phase 2  Subfinder         - Passive subdomain enumeration
 Phase 2  Amass             - Active subdomain enumeration
 Phase 2  Alterx            - Subdomain permutation from discovered subdomains
 Phase 2  ASN Discovery     - Owned ASN/CIDR ranges via amass intel (reports only)
+Phase 2  GitHub Org Recon  - Infra refs (internal hostnames, cloud buckets, API
+                             endpoints) leaked in the org's public GitHub repos
+                             (passive; official API — keyless, richer with a token)
 Phase 3  DNSx              - DNS resolution, public IP filtering
 Phase 4  Takeover Check    - Subdomain takeover detection via subzy
 Phase 4  Cloud Assets      - Public S3/Azure/GCP bucket enumeration (cloud_enum)

--- a/apps/core/reports/views.py
+++ b/apps/core/reports/views.py
@@ -112,6 +112,13 @@ _CWE_BY_CHECK = {
     # A registered lookalike domain is infrastructure built to be visually
     # confused with the org's real domain — the essence of CWE-451.
     "lookalike_domain": "CWE-451: User Interface (UI) Misrepresentation of Critical Information",
+    # github_recon — infra references (internal hostnames/subdomains, cloud-bucket
+    # URLs, API endpoints) and the public-repo surface leaked in the org's PUBLIC
+    # GitHub source. CWE-200 (Exposure of Sensitive Information to an Unauthorized
+    # Actor) is the exact category: the data is not itself a vuln, but exposing it
+    # hands an attacker recon they should have had to work for.
+    "github_infra_exposure": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor",
+    "github_public_repos": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor",
 }
 
 

--- a/apps/core/workflows/migrations/0027_add_github_recon_to_workflows.py
+++ b/apps/core/workflows/migrations/0027_add_github_recon_to_workflows.py
@@ -1,0 +1,60 @@
+"""Add github_recon (GitHub Org Recon) to the default workflows.
+
+github_recon is a passive, Surface-Enumeration (phase 2) tool that enumerates the
+target org's PUBLIC GitHub repos via GitHub's official REST API and surfaces exposed
+infrastructure references (internal hostnames/subdomains, cloud-bucket URLs, API
+endpoints) in that public code/config — widening the discovered attack surface from
+source. It must join:
+
+  * Full Scan    — the invariant test_full_scan_covers_every_registered_tool requires
+                   every non-core registered tool to be in the default Full Scan,
+                   else the scan/report/README under-count.
+  * Passive Scan — it is passive (active=False): it queries GitHub's API, never the
+                   target, so it belongs in the no-auth passive recon workflow. It
+                   works keyless (unauthenticated GitHub API, request-capped), so the
+                   Passive Scan stays fully self-serving with no key required.
+
+Additive and idempotent (skips if already present), matching 0021/0023/0024/0025/0026.
+Execution order is unaffected — the runner regroups steps by registry phase.
+"""
+
+from django.db import migrations
+
+_TOOL = "github_recon"
+_WORKFLOWS = ["Full Scan", "Passive Scan"]
+
+
+def add_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None:
+            continue
+        if wf.steps.filter(tool=_TOOL).exists():
+            continue
+        next_order = (
+            wf.steps.order_by("-order").values_list("order", flat=True).first() or 0
+        ) + 1
+        WorkflowStep.objects.create(workflow=wf, tool=_TOOL, order=next_order, enabled=True)
+
+
+def remove_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None:
+            continue
+        WorkflowStep.objects.filter(workflow=wf, tool=_TOOL).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflow", "0026_add_typosquat_to_workflows"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tool, remove_tool),
+    ]

--- a/apps/github_recon/analyzer.py
+++ b/apps/github_recon/analyzer.py
@@ -1,0 +1,192 @@
+"""GitHub Org Recon analyzer — turns public-repo metadata/config into Findings.
+
+Two Finding shapes (aggregate, low-noise — this complements github_secrets, which
+finds actual secrets; this one finds *infra exposure*):
+
+  * ``github_public_repos`` (info): one summary per scan — "N public repos discovered
+    for org X". Establishes the source-code attack surface.
+  * ``github_infra_exposure`` (low): one per unique infrastructure reference found in
+    that public code/config — an internal hostname/subdomain of the target domain, a
+    cloud-bucket URL (S3/Azure/GCP), or an API endpoint. Says WHICH repo and file it
+    came from so the operator can verify and remediate.
+
+We store the reference itself (a hostname / bucket name / URL) — NOT any secret. If a
+secret is what's exposed, github_secrets is the tool that reports it.
+"""
+
+import logging
+import re
+
+from apps.core.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+_MAX_FINDINGS = 200  # hard cap so a huge org can't flood the report
+
+# Cloud-storage bucket references. In an org's OWN public code these are very likely
+# the org's own buckets, so we surface all providers (not just target-domain matches).
+_BUCKET_RES = (
+    re.compile(r"s3://[a-z0-9][a-z0-9.\-]{1,254}", re.I),
+    re.compile(r"[a-z0-9][a-z0-9.\-]{1,254}\.s3(?:[.\-][a-z0-9\-]+)*\.amazonaws\.com", re.I),
+    re.compile(r"[a-z0-9][a-z0-9\-]{1,62}\.blob\.core\.windows\.net", re.I),
+    re.compile(r"storage\.googleapis\.com/[a-z0-9._\-]+", re.I),
+    re.compile(r"[a-z0-9][a-z0-9._\-]{1,254}\.storage\.googleapis\.com", re.I),
+)
+
+
+# A URL whose PATH exposes an API surface (avoids a bare `"/api" in url` substring
+# check, which static analysis flags as an incomplete-URL-sanitization pattern).
+_API_PATH_RE = re.compile(r"/(?:api|graphql)(?:[/.?]|$)", re.I)
+
+
+def _host_re(domain: str):
+    # A hostname that is a SUBDOMAIN of the target domain (>=1 label before it).
+    return re.compile(rf"\b((?:[a-z0-9_-]+\.)+{re.escape(domain)})\b", re.I)
+
+
+def _url_re(domain: str):
+    # A URL pointing at the target domain (used to catch /api paths on the apex).
+    return re.compile(rf"https?://[a-z0-9_.\-]*{re.escape(domain)}[^\s\"'<>()]*", re.I)
+
+
+def _looks_like_api(host: str) -> bool:
+    parts = host.split(".")
+    return parts[0] in ("api", "apis", "graphql", "gateway") or "api" in parts
+
+
+def extract_infra_refs(text: str, domain: str) -> set:
+    """Return a set of ``(ref_type, value)`` infra references found in ``text``.
+
+    ref_type is one of ``hostname``, ``api_endpoint``, ``cloud_bucket``. Pure /
+    side-effect-free so it is unit-testable in isolation.
+    """
+    refs: set = set()
+    if not text or not domain:
+        return refs
+    domain = domain.lower()
+
+    for host in _host_re(domain).findall(text):
+        host = host.lower().rstrip(".")
+        if host == domain:
+            continue
+        refs.add(("api_endpoint" if _looks_like_api(host) else "hostname", host))
+
+    for url in _url_re(domain).findall(text):
+        clean = url.rstrip("/").lower()
+        if _API_PATH_RE.search(clean):
+            refs.add(("api_endpoint", clean))
+
+    for rx in _BUCKET_RES:
+        for match in rx.findall(text):
+            refs.add(("cloud_bucket", match.lower().rstrip("/")))
+
+    return refs
+
+
+_TITLE_BY_TYPE = {
+    "hostname": "Internal hostname exposed in public GitHub repo",
+    "api_endpoint": "API endpoint exposed in public GitHub repo",
+    "cloud_bucket": "Cloud storage reference exposed in public GitHub repo",
+}
+
+
+def _infra_finding(session, domain, org, ref_type, value, repo, repo_url, location) -> Finding:
+    title = _TITLE_BY_TYPE.get(ref_type, "Infrastructure reference exposed in public GitHub repo")
+    return Finding(
+        session=session,
+        source="github_recon",
+        check_type="github_infra_exposure",
+        severity="low",
+        target=value,
+        title=f"{title}: {value}",
+        description=(
+            f"The {ref_type.replace('_', ' ')} '{value}' appears in the public GitHub "
+            f"repository '{repo}' ({location}). Public source code and configuration "
+            f"can leak internal infrastructure references — hostnames, storage buckets, "
+            f"and API endpoints — that widen your external attack surface even though "
+            f"the target itself was never scanned.\nRepository: {repo_url}"
+        ),
+        remediation=(
+            "Confirm whether this reference should be public. Remove internal hostnames, "
+            "bucket names, and API endpoints from public repositories (and their git "
+            "history), rotate anything sensitive, and ensure the referenced "
+            "infrastructure is firewalled / access-controlled and not implicitly trusted."
+        ),
+        extra={
+            "ref_type": ref_type,
+            "value": value,
+            "repo": repo,
+            "repo_url": repo_url,
+            "location": location,
+            "org": org,
+            "source_data": "github_recon",
+        },
+    )
+
+
+def analyze(session, domain, data) -> list[Finding]:
+    findings: list[Finding] = []
+    if not isinstance(data, dict):
+        return findings
+
+    org = data.get("org")
+    repos = data.get("repos") or []
+
+    if data.get("org_confirmed") and org and repos:
+        findings.append(Finding(
+            session=session,
+            source="github_recon",
+            check_type="github_public_repos",
+            severity="info",
+            target=str(org),
+            title=f"{len(repos)} public GitHub repositor{'y' if len(repos) == 1 else 'ies'} discovered for '{org}'",
+            description=(
+                f"{len(repos)} public repositor{'y' if len(repos) == 1 else 'ies'} were "
+                f"found under the GitHub {data.get('kind') or 'account'} '{org}' "
+                f"({data.get('org_url') or ''}). Public source code is part of your "
+                f"external attack surface — the individual findings below flag specific "
+                f"infrastructure references leaked in that code/config."
+            ),
+            remediation=(
+                "Review which repositories should be public. Audit them for internal "
+                "hostnames, credentials, and infrastructure details, and move private "
+                "work into private repositories."
+            ),
+            extra={
+                "org": org,
+                "kind": data.get("kind"),
+                "org_url": data.get("org_url"),
+                "repo_count": len(repos),
+                "source_data": "github_recon",
+            },
+        ))
+
+    seen: set = set()
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        name = repo.get("name") or ""
+        repo_url = repo.get("html_url") or ""
+        sources = [
+            ("description", repo.get("description") or ""),
+            ("homepage", repo.get("homepage") or ""),
+            ("topics", " ".join(repo.get("topics") or [])),
+        ]
+        for f in repo.get("files") or []:
+            if isinstance(f, dict):
+                sources.append((f"file:{f.get('path')}", f.get("content") or ""))
+
+        for location, text in sources:
+            for ref_type, value in extract_infra_refs(text, domain):
+                key = (ref_type, value)
+                if key in seen:
+                    continue
+                seen.add(key)
+                findings.append(
+                    _infra_finding(session, domain, org, ref_type, value, name, repo_url, location)
+                )
+                if len(findings) >= _MAX_FINDINGS:
+                    logger.info("github_recon: hit finding cap (%d) — truncating", _MAX_FINDINGS)
+                    return findings
+
+    return findings

--- a/apps/github_recon/apps.py
+++ b/apps/github_recon/apps.py
@@ -1,0 +1,24 @@
+from django.apps import AppConfig
+
+
+class GithubReconConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.github_recon"
+    label = "github_recon"
+    verbose_name = "GitHub Org Recon"
+    tool_meta = {
+        "label": "GitHub Org Recon",
+        "runner": "apps.github_recon.scanner.run_github_recon",
+        "phase": 2,
+        "phase_group": "Surface Enumeration",
+        "requires": [],
+        "produces_findings": True,
+        # Passive: queries GitHub's PUBLIC REST API for the org's public repos and
+        # the infra references (internal hostnames/subdomains, cloud-bucket URLs,
+        # API endpoints) exposed in that public code/config. Sends ZERO packets to
+        # the target's own systems — this is third-party (GitHub) data, so it needs
+        # NO DomainAuthorization. BYO-token is OPTIONAL: unauthenticated works at
+        # GitHub's 60 req/hr public limit (we cap requests to stay well under it);
+        # a GITHUB_TOKEN raises the ceiling to 5000 req/hr for richer coverage.
+        "active": False,
+    }

--- a/apps/github_recon/collector.py
+++ b/apps/github_recon/collector.py
@@ -1,0 +1,287 @@
+"""GitHub Org Recon collector — passive, two-tier (free + BYO-token).
+
+Enumerates the target org's PUBLIC GitHub repos via GitHub's official REST API and
+pulls lightweight metadata (+ a small, capped set of well-known config files) so the
+analyzer can surface exposed infrastructure references (internal hostnames /
+subdomains, cloud-bucket URLs, API endpoints) found in that public code/config.
+
+Two tiers, chosen automatically by whether a token is configured:
+
+  * FREE (default, no token): unauthenticated GitHub API, 60 requests/hr. We cap
+    total requests (``GITHUB_MAX_REQUESTS``) and repos (``GITHUB_MAX_REPOS``) to stay
+    well under it — every deployment gets useful recon out of the box.
+  * ENHANCED (``GITHUB_TOKEN`` set): authenticated API, 5000 requests/hr — deeper
+    repo + file coverage within the same caps.
+
+Design contract (mirrors apps/shodan, apps/hudson_rock — additive intelligence):
+  * FAIL-GRACEFUL, ALWAYS. Any timeout / non-200 / exhausted rate-limit / JSON error
+    is logged and skipped; the collector never raises. There is no binary, so it does
+    NOT raise ToolBinaryMissing / ToolTimeout.
+  * Uses ONLY GitHub's official API (never scrapes, never touches the target) and
+    sends the honest OpenEASD User-Agent so GitHub can identify us — GitHub rejects
+    requests with no UA. Honours GitHub's rate limits (403/429 + X-RateLimit-*).
+  * A 404 means "no such org/user/file" — normal, not an error.
+"""
+
+import base64
+import logging
+import time
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 10  # seconds, per call
+_MAX_RETRIES = 2  # extra attempts after a rate-limit response
+_DEFAULT_BACKOFF = 2  # seconds, when no Retry-After header
+_MAX_BACKOFF = 10  # cap the honoured Retry-After so we never stall a scan
+
+_PER_PAGE = 100  # GitHub's max page size for repo listings
+_DEFAULT_MAX_REPOS = 50  # cap repos inspected per scan
+_DEFAULT_MAX_REQUESTS = 100  # hard ceiling on total API calls per scan (free-tier guard)
+_MAX_FILES_PER_REPO = 4  # capped well-known config files fetched per repo
+_MAX_FILE_BYTES = 200_000  # skip config files larger than this (bound bytes parsed)
+
+# Well-known, low-risk config files most likely to carry infra references. Bounded
+# by _MAX_FILES_PER_REPO — we never fetch a repo's full tree.
+_WELL_KNOWN_FILES = (
+    "README.md",
+    ".env.example",
+    ".env.sample",
+    "docker-compose.yml",
+    ".github/workflows/ci.yml",
+)
+
+
+def _api_base() -> str:
+    return getattr(settings, "GITHUB_API_BASE", "https://api.github.com").rstrip("/")
+
+
+def _user_agent() -> str:
+    return getattr(settings, "OPENEASD_USER_AGENT", "OpenEASD/1.0")
+
+
+def _headers() -> dict:
+    headers = {
+        "User-Agent": _user_agent(),
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = getattr(settings, "GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _max_repos() -> int:
+    return getattr(settings, "GITHUB_MAX_REPOS", _DEFAULT_MAX_REPOS) or _DEFAULT_MAX_REPOS
+
+
+def _max_requests() -> int:
+    return getattr(settings, "GITHUB_MAX_REQUESTS", _DEFAULT_MAX_REQUESTS) or _DEFAULT_MAX_REQUESTS
+
+
+def _is_rate_limited(resp) -> bool:
+    """A 403/429 that is specifically GitHub's rate limit (vs a hard forbidden)."""
+    if resp.headers.get("Retry-After"):
+        return True
+    remaining = resp.headers.get("X-RateLimit-Remaining")
+    return remaining is not None and str(remaining) == "0"
+
+
+def _get_json(url: str, budget: dict, params: dict | None = None):
+    """GET a GitHub API endpoint. Returns parsed JSON, ``{}`` on 404 (no such
+    resource), or ``None`` on any failure. Never raises. Honours GitHub's rate
+    limits (403/429 + Retry-After / X-RateLimit-*) with capped backoff.
+
+    Counts every call against ``budget`` so the caller can stop before blowing the
+    free-tier request ceiling.
+    """
+    budget["used"] += 1
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            resp = requests.get(url, params=params, headers=_headers(), timeout=REQUEST_TIMEOUT)
+        except requests.RequestException as exc:
+            logger.warning("github_recon: request to %s failed: %s", url, exc)
+            return None
+
+        if resp.status_code in (403, 429):
+            if _is_rate_limited(resp) and attempt < _MAX_RETRIES:
+                backoff = _DEFAULT_BACKOFF
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        backoff = min(int(retry_after), _MAX_BACKOFF)
+                    except (ValueError, TypeError):
+                        backoff = _DEFAULT_BACKOFF
+                logger.info("github_recon: %s rate-limited, backing off %ss", url, backoff)
+                time.sleep(backoff)
+                continue
+            logger.warning("github_recon: %s returned HTTP %s (rate limit / forbidden)", url, resp.status_code)
+            return None
+
+        if resp.status_code == 404:
+            return {}  # no such org/user/file — normal.
+
+        if resp.status_code != 200:
+            logger.warning("github_recon: %s returned HTTP %s", url, resp.status_code)
+            return None
+
+        try:
+            return resp.json()
+        except ValueError as exc:
+            logger.warning("github_recon: %s returned non-JSON body: %s", url, exc)
+            return None
+
+    return None
+
+
+def _resolve_org(domain: str) -> str | None:
+    """Candidate GitHub org/user login for a domain.
+
+    ``GITHUB_ORG`` (per-deployment override) wins. Otherwise derive from the domain:
+    the registrable label is the second-to-last dot label — ``example.com`` and
+    ``www.example.com`` both -> ``example``. Multi-part TLDs (``example.co.uk``)
+    resolve imperfectly (-> ``co``); set ``GITHUB_ORG`` for those.
+    """
+    override = getattr(settings, "GITHUB_ORG", "")
+    if override:
+        return override.strip()
+    if not domain:
+        return None
+    labels = [label for label in str(domain).strip().lower().split(".") if label]
+    if len(labels) >= 2:
+        return labels[-2]
+    if labels:
+        return labels[0]
+    return None
+
+
+def _confirm_account(org: str, budget: dict) -> dict:
+    """Confirm the login exists as an org or user. Returns a dict with ``login``,
+    ``kind`` ('org'|'user'), and ``html_url``; ``login`` is None if unconfirmed."""
+    base = _api_base()
+    info = _get_json(f"{base}/orgs/{org}", budget)
+    if isinstance(info, dict) and info.get("login"):
+        return {"login": info["login"], "kind": "org", "html_url": info.get("html_url")}
+
+    if budget["used"] >= budget["max"]:
+        return {"login": None, "kind": None, "html_url": None}
+
+    info = _get_json(f"{base}/users/{org}", budget)
+    if isinstance(info, dict) and info.get("login"):
+        kind = "org" if str(info.get("type", "")).lower() == "organization" else "user"
+        return {"login": info["login"], "kind": kind, "html_url": info.get("html_url")}
+
+    return {"login": None, "kind": None, "html_url": None}
+
+
+def _repo_record(item: dict) -> dict:
+    return {
+        "name": item.get("name") or "",
+        "full_name": item.get("full_name") or "",
+        "description": item.get("description") or "",
+        "homepage": item.get("homepage") or "",
+        "topics": [t for t in (item.get("topics") or []) if isinstance(t, str)],
+        "html_url": item.get("html_url") or "",
+        "size": item.get("size") or 0,
+        "files": [],
+    }
+
+
+def _list_repos(login: str, kind: str, budget: dict) -> list[dict]:
+    """Paginate the account's PUBLIC repos, capped at GITHUB_MAX_REPOS. Skips forks
+    (their infra refs belong to the upstream, not the org)."""
+    base = _api_base()
+    repos_path = f"/orgs/{login}/repos" if kind == "org" else f"/users/{login}/repos"
+    repo_type = "public" if kind == "org" else "owner"
+    cap = _max_repos()
+
+    repos: list[dict] = []
+    page = 1
+    while len(repos) < cap and budget["used"] < budget["max"]:
+        data = _get_json(
+            f"{base}{repos_path}",
+            budget,
+            params={"type": repo_type, "per_page": _PER_PAGE, "page": page},
+        )
+        if not isinstance(data, list) or not data:
+            break
+        for item in data:
+            if not isinstance(item, dict) or item.get("fork"):
+                continue
+            repos.append(_repo_record(item))
+            if len(repos) >= cap:
+                break
+        if len(data) < _PER_PAGE:
+            break
+        page += 1
+    return repos
+
+
+def _fetch_files(login: str, repo: str, budget: dict) -> list[dict]:
+    """Fetch a small, capped set of well-known config files' text via the contents
+    API. Bounds both file count (_MAX_FILES_PER_REPO) and bytes (_MAX_FILE_BYTES)."""
+    base = _api_base()
+    files: list[dict] = []
+    attempted = 0
+    for path in _WELL_KNOWN_FILES:
+        if attempted >= _MAX_FILES_PER_REPO or budget["used"] >= budget["max"]:
+            break
+        attempted += 1
+        data = _get_json(f"{base}/repos/{login}/{repo}/contents/{path}", budget)
+        if not isinstance(data, dict) or data.get("encoding") != "base64":
+            continue  # {} for 404 (absent), or a directory listing (a list) — skip
+        if (data.get("size") or 0) > _MAX_FILE_BYTES or not data.get("content"):
+            continue
+        try:
+            text = base64.b64decode(data["content"]).decode("utf-8", "replace")
+        except (ValueError, TypeError) as exc:
+            logger.warning("github_recon: could not decode %s in %s: %s", path, repo, exc)
+            continue
+        files.append({"path": path, "content": text})
+    return files
+
+
+def collect(domain: str) -> dict:
+    """Enumerate the target org's public repos + capped config files.
+
+    Returns ``{"org", "org_confirmed", "org_url", "kind", "repos"}``. Always returns
+    a dict; never raises.
+    """
+    org = _resolve_org(domain)
+    empty = {"org": org, "org_confirmed": False, "org_url": None, "kind": None, "repos": []}
+    if not org:
+        logger.info("github_recon: no org resolvable from domain %r — skipping", domain)
+        return empty
+
+    budget = {"used": 0, "max": _max_requests()}
+    account = _confirm_account(org, budget)
+    if not account["login"]:
+        logger.info("github_recon: no GitHub org/user '%s' — skipping", org)
+        return empty
+
+    login, kind = account["login"], account["kind"]
+    repos = _list_repos(login, kind, budget)
+    for repo in repos:
+        if budget["used"] >= budget["max"]:
+            logger.info(
+                "github_recon: request budget (%d) reached — %d repo(s) not file-scanned",
+                budget["max"], len(repos) - repos.index(repo),
+            )
+            break
+        repo["files"] = _fetch_files(login, repo["name"], budget)
+
+    logger.info(
+        "github_recon: org '%s' (%s) — %d public repo(s) inspected in %d API call(s)%s",
+        login, kind, len(repos), budget["used"],
+        "" if getattr(settings, "GITHUB_TOKEN", "") else " (unauthenticated free tier)",
+    )
+    return {
+        "org": login,
+        "org_confirmed": True,
+        "org_url": account["html_url"] or f"https://github.com/{login}",
+        "kind": kind,
+        "repos": repos,
+    }

--- a/apps/github_recon/models.py
+++ b/apps/github_recon/models.py
@@ -1,0 +1,2 @@
+# github_recon writes to the shared apps/core/findings/ model. No tool-specific
+# models — see analyzer.py for the Finding shapes produced.

--- a/apps/github_recon/scanner.py
+++ b/apps/github_recon/scanner.py
@@ -1,0 +1,37 @@
+"""GitHub Org Recon scanner — thin orchestrator: collect -> analyze -> save.
+
+Passive additive intelligence. Any failure inside collect/analyze is swallowed and
+the scan continues with zero findings — this tool must never fail a scan.
+"""
+
+import logging
+
+from apps.core.findings.models import Finding
+
+from .analyzer import analyze
+from .collector import collect
+
+logger = logging.getLogger(__name__)
+
+
+def run_github_recon(session) -> list[Finding]:
+    domain = session.domain  # CharField: "example.com"
+    if not domain:
+        logger.info("[github_recon:%s] no domain — skipping", session.id)
+        return []
+
+    try:
+        data = collect(domain)
+        findings = analyze(session, domain, data)
+    except Exception:  # noqa: BLE001 — never let this tool fail a scan
+        logger.exception("[github_recon:%s] unexpected error — skipping", session.id)
+        return []
+
+    if not findings:
+        logger.info("[github_recon:%s] no GitHub exposure — nothing to save", session.id)
+        return []
+
+    Finding.objects.bulk_create(findings, ignore_conflicts=True)
+    saved = list(Finding.objects.filter(session=session, source="github_recon"))
+    logger.info("[github_recon:%s] saved %d GitHub recon finding(s)", session.id, len(saved))
+    return saved

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -126,6 +126,7 @@ INSTALLED_APPS = [
     "apps.js_secrets",
     "apps.shodan",
     "apps.typosquat",
+    "apps.github_recon",
     "apps.cve_intel",
 ]
 
@@ -314,6 +315,28 @@ TOOL_GITLEAKS = config("TOOL_GITLEAKS", default="gitleaks")
 # the licensed host API) or disable the shodan tool. See THIRD_PARTY_NOTICES.md.
 SHODAN_API_KEY = config("SHODAN_API_KEY", default="")
 SHODAN_MAX_IPS = config("SHODAN_MAX_IPS", default=50, cast=int)
+
+# GitHub Org Recon tool (apps/github_recon) — passive. Enumerates the target org's
+# PUBLIC GitHub repos via GitHub's official REST API and surfaces exposed infra
+# references (internal hostnames/subdomains, cloud-bucket URLs, API endpoints) in
+# that public code/config. Two-tier, BYO-token:
+#   * No token  -> unauthenticated API, 60 req/hr. We cap total requests
+#                  (GITHUB_MAX_REQUESTS) + repos (GITHUB_MAX_REPOS) to stay under it,
+#                  so the tool always adds value out of the box.
+#   * GITHUB_TOKEN set (per-deployment SECRET — NEVER bake into the public image,
+#     that would leak the token; a read-only/public_repo-scope classic or
+#     fine-grained token is plenty) -> authenticated API, 5000 req/hr, richer
+#     coverage within the same caps.
+# GITHUB_ORG overrides the domain-derived org guess (use it for orgs whose GitHub
+# login differs from the apex label, or multi-part TLDs like example.co.uk).
+# NOTE: honours GitHub's REST API rate limits and only uses the official API.
+# NOTE (concurrent PRs): GITHUB_TOKEN / GITHUB_ORG may also be introduced by the
+# github_secrets tool PR — at merge, keep ONE definition of each (reviewer reconciles).
+GITHUB_TOKEN = config("GITHUB_TOKEN", default="")
+GITHUB_ORG = config("GITHUB_ORG", default="")
+GITHUB_API_BASE = config("GITHUB_API_BASE", default="https://api.github.com")
+GITHUB_MAX_REPOS = config("GITHUB_MAX_REPOS", default=50, cast=int)
+GITHUB_MAX_REQUESTS = config("GITHUB_MAX_REQUESTS", default=100, cast=int)
 
 # Honest scanner identity. Sent as the User-Agent on the tools that probe the
 # target's web surface (httpx, katana, nuclei) so a customer can deliberately

--- a/tests/unit/test_github_recon.py
+++ b/tests/unit/test_github_recon.py
@@ -1,0 +1,437 @@
+"""Unit tests for apps/github_recon — collector (two-tier BYO-token), infra-reference
+extraction, analyzer, scanner.
+
+github_recon is a passive tool: it enumerates the target org's PUBLIC GitHub repos
+via GitHub's official REST API and surfaces exposed infrastructure references
+(internal hostnames/subdomains, cloud-bucket URLs, API endpoints) in that public
+code/config. It must be fail-graceful (never raise) and stay within a capped request
+budget so the unauthenticated free tier (60 req/hr) is never blown.
+"""
+
+import base64
+import re
+
+import pytest
+import requests
+from unittest.mock import MagicMock, patch
+
+from apps.github_recon.analyzer import analyze, extract_infra_refs
+from apps.github_recon.collector import _resolve_org, collect
+from apps.github_recon.scanner import run_github_recon
+
+
+def _session(domain="example.com"):
+    from apps.core.scans.models import ScanSession
+    return ScanSession.objects.create(domain=domain, scan_type="full")
+
+
+def _resp(status=200, json_body=None, headers=None):
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    r.json.return_value = json_body if json_body is not None else {}
+    return r
+
+
+def _b64_file(text, size=None):
+    encoded = base64.b64encode(text.encode()).decode()
+    return {"encoding": "base64", "content": encoded, "size": size if size is not None else len(text)}
+
+
+def _router(handlers):
+    """Build a requests.get side_effect that dispatches on the URL.
+
+    handlers: list of (path_pattern, response). First pattern that matches the
+    request URL (via re.search — avoids a flagged `needle in url` substring check)
+    wins. A final catch-all 404 is returned otherwise.
+    """
+    def _get(url, params=None, headers=None, timeout=None):
+        for pattern, resp in handlers:
+            if re.search(pattern, url):
+                return resp
+        return _resp(status=404)
+    return _get
+
+
+# ---------------------------------------------------------------------------
+# Org resolution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestResolveOrg:
+    def test_derives_registrable_label(self, settings):
+        settings.GITHUB_ORG = ""
+        assert _resolve_org("example.com") == "example"
+
+    def test_strips_subdomain(self, settings):
+        settings.GITHUB_ORG = ""
+        assert _resolve_org("www.example.com") == "example"
+
+    def test_override_wins(self, settings):
+        settings.GITHUB_ORG = "acme-labs"
+        assert _resolve_org("example.com") == "acme-labs"
+
+    def test_empty_domain(self, settings):
+        settings.GITHUB_ORG = ""
+        assert _resolve_org("") is None
+
+
+# ---------------------------------------------------------------------------
+# Collector — enumeration happy paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCollectorEnumeration:
+    def _org_ok(self, login="example"):
+        return _resp(json_body={"login": login, "html_url": f"https://github.com/{login}"})
+
+    def test_org_confirmed_and_repos_parsed(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        repos = [{"name": "web", "full_name": "example/web", "description": "d",
+                  "homepage": "https://example.com", "topics": ["infra"],
+                  "html_url": "https://github.com/example/web", "fork": False, "size": 1}]
+        handlers = [
+            ("/orgs/example/repos", _resp(json_body=repos)),
+            ("/orgs/example", self._org_ok()),
+            ("/contents/", _resp(status=404)),
+        ]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert data["org_confirmed"] is True
+        assert data["org"] == "example"
+        assert data["kind"] == "org"
+        assert [r["name"] for r in data["repos"]] == ["web"]
+
+    def test_repos_endpoint_uses_orgs_path_first(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        captured = {}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            if url.endswith("/orgs/example"):
+                return self._org_ok()
+            if "/orgs/example/repos" in url:
+                captured["repos_url"] = url
+                return _resp(json_body=[])
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert captured["repos_url"].startswith("https://api.github.com/orgs/example/repos")
+
+    def test_user_fallback_when_org_404(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        handlers = [
+            ("/users/example/repos", _resp(json_body=[])),
+            ("/orgs/example", _resp(status=404)),
+            ("/users/example", _resp(json_body={"login": "example", "type": "User",
+                                                "html_url": "https://github.com/example"})),
+        ]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert data["org_confirmed"] is True
+        assert data["kind"] == "user"
+
+    def test_unknown_account_not_confirmed(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        with patch("apps.github_recon.collector.requests.get", return_value=_resp(status=404)):
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+        assert data["repos"] == []
+
+    def test_forks_skipped(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        repos = [
+            {"name": "own", "fork": False, "html_url": "u"},
+            {"name": "forked", "fork": True, "html_url": "u"},
+        ]
+        handlers = [("/orgs/example/repos", _resp(json_body=repos)),
+                    ("/orgs/example", self._org_ok())]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert [r["name"] for r in data["repos"]] == ["own"]
+
+    def test_repos_capped_at_max(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        settings.GITHUB_MAX_REPOS = 3
+        settings.GITHUB_MAX_REQUESTS = 100
+        repos = [{"name": f"r{i}", "fork": False, "html_url": "u"} for i in range(50)]
+        handlers = [("/orgs/example/repos", _resp(json_body=repos)),
+                    ("/orgs/example", self._org_ok()),
+                    ("/contents/", _resp(status=404))]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert len(data["repos"]) == 3
+
+    def test_config_file_fetched_and_decoded(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        settings.GITHUB_MAX_REQUESTS = 100
+        repos = [{"name": "web", "fork": False, "html_url": "u"}]
+        readme = _b64_file("see internal.example.com and s3://acme-backups")
+        handlers = [
+            ("/orgs/example/repos", _resp(json_body=repos)),
+            ("/orgs/example", self._org_ok()),
+            ("/contents/README.md", _resp(json_body=readme)),
+            ("/contents/", _resp(status=404)),
+        ]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        files = data["repos"][0]["files"]
+        assert files and files[0]["path"] == "README.md"
+        assert files[0]["content"] == "see internal.example.com and s3://acme-backups"
+
+    def test_oversized_file_skipped(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        repos = [{"name": "web", "fork": False, "html_url": "u"}]
+        big = _b64_file("x", size=999_999)
+        handlers = [("/orgs/example/repos", _resp(json_body=repos)),
+                    ("/orgs/example", self._org_ok()),
+                    ("/contents/", _resp(json_body=big))]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert data["repos"][0]["files"] == []
+
+    def test_request_budget_caps_total_calls(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        settings.GITHUB_MAX_REPOS = 50
+        settings.GITHUB_MAX_REQUESTS = 3  # confirm(1) + repos(1) leaves ~1 for files
+        repos = [{"name": f"r{i}", "fork": False, "html_url": "u"} for i in range(10)]
+        calls = {"n": 0}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            calls["n"] += 1
+            if url.endswith("/orgs/example"):
+                return self._org_ok()
+            if "/orgs/example/repos" in url:
+                return _resp(json_body=repos)
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert calls["n"] <= 3  # never exceeds GITHUB_MAX_REQUESTS
+
+    def test_token_sets_auth_header(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = "ghp_secret"
+        captured = {}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            captured["headers"] = headers
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert captured["headers"]["Authorization"] == "Bearer ghp_secret"
+
+    def test_no_token_no_auth_header(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        captured = {}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            captured["headers"] = headers
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert "Authorization" not in captured["headers"]
+        assert captured["headers"]["User-Agent"]  # honest UA always sent
+
+
+# ---------------------------------------------------------------------------
+# Collector — fail-graceful contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCollectorFailGraceful:
+    def test_request_exception_never_raises(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        with patch("apps.github_recon.collector.requests.get",
+                   side_effect=requests.RequestException("boom")):
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+
+    def test_500_never_raises(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        with patch("apps.github_recon.collector.requests.get", return_value=_resp(status=500)):
+            assert collect("example.com")["org_confirmed"] is False
+
+    def test_rate_limit_retries_then_gives_up(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        limited = _resp(status=403, headers={"Retry-After": "0", "X-RateLimit-Remaining": "0"})
+        with patch("apps.github_recon.collector.requests.get", return_value=limited), \
+             patch("apps.github_recon.collector.time.sleep") as slept:
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+        assert slept.called  # honoured the backoff before giving up
+
+    def test_hard_403_not_retried(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        # A 403 that is NOT a rate limit (no Retry-After, remaining not zero).
+        forbidden = _resp(status=403, headers={"X-RateLimit-Remaining": "42"})
+        with patch("apps.github_recon.collector.requests.get", return_value=forbidden), \
+             patch("apps.github_recon.collector.time.sleep") as slept:
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+        assert not slept.called  # did not treat a hard 403 as a rate limit
+
+    def test_bad_json_never_raises(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        r = _resp(status=200)
+        r.json.side_effect = ValueError("not json")
+        with patch("apps.github_recon.collector.requests.get", return_value=r):
+            assert collect("example.com")["org_confirmed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Infra-reference extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractInfraRefs:
+    def test_subdomain_hostname(self):
+        refs = extract_infra_refs("connect to internal.example.com now", "example.com")
+        assert ("hostname", "internal.example.com") in refs
+
+    def test_api_subdomain_classified_as_api(self):
+        refs = extract_infra_refs("base https://api.example.com/v1", "example.com")
+        assert ("api_endpoint", "api.example.com") in refs
+
+    def test_api_path_on_apex(self):
+        refs = extract_infra_refs("call https://example.com/api/v1/users", "example.com")
+        assert ("api_endpoint", "https://example.com/api/v1/users") in refs
+
+    def test_apex_alone_not_reported(self):
+        # The bare apex is not an interesting infra leak — only subdomains/URLs are.
+        refs = extract_infra_refs("visit example.com", "example.com")
+        assert refs == set()
+
+    def test_s3_bucket_uri(self):
+        refs = extract_infra_refs("backup to s3://acme-prod-backups/db", "example.com")
+        # The bucket name is the identifier we surface (object path is dropped).
+        assert ("cloud_bucket", "s3://acme-prod-backups") in refs
+
+    def test_s3_virtual_host(self):
+        refs = extract_infra_refs("https://assets.s3.amazonaws.com/logo.png", "example.com")
+        assert ("cloud_bucket", "assets.s3.amazonaws.com") in refs
+
+    def test_azure_blob(self):
+        refs = extract_infra_refs("https://acmestore.blob.core.windows.net/x", "example.com")
+        assert ("cloud_bucket", "acmestore.blob.core.windows.net") in refs
+
+    def test_gcp_bucket(self):
+        refs = extract_infra_refs("gs at storage.googleapis.com/acme-assets", "example.com")
+        assert ("cloud_bucket", "storage.googleapis.com/acme-assets") in refs
+
+    def test_empty_and_none(self):
+        assert extract_infra_refs("", "example.com") == set()
+        assert extract_infra_refs("nothing here", "example.com") == set()
+        assert extract_infra_refs("internal.example.com", "") == set()
+
+
+# ---------------------------------------------------------------------------
+# Analyzer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestAnalyzer:
+    def _data(self, repos, org="example", confirmed=True):
+        return {"org": org, "org_confirmed": confirmed, "kind": "org",
+                "org_url": f"https://github.com/{org}", "repos": repos}
+
+    def test_summary_finding_emitted(self):
+        sess = _session()
+        data = self._data([{"name": "web", "html_url": "u", "description": "", "topics": [], "files": []}])
+        findings = analyze(sess, "example.com", data)
+        summary = [f for f in findings if f.check_type == "github_public_repos"]
+        assert len(summary) == 1
+        assert summary[0].severity == "info"
+        assert summary[0].source == "github_recon"
+        assert summary[0].extra["repo_count"] == 1
+
+    def test_infra_finding_shape(self):
+        sess = _session()
+        repo = {"name": "web", "html_url": "https://github.com/example/web",
+                "description": "uses internal.example.com", "topics": [], "files": []}
+        findings = analyze(sess, "example.com", self._data([repo]))
+        infra = [f for f in findings if f.check_type == "github_infra_exposure"]
+        assert len(infra) == 1
+        f = infra[0]
+        assert f.severity == "low"
+        assert f.source == "github_recon"
+        assert f.target == "internal.example.com"
+        assert f.extra["ref_type"] == "hostname"
+        assert f.extra["repo"] == "web"
+        assert f.extra["source_data"] == "github_recon"
+
+    def test_refs_deduped_across_repos(self):
+        sess = _session()
+        repos = [
+            {"name": "a", "html_url": "u", "description": "internal.example.com", "topics": [], "files": []},
+            {"name": "b", "html_url": "u", "description": "internal.example.com", "topics": [], "files": []},
+        ]
+        findings = analyze(sess, "example.com", self._data(repos))
+        infra = [f for f in findings if f.check_type == "github_infra_exposure"]
+        assert len(infra) == 1  # same reference reported once
+
+    def test_no_summary_when_unconfirmed(self):
+        sess = _session()
+        findings = analyze(sess, "example.com", self._data([], confirmed=False))
+        assert findings == []
+
+    def test_finding_from_file_content(self):
+        sess = _session()
+        repo = {"name": "web", "html_url": "u", "description": "", "topics": [],
+                "files": [{"path": "README.md", "content": "bucket s3://acme-prod"}]}
+        findings = analyze(sess, "example.com", self._data([repo]))
+        buckets = [f for f in findings if f.extra.get("ref_type") == "cloud_bucket"]
+        assert buckets and buckets[0].extra["location"] == "file:README.md"
+
+    def test_non_dict_data_safe(self):
+        assert analyze(_session(), "example.com", None) == []
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestScanner:
+    def test_saves_findings(self):
+        from apps.core.findings.models import Finding
+        sess = _session()
+        data = {"org": "example", "org_confirmed": True, "kind": "org",
+                "org_url": "https://github.com/example",
+                "repos": [{"name": "web", "html_url": "u",
+                           "description": "internal.example.com", "topics": [], "files": []}]}
+        with patch("apps.github_recon.scanner.collect", return_value=data):
+            saved = run_github_recon(sess)
+        assert len(saved) == 2  # summary + one infra exposure
+        assert Finding.objects.filter(session=sess, source="github_recon").count() == 2
+
+    def test_empty_when_no_data(self):
+        sess = _session()
+        with patch("apps.github_recon.scanner.collect",
+                   return_value={"org": None, "org_confirmed": False, "repos": []}):
+            assert run_github_recon(sess) == []
+
+    def test_never_raises_on_collect_error(self):
+        sess = _session()
+        with patch("apps.github_recon.scanner.collect", side_effect=RuntimeError("boom")):
+            assert run_github_recon(sess) == []
+
+    def test_no_domain_skips(self):
+        sess = _session(domain="")
+        assert run_github_recon(sess) == []


### PR DESCRIPTION
## What

New passive tool `github_recon` (tool #25, Phase 2 Surface Enumeration). Enumerates the target org's **public** GitHub repos via GitHub's official REST API and surfaces exposed **infrastructure references** in that public code/config — internal hostnames/subdomains, cloud-bucket URLs (S3/Azure/GCP), and API endpoints. Complements the secret-focused `js_secrets`/`github_secrets`: this finds *infra exposure*, and never stores secrets.

- One `info` summary Finding ("N public repos discovered for org X") + one `low` `github_infra_exposure` Finding per unique reference (deduped, capped at 200), each naming the repo + file.
- **Passive** (`active=False`): queries GitHub, never the target → no `DomainAuthorization`. Joins Full Scan + Passive Scan (migration 0027).
- **Two-tier BYO-token:** keyless unauthenticated API works out of the box (60 req/hr; total requests + repos capped to stay under it); `GITHUB_TOKEN` raises to 5000 req/hr.
- **Fail-graceful:** any API/network/JSON error or rate-limit returns empty, never fails a scan. Honours GitHub rate limits (403/429 + `X-RateLimit-*`) with capped backoff.

## Definition-of-done

INSTALLED_APPS · migration 0027 (Full Scan + Passive Scan) · settings (`GITHUB_TOKEN`/`GITHUB_ORG`/`GITHUB_API_BASE`/`GITHUB_MAX_REPOS`/`GITHUB_MAX_REQUESTS`) · `_CWE_BY_CHECK` (`github_infra_exposure` + `github_public_repos` → CWE-200) · 39 tests · README + CLAUDE.md + CHANGELOG.

## Verification

- `test_github_recon.py` (39) + `test_default_workflow.py` + `test_passive_scan.py` + `test_reports.py` pass.
- Full fast suite: **1429 passed** (`pytest tests/ --ignore=tests/unit/test_domain_security.py`).
- `makemigrations --check` clean, `manage.py check` clean.

## Reviewer notes

- **Counts:** registered tools 24 → **25**; test total 1437 → **1481** (1429 fast + 52 slow). README prose was already inconsistent on main ("Twenty-four" vs "23-tool"); bumped both to 25 while here.
- **⚠️ Merge conflict expected with the concurrent `github_secrets` PR:** both add `GITHUB_TOKEN`/`GITHUB_ORG` to `settings.py`. Keep **ONE** definition of each at merge — reviewer reconciles. (Code reads them via `getattr(settings, ...)`, so either block's definition works.)
- **GitHub API ToS:** uses only the official REST API (no scraping), honest User-Agent, documented rate limits honoured. `GITHUB_TOKEN`/`GITHUB_ORG` are per-deployment secrets, never baked into the image.
- **Website sync (cybersecify.com):** tool count / feature cards / sample report should reflect the new tool (standing GitHub↔website sync requirement).
- **Ambiguity calls made:** org resolved from the registrable label (`example.com`/`www.example.com` → `example`); multi-part TLDs (`example.co.uk`) resolve imperfectly — set `GITHUB_ORG` for those (documented in settings + `_resolve_org`). Config-file scan is bounded to a few well-known files (README/.env.example/docker-compose/CI) per repo, capped by bytes + the global request budget. Forks skipped (their infra refs belong upstream). Buckets from any provider are surfaced (in the org's own public code they're likely the org's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)