### PR TITLE
docs: recommend the 3-tier deployment architecture explicitly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,13 @@ uv run manage.py dbos_worker
 
 ### Docker (production) — 3 services
 
-The stack is **PostgreSQL + web + worker** (Option B). Use Docker Compose:
+The stack is **PostgreSQL + web + worker** (Option B) — the **recommended
+architecture**: it keeps offensive tooling + `NET_RAW` off the internet-facing
+`web` tier (privilege separation), isolates OOM-prone tool crashes to a worker
+(the UI stays up), and lets workers scale independently of web. Collapsing
+web+worker into one container is only for a small trusted single-user eval (it
+puts tools + raw sockets on the exposed process); keep `db` separate regardless.
+Use Docker Compose:
 
 ```bash
 # Set real secrets in docker-compose.yml (SECRET_KEY, DB_PASSWORD, ALLOWED_HOSTS), then:

--- a/README.md
+++ b/README.md
@@ -316,6 +316,23 @@ docker compose up -d --build
 - `web` — the slim `openeasd-web` image (UI/API + PDF reports; no scanner tools)
 - `worker` — the `openeasd-worker` image (DBOS worker + the full scanner matrix, `NET_RAW`)
 
+> **Run all three tiers — this is the recommended architecture.** Keeping
+> `web`, `worker`, and `db` as separate containers is deliberate:
+> - **Privilege separation** — the internet-facing `web` image carries **no
+>   scanner tools and no `NET_RAW`**, so a compromised web surface doesn't
+>   inherit the offensive toolkit or raw-socket access (those live only on the
+>   worker, which isn't exposed).
+> - **Fault isolation** — nuclei/amass are memory-hungry; if one is OOM-killed
+>   it takes down only a worker, not the UI/API.
+> - **Independent scaling** — Postgres has no single-writer lock, so you can run
+>   multiple `worker` replicas pulling the same DBOS queue for scan throughput
+>   while the `web` tier scales separately for HTTP load.
+>
+> Collapsing `web` + `worker` into one container is possible for a small,
+> trusted, single-user evaluation, but it puts the scanner tools and `NET_RAW`
+> on the exposed process — **not recommended for internet-facing deployments.**
+> Keep `db` as its own container either way so app replacement never risks data.
+
 Open http://localhost:8000, then log in with `admin` / `admin`. You will be forced to set a new password before accessing the app.
 
 > **Production note:** `ALLOWED_HOSTS="*"` is fine for evaluation on a private network. For internet-facing deployments, narrow it to your actual hostname or IP (e.g. `ALLOWED_HOSTS="scanner.example.com,127.0.0.1"`) and set `CSRF_TRUSTED_ORIGINS` if accessing over a domain.


### PR DESCRIPTION
The deployment docs listed the three services but never stated *why* the split is the recommended architecture. Makes the recommendation explicit with the rationale:

- **Privilege separation** — the internet-facing `web` image carries no scanner tools and no `NET_RAW`; a compromised web surface doesn't inherit the offensive toolkit.
- **Fault isolation** — an OOM-killed nuclei/amass takes down only a worker, not the UI.
- **Independent scaling** — multiple `worker` replicas can pull the DBOS queue while `web` scales separately.

Notes that collapsing web+worker is acceptable only for a small trusted single-user eval (it puts tools + raw sockets on the exposed process), and `db` stays its own container regardless. Docs-only (README + CLAUDE.md).