### PR TITLE
chore: bump version to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "0.10.0"
+version = "2.0.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Bumps pyproject version 0.10.0 -> 2.0.0 to match the v2.0.0 release tag, so `:latest` images and `/api/version` report 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv