### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.1.0] — 2026-09-06
+
 ### Removed
 - **Dead `main.py` dev-runner.** It launched `manage.py qcluster` (Django-Q2,
   removed in the v2.0 DBOS re-platform) and was only `COPY`d into the image, never

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.0.0"
+version = "2.1.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Cuts **v2.1.0** for the hardening + tooling merged since v2.0.0, and (per the tag review) will exercise the `:vX.Y` image-tag automation for the first time on a real tag push.

## Included since v2.0.0
- **Security:** login brute-force rate limiting (per-IP, DB-backed, configurable XFF trust) + BYOK secrets encrypted at rest (Fernet)
- **Quality gates:** `ruff` lint, frontend Vitest suite, 80% coverage floor
- **Cleanup:** removed the dead `main.py` dev-runner + stale references

## Change
- `pyproject.toml` + `uv.lock`: 2.0.0 → 2.1.0
- `CHANGELOG.md`: `[Unreleased]` → `[v2.1.0]`

After merge I'll tag `v2.1.0` on main → CI publishes `:v2.1.0` + `:v2.1` + refreshes `:latest`, then I'll create the GitHub Release and verify the images land.