### PR TITLE
ci: extend ruff lint to tests/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
         run: uv sync --group dev
 
       - name: Lint — ruff
-        run: uv run ruff check apps/ openeasd/
+        run: uv run ruff check apps/ openeasd/ tests/
         # High-signal correctness rules (E/F/W, E501 deferred). Config in
-        # pyproject.toml [tool.ruff]. Runs before tests so lint fails fast.
+        # pyproject.toml [tool.ruff]. Includes tests/ (per-file-ignores relax
+        # E402/E702 there). Runs before tests so lint fails fast.
 
       - name: Run tests + coverage gate (fast — exclude slow DNS tests)
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,7 +300,7 @@ Maintainers will ask you to add sign-offs before merging if they're missing.
 
 - Python: follow what's there. We use Django 5+ idioms. **`ruff check` runs
   in CI** (config in `pyproject.toml [tool.ruff]`, rules E/F/W with line-length
-  deferred) — run `uv run ruff check apps/ openeasd/` before pushing, or
+  deferred) — run `uv run ruff check apps/ openeasd/ tests/` before pushing, or
   `uv run ruff check --fix` to auto-fix. No line-reflow formatter is enforced
   yet, so please don't reformat unrelated lines in your PR.
 - JS: ES modules + JSX. Tailwind utility classes for styling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,3 +126,6 @@ ignore = [
 # Routers are imported AFTER the NinjaAPI instance is built, on purpose
 # (each router module imports back from here) — the ordering is load-bearing.
 "apps/core/api/ninja.py" = ["E402"]
+# Tests legitimately import mid-file (near the case that uses them) and use
+# compact semicolon setup lines; keep the correctness rules (F/W) on them.
+"tests/**" = ["E402", "E702"]

--- a/tests/test_backports_refresh.py
+++ b/tests/test_backports_refresh.py
@@ -71,22 +71,22 @@ def test_do_refresh_schema_merge(mock_replace, mock_open, mock_alpine, mock_debi
     mock_ubuntu.return_value = {"CVE-UBUNTU": {"pkg": "1.0"}}
     mock_debian.return_value = {"CVE-DEBIAN": {"pkg": "2.0"}}
     mock_alpine.return_value = {"CVE-ALPINE": {"pkg": "3.0"}}
-    
+
     # Import the command locally to avoid executing it on import if __main__ is not protected
     from apps.nmap.management.commands.refresh_backports import do_refresh
-    
+
     do_refresh()
-    
+
     mock_ubuntu.assert_called_once()
     mock_debian.assert_called_once()
     mock_alpine.assert_called_once()
     mock_open.assert_called_once()
-    
+
     # Extract the JSON string that was written
     handle = mock_open.return_value.__enter__.return_value
     written_data = "".join(call.args[0] for call in handle.write.call_args_list)
     parsed_json = json.loads(written_data)
-    
+
     assert "ubuntu" in parsed_json
     assert "debian" in parsed_json
     assert "alpine" in parsed_json

--- a/tests/unit/test_alpine_secdb.py
+++ b/tests/unit/test_alpine_secdb.py
@@ -31,11 +31,11 @@ def test_fetch_alpine_backports_happy_path(mock_urlopen, mock_alpine_json):
     mock_urlopen.return_value.__enter__.return_value = mock_response
 
     backports = fetch_alpine_backports()
-    
+
     # Assert
     assert "CVE-2021-30473" in backports
     assert backports["CVE-2021-30473"]["aom"] == "3.1.1-r0"
-    
+
     assert "CVE-2024-5171" in backports
     assert backports["CVE-2024-5171"]["aom"] == "3.9.1-r0"
 
@@ -50,7 +50,7 @@ def test_fetch_alpine_backports_malformed(mock_urlopen, mock_malformed_json):
     mock_urlopen.return_value.__enter__.return_value = mock_response
 
     backports = fetch_alpine_backports()
-    
+
     # Should not crash and return empty dictionary since all fetches fail json parsing
     assert backports == {}
     assert mock_urlopen.call_count == 6
@@ -61,7 +61,7 @@ def test_fetch_alpine_backports_network_error(mock_urlopen):
     mock_urlopen.side_effect = Exception("Network timeout")
 
     backports = fetch_alpine_backports()
-    
+
     # Should handle error gracefully and return empty dict
     assert backports == {}
     assert mock_urlopen.call_count == 6

--- a/tests/unit/test_nmap.py
+++ b/tests/unit/test_nmap.py
@@ -302,14 +302,14 @@ class TestBackportMatching:
     def test_backport_applied_demotes_to_info(self):
         sess = self._make_session()
         findings = analyze(sess, {"1.2.3.4": self.SAMPLE_XML_UBUNTU})
-        
+
         by_cve = {f.cve: f for f in findings}
-        
+
         # CVE-2024-6387 is patched in 3ubuntu13.3, and we are running 3ubuntu13.4 -> info
         f1 = by_cve["CVE-2024-6387"]
         assert f1.severity == "info"
         assert f1.extra.get("backport_applied") is True
-        
+
         # CVE-2024-39894 is not in our mock BACKPORTS -> original severity
         f2 = by_cve["CVE-2024-39894"]
         assert f2.severity == "medium"


### PR DESCRIPTION
Closes the lint blind spot from the CI-review: `tests/` wasn't linted, so an unused import (`test_exposure_score.py`) and count drift slipped through there earlier.

- **ci.yml** — ruff now checks `apps/ openeasd/ tests/`.
- **pyproject** — a `tests/**` per-file-ignore relaxes **E402** (tests import mid-file, next to the case that uses them) and **E702** (compact semicolon setup lines), while keeping the valuable **F/W** correctness rules — the unused-import class that escaped — enforced on tests.
- Auto-fixed trailing whitespace (W293) in 3 test files.
- CONTRIBUTING pre-push command updated.

ruff clean on `apps/ openeasd/ tests/`.