### PR TITLE
docs: clean up dangling references to the removed root PRD.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,6 @@ frontend/node_modules/
 tests/
 docs/
 *.md
-PRD.md
 
 # Build artifacts already copied via multi-stage
 frontend/dist/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,6 @@
 /CHANGELOG.md                    @rathnakaragn @ashok-kamat
 /CONTRIBUTING.md                 @rathnakaragn @ashok-kamat
 /CLAUDE.md                       @rathnakaragn @ashok-kamat
-/PRD.md                          @rathnakaragn @ashok-kamat
 /LICENSE                         @rathnakaragn @ashok-kamat
 
 # Security (technical-leaning — Rathnakar primary, Ashok co-reviewer)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -213,7 +213,7 @@ Calling these out so contributors don't add them back without a discussion:
 > report/alert summaries — because they turned out to be thin consumers of
 > triage's plumbing. See D-015 for the reasoning.
 
-**What.** v2.0 will add an LLM-powered finding triage layer to OpenEASD — turning the scanner's raw output (76 findings, 3 critical, 21 high…) into a ranked, contextualised "fix this first" list with reasoning. Direction chosen over 4 other candidate scopes (chat-over-findings, auto-generated tool integrations, multi-agent recon planning, remediation playbooks) — see PRD.md v2.0 section.
+**What.** v2.0 will add an LLM-powered finding triage layer to OpenEASD — turning the scanner's raw output (76 findings, 3 critical, 21 high…) into a ranked, contextualised "fix this first" list with reasoning. Direction chosen over 4 other candidate scopes (chat-over-findings, auto-generated tool integrations, multi-agent recon planning, remediation playbooks) — see D-014/D-015.
 
 **Why.** The OSS recon-tool wrapper space is saturated. Analyst-grade output is genuinely scarce. Backport-aware CVE matching (PR #56, [@turfin-logic](https://github.com/turfin-logic)) made the gap concrete: scanner output emits the same false-positive noise the underlying tools do, and the differentiation we can offer is *being smarter about the output than the tool we wrap*. LLM-triage extends that exact play from "filter out one class of false positive" to "rank everything by what actually matters."
 


### PR DESCRIPTION
Answering "did we update all docs" — removing root `PRD.md` (#333) left **three stale references** the audit caught:

- **`.dockerignore`** — dropped the redundant `PRD.md` line (the `*.md` rule above it already excludes it; the explicit line now named a deleted file).
- **`.github/CODEOWNERS`** — removed the dead `/PRD.md` owner rule (the `/docs/` rule already owns `docs/PRD.md`).
- **`docs/DECISIONS.md`** — the "see PRD.md v2.0 section" prose pointer is now stale (`docs/PRD.md` has no v2.0 section) → repointed to **D-014/D-015**, the authoritative record of that scope.

The only remaining `PRD.md` reference is `docs/DESIGN.md`'s relative `[PRD.md](PRD.md)`, which correctly resolves to `docs/PRD.md`. No dangling references left.