### PR TITLE
chore: sync uv.lock openeasd version to 2.0.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "0.10.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Found while working on the CI tag change: the `2.0.0` version bump (#305) updated `pyproject.toml` but left `uv.lock` pinning the editable `openeasd` package at `0.10.0`. This re-syncs the lockfile so `uv sync --frozen` and the release version agree.

One-line change (the `[[package]] name = "openeasd"` version field). No dependency versions change.