### PR TITLE
ci: enforce ruff lint in CI + add ruff config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Lint — ruff
+        run: uv run ruff check apps/ openeasd/
+        # High-signal correctness rules (E/F/W, E501 deferred). Config in
+        # pyproject.toml [tool.ruff]. Runs before tests so lint fails fast.
+
       - name: Run tests (fast — exclude slow DNS tests)
         env:
           SECRET_KEY: "ci-test-secret-key-not-used-in-prod"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ git describe --tags --abbrev=0
 ## CI/CD (GitHub Actions)
 - Pipeline: `.github/workflows/ci.yml` — runs on every push to `main` and `v*` tags
 - **4 jobs:**
-  - `test` — pytest (fast, excludes `test_domain_security.py`) against a **`postgres:17-alpine` service container** (DB_* env), bandit (SAST), pip-audit (CVE scan)
+  - `test` — ruff (lint), pytest (fast, excludes `test_domain_security.py`) against a **`postgres:17-alpine` service container** (DB_* env), bandit (SAST), pip-audit (CVE scan)
   - `frontend` — `npm ci && npm run build`
   - `docker` — matrix over the `web` + `worker` build targets, `docker buildx build` for `linux/amd64` (no push, cache check per target)
   - `publish` — matrix over `web` + `worker`; builds `linux/amd64` and pushes to `ghcr.io/cybersecify/openeasd-web` and `-worker`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,8 +293,11 @@ Maintainers will ask you to add sign-offs before merging if they're missing.
 
 ## Code style
 
-- Python: follow what's there. We use Django 5+ idioms. No formatter
-  enforced in CI yet; please don't reformat unrelated lines in your PR.
+- Python: follow what's there. We use Django 5+ idioms. **`ruff check` runs
+  in CI** (config in `pyproject.toml [tool.ruff]`, rules E/F/W with line-length
+  deferred) — run `uv run ruff check apps/ openeasd/` before pushing, or
+  `uv run ruff check --fix` to auto-fix. No line-reflow formatter is enforced
+  yet, so please don't reformat unrelated lines in your PR.
 - JS: ES modules + JSX. Tailwind utility classes for styling.
 - Comments: only when the *why* is non-obvious. Don't restate the code.
 - Don't introduce new dependencies in a small PR — flag it in the

--- a/apps/core/api/update_check.py
+++ b/apps/core/api/update_check.py
@@ -48,10 +48,10 @@ def _parse_version(value):
 def is_update_available(current, latest):
     """True only when both versions parse AND latest is strictly newer."""
     c = _parse_version(current)
-    l = _parse_version(latest)
-    if c is None or l is None:
+    latest_v = _parse_version(latest)
+    if c is None or latest_v is None:
         return False
-    return l > c
+    return latest_v > c
 
 
 def get_latest_release(force=False):

--- a/apps/core/dashboard/management/commands/tools_healthcheck.py
+++ b/apps/core/dashboard/management/commands/tools_healthcheck.py
@@ -151,7 +151,7 @@ def run_probe(probe: Probe) -> tuple[bool, str]:
     # either stream is fine.
     combined = (result.stdout or "") + (result.stderr or "")
     if probe.expect_in_stdout and probe.expect_in_stdout not in combined:
-        return False, f"empty/unexpected output (this is the silent-fail mode)"
+        return False, "empty/unexpected output (this is the silent-fail mode)"
 
     return True, "OK"
 

--- a/apps/core/durable/dbos_app.py
+++ b/apps/core/durable/dbos_app.py
@@ -12,7 +12,7 @@ there is still just one database to run (no second service).
 
 from django.conf import settings
 
-from .constants import QUEUE_NAME, SYSTEM_SCHEMA as _SYSTEM_SCHEMA
+from .constants import SYSTEM_SCHEMA as _SYSTEM_SCHEMA
 
 _client = None
 

--- a/apps/core/scans/api.py
+++ b/apps/core/scans/api.py
@@ -10,7 +10,6 @@ from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
-import json as _json
 
 from ninja import Router, Schema, Status
 from ninja.errors import HttpError
@@ -24,7 +23,7 @@ from apps.core.scans.models import ScanSession
 logger = logging.getLogger(__name__)
 
 # RFC 1035 / RFC 1123 hostname validation (shared with domains/api.py)
-import re as _re
+import re as _re  # noqa: E402  (intentional: kept next to the pattern it compiles)
 _VALID_HOSTNAME = _re.compile(
     r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$"
 )

--- a/apps/dnsx/collector.py
+++ b/apps/dnsx/collector.py
@@ -37,7 +37,7 @@ def collect(session, subdomains: list[str]) -> list[dict]:
         raise ToolBinaryMissing(f"dnsx binary not found: {binary}")
     except subprocess.TimeoutExpired:
         logger.error(f"[dnsx:{session.id}] Timed out")
-        raise ToolTimeout(f"dnsx timed out")
+        raise ToolTimeout("dnsx timed out")
     finally:
         os.unlink(tmp)
 

--- a/apps/nmap/analyzer.py
+++ b/apps/nmap/analyzer.py
@@ -142,9 +142,9 @@ def analyze(session, xml_outputs: dict[str, str]) -> list[Finding]:
                             "port_number": port_num,
                             "address": ip,
                         }
-                        
+
                         severity = _severity_from_cvss(v["cvss"])
-                        
+
                         # Check backports
                         full_version_string = f"{version} {extrainfo}".strip()
                         backport_info = check_backport(product, full_version_string, v["id"])

--- a/apps/nmap/backports.py
+++ b/apps/nmap/backports.py
@@ -19,18 +19,18 @@ def compare_debian_versions(v1: str, v2: str) -> int:
     """
     def parse_parts(v):
         return [int(x) if x.isdigit() else x for x in re.split(r'([0-9]+)', v) if x]
-    
+
     p1 = parse_parts(v1)
     p2 = parse_parts(v2)
-    
+
     for a, b in zip(p1, p2):
         if a == b:
             continue
-        if type(a) == type(b):
+        if type(a) is type(b):
             return 1 if a > b else -1
         # In debian, strings and numbers compare strangely, but casting to str works for most simple cases
         return 1 if str(a) > str(b) else -1
-        
+
     if len(p1) > len(p2):
         return 1
     elif len(p1) < len(p2):
@@ -44,9 +44,9 @@ def check_backport(product: str, version_string: str, cve: str) -> dict:
     """
     if not version_string or not product:
         return None
-        
+
     product = product.lower()
-    
+
     # Identify distro and distro-specific version from nmap extrainfo strings.
     # Examples:
     #   "OpenSSH 9.6p1 Ubuntu Linux; protocol 2.0"   → no version suffix (skip)
@@ -56,27 +56,27 @@ def check_backport(product: str, version_string: str, cve: str) -> dict:
     # We specifically require the suffix to START with a digit to avoid capturing
     # words like "protocol" that appear in the common "Ubuntu Linux; protocol 2.0" format.
     match = re.search(r'(?i)(ubuntu|debian)(?:[^;]*?[-; ])\s*(\d[a-z0-9.~+-]*)', version_string)
-    
+
     distro = None
     distro_version = None
-    
+
     if match:
         distro = match.group(1).lower()
         distro_version = match.group(2).strip()
-                
+
     if not distro or not distro_version:
         return None
-        
+
     distro_data = BACKPORTS.get(distro, {})
     cve_data = distro_data.get(cve)
     if not cve_data:
         return None
-        
+
     # Get the fixed version for this product
     fixed_version = cve_data.get(product)
     if not fixed_version:
         return None
-        
+
     # Compare distro_version with fixed_version
     # If installed version >= fixed_version, it is patched
     if compare_debian_versions(distro_version, fixed_version) >= 0:
@@ -84,5 +84,5 @@ def check_backport(product: str, version_string: str, cve: str) -> dict:
             "backport_applied": True,
             "first_fixed_in": fixed_version
         }
-        
+
     return None

--- a/apps/nmap/sources/alpine_secdb.py
+++ b/apps/nmap/sources/alpine_secdb.py
@@ -11,14 +11,14 @@ def fetch_alpine_backports() -> Dict[str, Dict[str, str]]:
     base_url = "https://secdb.alpinelinux.org"
     branches = ["v3.20", "v3.21", "edge"]
     repos = ["main", "community"]
-    
+
     backports = {}
 
     for branch in branches:
         for repo in repos:
             url = f"{base_url}/{branch}/{repo}.json"
             req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-            
+
             try:
                 with urllib.request.urlopen(req, timeout=30) as response:  # nosec B310
                     data = json.loads(response.read().decode('utf-8'))
@@ -31,7 +31,7 @@ def fetch_alpine_backports() -> Dict[str, Dict[str, str]]:
                 pkg = pkg_entry.get('pkg', {})
                 pkg_name = pkg.get('name')
                 secfixes = pkg.get('secfixes', {})
-                
+
                 if not pkg_name or not secfixes:
                     continue
 

--- a/apps/nmap/sources/debian_security_tracker.py
+++ b/apps/nmap/sources/debian_security_tracker.py
@@ -9,7 +9,7 @@ def fetch_debian_backports() -> Dict[str, Dict[str, str]]:
     """
     url = "https://security-tracker.debian.org/tracker/data/json"
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-    
+
     try:
         with urllib.request.urlopen(req, timeout=30) as response:  # nosec B310
             data = json.loads(response.read().decode('utf-8'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,30 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+# Migrations are auto-generated; don't lint them.
+extend-exclude = ["**/migrations/**"]
+
+[tool.ruff.lint]
+# High-signal correctness rules only for now. E501 (line length) and import
+# ordering are left to a future formatter-adoption pass so this gate stays a
+# small, mechanical-diff-free correctness check rather than a 200-file reformat.
+select = ["E", "F", "W"]
+ignore = [
+    "E501",  # line length — deferred to formatter adoption
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Intentional late/deferred imports: Django settings run import-time side
+# effects, AppConfig.ready() wiring, and the DBOS modules defer imports to
+# break registration cycles — E402 is a false positive in these.
+"openeasd/settings.py" = ["E402"]
+"**/apps.py" = ["E402"]
+"apps/core/durable/**" = ["E402"]
+"manage.py" = ["E402"]
+# Routers are imported AFTER the NinjaAPI instance is built, on purpose
+# (each router module imports back from here) — the ordering is load-bearing.
+"apps/core/api/ninja.py" = ["E402"]


### PR DESCRIPTION
`ruff`, `black`, and `isort` are all dev dependencies, but **CI never ran any of them** (only pytest + bandit + pip-audit) — so lint drift went uncaught. This adds a ruff config and gates CI on it.

## Scope decision
Enabling everything surfaced ~1,800 issues — but **1,362 were line-length (E501)** and **295 were import-ordering**, both of which belong to a *formatter* pass, not a lint gate. Enforcing them now would mean a 200+ file mechanical reformat that would collide head-on with the open PRs (#291, #302). So this PR is deliberately a **small correctness gate**:

- `[tool.ruff]` with `select = ["E", "F", "W"]`, `ignore = ["E501"]`, migrations excluded.
- `per-file-ignores` for genuinely intentional late imports (settings side effects, `AppConfig.ready` wiring, the DBOS import-cycle breaks, and `ninja.py`'s load-bearing router-registration order).
- Fixed the 32 issues it surfaced: auto-fixes (3 unused imports, 2 placeholder-less f-strings, trailing whitespace) + 3 by hand:
  - `type(a) == type(b)` → `type(a) is type(b)` (`apps/nmap/backports.py`)
  - ambiguous variable `l` → `latest_v` (`apps/core/api/update_check.py`)
  - `# noqa: E402` on `scans/api.py`'s intentional mid-file `re` import
- `ci.yml`: a "Lint — ruff" step in the **required** `test` job (gates without a branch-protection change).
- CONTRIBUTING + CLAUDE.md updated to say `ruff check` runs in CI.

## Deferred (flagged, not done here)
The full `ruff format`/black reformat (207 files) + import-sort (`I`) is a **separate** follow-up — best run *after* #291/#302 merge to avoid mass conflicts. Not in this PR.

## Verification
`ruff check apps/ openeasd/` is clean. Full fast suite run against local Postgres (autofixes are unused-import/whitespace only — mechanically safe).