### PR TITLE
fix: bump k8s image tag from v0.4 to v2.1.0

### DIFF
--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -2,10 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: default
 images:
+  # Pin to a released version for reproducible rollouts. Bump per release (or
+  # switch to the floating :v2.1 major.minor tag + imagePullPolicy: Always to
+  # auto-pick-up patch releases).
   - name: ghcr.io/cybersecify/openeasd-web
-    newTag: v0.4
+    newTag: v2.1.0
   - name: ghcr.io/cybersecify/openeasd-worker
-    newTag: v0.4
+    newTag: v2.1.0
 resources:
   - configmap.yaml
   - pvc.yaml


### PR DESCRIPTION
The project already deploys via **Kustomize** (`kubectl apply -k k8s/`), but the `images:` override pinned `openeasd-web`/`-worker` to **`v0.4`** — a pre-split tag that **doesn't exist** (the split images start at v2.0.0). A fresh apply would `ImagePullBackOff`.

- Pin both to the current release **`v2.1.0`** (with a note on switching to the floating `:v2.1` + `imagePullPolicy: Always` for auto-patch).
- Verified: `kubectl kustomize k8s/` renders `openeasd-web:v2.1.0` + `openeasd-worker:v2.1.0`; all 59 `test_k8s_manifests.py` tests pass; the v2.1.0 images exist in GHCR.

The flat kustomize layout is kept — it's the right shape for a single-target single-user deploy; base+overlays would be over-engineering here.