### PR TITLE
ci: publish amd64 images only (drop arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,12 +185,12 @@ jobs:
             echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push ${{ matrix.target }} (amd64 + arm64)
+      - name: Build and push ${{ matrix.target }} (amd64)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           target: ${{ matrix.target }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64   # amd64 only — arm64 not required
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ git describe --tags --abbrev=0
   - `test` — pytest (fast, excludes `test_domain_security.py`) against a **`postgres:17-alpine` service container** (DB_* env), bandit (SAST), pip-audit (CVE scan)
   - `frontend` — `npm ci && npm run build`
   - `docker` — matrix over the `web` + `worker` build targets, `docker buildx build` for `linux/amd64` (no push, cache check per target)
-  - `publish` — matrix over `web` + `worker`; builds `linux/amd64` + `linux/arm64` and pushes to `ghcr.io/cybersecify/openeasd-web` and `-worker`
+  - `publish` — matrix over `web` + `worker`; builds `linux/amd64` and pushes to `ghcr.io/cybersecify/openeasd-web` and `-worker`
 - **Publish triggers:** every push to `main` (`:latest` tag) and `v*` tags (`:vX.Y` tag)
 - Runner: `ubuntu-24.04`, Python 3.12, `uv sync --group dev` for deps, `libcairo2-dev gcc libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0` system deps required (WeasyPrint PDF rendering)
 - `pip-audit --ignore-vuln PYSEC-2025-183` — disputed PyJWT weak-key-length CVE, no fix available

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ from the upstream URL; it should byte-match what ships in the image.
 
 Every push to `main` and every `vX.Y` tag triggers
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml), which builds
-`linux/amd64` + `linux/arm64` images and publishes to
+`linux/amd64` images and publishes to
 `ghcr.io/cybersecify/openeasd`. The build is reproducible from the
 public source; the published image carries:
 
@@ -452,7 +452,7 @@ GitHub Actions runs on every push to `main` and `v*` tags:
 - **pip-audit**: dependency CVE scan
 - **Frontend build**: `npm ci && npm run build`
 - **Docker build**: amd64 smoke-build on every push
-- **Publish to GHCR**: multi-arch (`amd64` + `arm64`) image published on every `main` push and version tags
+- **Publish to GHCR**: `amd64` images published on every `main` push and version tags
 
 ## API
 


### PR DESCRIPTION
arm64 is not required. The publish job now builds/pushes `linux/amd64` only — faster releases (no arm64 emulation). Docs updated to match; the docker build-check job was already amd64-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv