### PR TITLE
ci: add a test coverage gate (--cov-fail-under=80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         # High-signal correctness rules (E/F/W, E501 deferred). Config in
         # pyproject.toml [tool.ruff]. Runs before tests so lint fails fast.
 
-      - name: Run tests (fast — exclude slow DNS tests)
+      - name: Run tests + coverage gate (fast — exclude slow DNS tests)
         env:
           SECRET_KEY: "ci-test-secret-key-not-used-in-prod"
           DEBUG: "True"
@@ -77,7 +77,12 @@ jobs:
           DB_NAME: openeasd
           DB_USER: openeasd
           DB_PASSWORD: openeasd
-        run: uv run pytest tests/ --ignore=tests/unit/test_domain_security.py -q
+        # --cov uses [tool.coverage.run] source/omit in pyproject.toml.
+        # Fail-under is set a few points below the current ~83% so the gate
+        # catches real regressions without flapping on minor fluctuation.
+        run: >-
+          uv run pytest tests/ --ignore=tests/unit/test_domain_security.py -q
+          --cov --cov-report=term-missing --cov-fail-under=80
 
       - name: SAST — bandit
         run: uv run bandit -r apps/ openeasd/ -ll -x tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ git describe --tags --abbrev=0
 ## CI/CD (GitHub Actions)
 - Pipeline: `.github/workflows/ci.yml` — runs on every push to `main` and `v*` tags
 - **4 jobs:**
-  - `test` — ruff (lint), pytest (fast, excludes `test_domain_security.py`) against a **`postgres:17-alpine` service container** (DB_* env), bandit (SAST), pip-audit (CVE scan)
+  - `test` — ruff (lint), pytest (fast, excludes `test_domain_security.py`) against a **`postgres:17-alpine` service container** (DB_* env) with a **coverage gate** (`--cov-fail-under=80`; config in `[tool.coverage.run]`, ~83% currently), bandit (SAST), pip-audit (CVE scan)
   - `frontend` — `npm ci`, `npm run test:run` (Vitest + Testing Library, happy-dom env), `npm run build`
   - `docker` — matrix over the `web` + `worker` build targets, `docker buildx build` for `linux/amd64` (no push, cache check per target)
   - `publish` — matrix over `web` + `worker`; builds `linux/amd64` and pushes to `ghcr.io/cybersecify/openeasd-web` and `-worker`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,29 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 testpaths = ["tests"]
 
+[tool.coverage.run]
+source = ["apps", "openeasd"]
+branch = true
+omit = [
+    "*/migrations/*",  # auto-generated
+    "*/tests/*",
+    "manage.py",
+    "*/apps.py",       # trivial AppConfig registration (tool_meta only)
+    "*/admin.py",      # Django admin registration
+    "openeasd/wsgi.py",
+    "openeasd/asgi.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+]
+
 [tool.ruff]
 target-version = "py312"
 line-length = 88


### PR DESCRIPTION
`pytest-cov` was already a dev dependency, but **coverage was never measured or enforced** in CI. This measures it and adds a floor so coverage regressions get caught.

## Measured
Full fast suite (against local Postgres): **~83%** line coverage (8,453 statements, branch coverage on).

## Change
- **`pyproject.toml`** — `[tool.coverage.run]` (source `apps`+`openeasd`, `branch = true`, omit migrations/tests/`apps.py`/`admin.py`/`wsgi`/`asgi`) and `[tool.coverage.report]` (`show_missing` + standard `exclude_lines`).
- **`ci.yml`** — the test step now runs `--cov --cov-report=term-missing --cov-fail-under=80`. The floor sits ~3 points below current so it **catches real regressions without flapping** on minor fluctuation.
- **`CLAUDE.md`** — documents the gate.

This is the third and final Tier-1 PR (after ruff lint #310 and frontend tests #311).