### PR TITLE
docs: fix stale Django-Q references in comments

### DIFF
--- a/apps/core/ai/orchestrator.py
+++ b/apps/core/ai/orchestrator.py
@@ -1,7 +1,7 @@
 """Adaptive scan orchestration — the bounded agent loop.
 
 One step = exactly one LLM decision call plus bookkeeping. Steps are chained
-through Django-Q: a step that launches a subscan returns immediately, and the
+through DBOS: a step that launches a subscan returns immediately, and the
 subscan's finalize re-enqueues the next step (hooks.maybe_continue_agent).
 Nothing ever waits on another task, so the single worker cannot deadlock.
 

--- a/apps/core/scans/pipeline.py
+++ b/apps/core/scans/pipeline.py
@@ -282,9 +282,9 @@ def create_scan_session(domain: str, triggered_by: str = "manual", workflow=None
 
     try:
         with transaction.atomic():
-            # NOTE: select_for_update(nowait=True) is a no-op on SQLite — Django silently
-            # ignores it. Real duplicate-session protection comes from workers=1 in
-            # Q_CLUSTER and the if-active check below, not from DB-level locking.
+            # Real duplicate-session protection comes from the partial unique
+            # constraint (uniq_active_scan_per_domain) plus the if-active check
+            # below; on Postgres select_for_update(nowait=True) also narrows the race.
             active = (
                 ScanSession.objects
                 .select_for_update(nowait=True)
@@ -331,7 +331,7 @@ def _seed_apex_into_assets(session) -> None:
 
     The Subdomain insert alone isn't enough — dnsx has been observed silently
     returning 0 records for a single-host input list when invoked from the
-    Django-Q worker (works fine in a bare subprocess). Resolving here with
+    worker process (works fine in a bare subprocess). Resolving here with
     dnspython sidesteps that and guarantees the apex flows downstream into
     naabu / service_detection / nmap / tls / ssh / nuclei_network.
     """

--- a/apps/core/scheduler/scheduler.py
+++ b/apps/core/scheduler/scheduler.py
@@ -14,14 +14,14 @@ from django.utils import timezone as django_tz
 logger = logging.getLogger(__name__)
 
 from decouple import config as _config  # noqa: E402
-# Must be >= Q_CLUSTER["timeout"] (4h / 14400s). The watchdog only cleans up the
-# DB status of scans whose worker died without finalizing; it must not fire while
-# a healthy scan is still legitimately running, or it flips a live scan to
-# "partial" mid-run. Keep this at/above the worker hard-kill (240m).
+# Must be >= the worker's scan hard-kill (SCAN_TASK_TIMEOUT). The watchdog only
+# cleans up the DB status of scans whose worker died without finalizing; it must
+# not fire while a healthy scan is still legitimately running, or it flips a live
+# scan to "partial" mid-run. Keep this at/above the worker hard-kill (240m).
 SCAN_TIMEOUT_MINUTES = _config("SCAN_TIMEOUT_MINUTES", default=1440, cast=int)  # 24h; >= SCAN_TASK_TIMEOUT
 
-# A scan stuck in "pending" never started running — its enqueued Django-Q task was
-# lost (e.g. the qcluster worker restarted between enqueue and pickup), so it sits
+# A scan stuck in "pending" never started running — its enqueued workflow never
+# got picked up (e.g. the worker was down between enqueue and pickup), so it sits
 # in "pending" forever. Because the per-domain concurrency guard counts pending
 # scans as active, one orphaned pending scan blocks every new scan for that domain
 # indefinitely (observed in prod: a scan sat pending ~6h and blocked the domain).
@@ -34,7 +34,7 @@ SCAN_PENDING_TIMEOUT_MINUTES = _config("SCAN_PENDING_TIMEOUT_MINUTES", default=6
 
 
 # ---------------------------------------------------------------------------
-# Core schedule setup (called once on qcluster startup)
+# Core schedule setup (legacy no-op — schedules are DBOS @scheduled workflows)
 # ---------------------------------------------------------------------------
 
 def setup_core_schedules():
@@ -61,7 +61,7 @@ def sync_domain_monitoring_jobs():
 
 
 # ---------------------------------------------------------------------------
-# Callable functions (must be importable module-level paths for Django-Q2)
+# Callable functions (invoked by the DBOS @scheduled sweeps in apps/core/durable)
 # ---------------------------------------------------------------------------
 
 def _is_authorized(domain: str) -> bool:
@@ -145,7 +145,7 @@ def run_due_user_scans():
 
 
 def run_scheduled_scan(domain: str, triggered_by: str = "scheduled"):
-    """Top-level callable for Django-Q2 one-time and recurring scan jobs.
+    """Top-level callable for one-time and recurring scan jobs (invoked by the DBOS user-schedule sweep).
 
     Re-checks consent at run time, mirroring daily_scan/run_monitoring_scan.
     A user-created recurring/one-time schedule is authorization-checked only
@@ -211,8 +211,8 @@ def reap_stuck_scans():
       worker hard-kill so a healthy long scan is never flipped mid-run).
     - `pending` scans are reaped after SCAN_PENDING_TIMEOUT_MINUTES, which is far
       shorter: a pending scan never started, so it doesn't need the running budget.
-      This is what stops an orphaned pending scan (lost Django-Q task after a worker
-      restart) from blocking a domain for hours via the pending-counting guard.
+      This is what stops an orphaned pending scan (the worker was down between
+      enqueue and pickup) from blocking a domain for hours via the pending-counting guard.
 
     A scan that had at least one step complete before the timeout is reaped as
     `partial` (its findings are kept and shown). A scan with no completed steps


### PR DESCRIPTION
Follow-up to the AI-agent-loop walkthrough: several comments/docstrings still described the **current** mechanism in Django-Q / `Q_CLUSTER` / qcluster terms, but the project has run on **DBOS** since v2.0.

Fixed (comment/docstring only — no code change):
- **orchestrator.py** — agent steps are chained through **DBOS**, not Django-Q (the one flagged in the walkthrough).
- **scheduler.py** — watchdog timeout basis is `SCAN_TASK_TIMEOUT`, not `Q_CLUSTER["timeout"]`; callables are invoked by the DBOS `@scheduled` sweeps (not "importable paths for Django-Q2"); the stuck-pending rationale and the setup-header "on qcluster startup" reworded.
- **pipeline.py** — duplicate-scan protection is now the `uniq_active_scan_per_domain` partial unique constraint + the if-active check on Postgres (the old note claimed "workers=1 in Q_CLUSTER" and an SQLite no-op); the dnsx note says "worker process".

Left untouched: the accurate historical "replaces / removed / no longer" Django-Q notes (they correctly document the migration). ruff clean.