### PR TITLE
fix: graceful timeout handling for asn_discovery and dnsx

### DIFF
--- a/apps/asn_discovery/scanner.py
+++ b/apps/asn_discovery/scanner.py
@@ -14,6 +14,7 @@ separate authorization decision — see collector.py / analyzer.py).
 import logging
 
 from apps.core.findings.models import Finding
+from apps.core.workflows.exceptions import ToolTimeout
 
 from .analyzer import analyze
 from .collector import collect
@@ -23,7 +24,14 @@ logger = logging.getLogger(__name__)
 
 def run_asn_discovery(session) -> list[Finding]:
     """Discover owned ASNs/CIDRs for the session domain and persist Findings."""
-    records = collect(session)
+    try:
+        records = collect(session)
+    except ToolTimeout:
+        logger.warning(
+            "[asn_discovery:%s] amass intel timed out — skipping ASN discovery",
+            session.id,
+        )
+        return []
     if not records:
         return []
 

--- a/apps/dnsx/collector.py
+++ b/apps/dnsx/collector.py
@@ -31,7 +31,7 @@ def collect(session, subdomains: list[str]) -> list[dict]:
     logger.info(f"[dnsx:{session.id}] Resolving {len(subdomains)} subdomains")
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, stdin=subprocess.DEVNULL)
     except FileNotFoundError:
         logger.error(f"[dnsx:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"dnsx binary not found: {binary}")


### PR DESCRIPTION
 ## Problem

  Two tools were marking scans as Partial on large domains:

  1. **asn_discovery** — `amass intel` times out after 300s on slow
     BGP/registry lookups. Since ASN/CIDR discovery is informational
     only, this should not fail the step.

  2. **dnsx** — Large subdomain sets exceed the 300s subprocess timeout.

  ## Fix

  - `asn_discovery/scanner.py`: catch `ToolTimeout`, log a warning,
    return `[]` — step completes cleanly instead of FAILED
  - `dnsx/collector.py`: raise timeout 300s → 600s

  ## Files changed
  - `apps/asn_discovery/scanner.py`
  - `apps/dnsx/collector.py`