### PR TITLE
chore: remove dead SQLite WAL signal handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Removed
+- **Dead SQLite WAL signal handler** in settings — a leftover `connection_created`
+  hook that only fired for the SQLite backend, which no longer exists (Postgres
+  since v2.0). No behavior change.
+
 ## [v2.1.0] — 2026-09-06
 
 ### Removed

--- a/openeasd/settings.py
+++ b/openeasd/settings.py
@@ -611,15 +611,3 @@ NINJA_JWT = {
     "BLACKLIST_AFTER_ROTATION": False,
     "UPDATE_LAST_LOGIN": False,
 }
-
-# Enable WAL journal mode for SQLite so parallel phase-7 tool threads
-# can write concurrently without hitting "database is locked" errors.
-from django.db.backends.signals import connection_created  # noqa: E402
-
-
-def _set_sqlite_wal(sender, connection, **kwargs):
-    if connection.vendor == "sqlite":
-        connection.cursor().execute("PRAGMA journal_mode=WAL;")
-
-
-connection_created.connect(_set_sqlite_wal)


### PR DESCRIPTION
Follow-up to the architecture review: settings.py had a `connection_created` signal handler that ran `PRAGMA journal_mode=WAL` — but it only fires `if connection.vendor == "sqlite"`, and SQLite was removed in the v2.0 Postgres re-platform. It's dead on every real deployment. Removes the handler and its now-unused import. No behavior change (django check + settings-security tests pass; ruff clean).