### PR TITLE
feat: asset inventory API — /api/assets/ list/detail/summary (PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ commits to recover the reasoning.
   `status`, populated by a fail-graceful rollup at scan finalize (honest
   `gone`-marking: only on completed scans, only for kinds actually observed).
   `Finding.asset` links findings to the inventory. A backfill migration seeds it
-  from existing scan history. No user-facing surface yet — the `/api/assets/`
-  endpoints and Assets UI are later PRs (see
-  `docs/specs/2026-09-06-asset-centric-inventory.md`). Additive: with the
-  inventory unused, scans behave exactly as before.
+  from existing scan history. **Read API (PR2):** `GET /api/assets/` (paginated,
+  filterable by domain/kind/status/search, each row with per-severity open-finding
+  counts), `GET /api/assets/summary/` (totals by kind + active/gone), and
+  `GET /api/assets/<id>/` (metadata + findings + scan timeline). The Assets UI is
+  the next PR (see `docs/specs/2026-09-06-asset-centric-inventory.md`). Additive:
+  with the inventory unused, scans behave exactly as before.
 - **Historical DNS Records tool (`dns_history`, tool #28) — passive.** Queries a
   passive-DNS dataset for a domain's historical A/AAAA/MX records and surfaces
   each as an informational finding (past hosting / stale records → recon and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,7 @@ Per-module routers (each file exports a `router = Router(auth=JWTAuth())`):
     apps/core/workflows/api.py   — /api/workflows/ CRUD + /tools/
     apps/core/insights/api.py    — /api/insights/
     apps/core/notifications/api.py — /api/notifications/ config + test + alerts
+    apps/core/asset_inventory/api.py — /api/assets/ list + summary + detail
     (scheduled router in scans/api.py) — /api/scheduled/
 ```
 
@@ -698,6 +699,9 @@ POST /api/workflows/<pk>/update/          — update workflow name/tools
 POST /api/workflows/<pk>/rename/          — rename workflow
 POST /api/workflows/<pk>/delete/          — delete workflow
 POST /api/workflows/<pk>/steps/<tool>/toggle/ — toggle single tool step
+GET  /api/assets/                         — persistent asset inventory (paginated; ?domain=&kind=&status=&q=), each row with per-severity open-finding counts
+GET  /api/assets/summary/                 — inventory totals by kind + active/gone
+GET  /api/assets/<id>/                     — asset detail: metadata + extra, findings, scan timeline (seen_in_scans)
 GET  /api/insights/                       — trends, top hosts, asset growth, KPIs, Exposure Score + trend (per-scan exposure_score/grade + top-level exposure block)
 GET  /api/notifications/config/           — get Slack/Teams notification config
 POST /api/notifications/config/           — update notification config
@@ -795,7 +799,8 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_login_ratelimit.py` | 13 | Login brute-force limiter — threshold lockout, window reset, success clears, X-Forwarded-For keying (+ untrusted-XFF fallback / spoof-evasion), middleware integration (per-IP isolation, disabled bypass, refresh endpoint unaffected) |
 
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
+| `tests/unit/test_asset_inventory_api.py` | 11 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404) |
 
-**Total: 1741 tests** (1689 fast + 52 slow domain_security)
+**Total: 1752 tests** (1700 fast + 52 slow domain_security)
 
 Frontend: **15 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, and the axios 401-refresh interceptor. Run with `cd frontend && npm run test:run`.

--- a/apps/core/api/ninja.py
+++ b/apps/core/api/ninja.py
@@ -171,3 +171,6 @@ api.add_router("/notifications", notifications_router)
 
 from apps.core.ai.api import router as ai_router
 api.add_router("/ai", ai_router)
+
+from apps.core.asset_inventory.api import router as assets_router
+api.add_router("/assets", assets_router)

--- a/apps/core/asset_inventory/api.py
+++ b/apps/core/asset_inventory/api.py
@@ -1,0 +1,166 @@
+"""Asset inventory API — /api/assets/ (spec: docs/specs/2026-09-06-asset-centric-inventory.md, PR2).
+
+Read-only views over the persistent Asset inventory built by the finalize
+rollup. Flat JSON, JWT-authed, same shape/pagination as the rest of the API.
+"""
+
+import logging
+
+from django.core.paginator import Paginator
+from django.db.models import Count, Q
+from django.shortcuts import get_object_or_404
+from ninja import Router
+
+from apps.core.api.auth import JWTAuth
+
+from .models import Asset
+
+logger = logging.getLogger(__name__)
+
+router = Router(auth=JWTAuth())
+
+_SEV = ["critical", "high", "medium", "low", "info"]
+
+
+def _severity_counts():
+    """Conditional-aggregation annotations: open findings per severity, per asset."""
+    return {
+        f"c_{s}": Count("findings", filter=Q(findings__severity=s, findings__status="open"))
+        for s in _SEV
+    }
+
+
+def _row(a) -> dict:
+    return {
+        "id": a.id,
+        "kind": a.kind,
+        "key": a.key,
+        "domain": a.domain.name,
+        "status": a.status,
+        "first_seen": a.first_seen.isoformat(),
+        "last_seen": a.last_seen.isoformat(),
+        "findings": {s: getattr(a, f"c_{s}", 0) for s in _SEV},
+    }
+
+
+def _finding_brief(f) -> dict:
+    return {
+        "id": f.id,
+        "session_uuid": str(f.session.uuid) if f.session_id else None,
+        "source": f.source,
+        "check_type": f.check_type,
+        "severity": f.severity,
+        "title": f.title,
+        "target": f.target,
+        "status": f.status,
+        "discovered_at": f.discovered_at.isoformat(),
+    }
+
+
+def _seen_in_scans(asset) -> list[dict]:
+    """Best-effort scan timeline: sessions whose per-scan assets carried this key.
+
+    PR1 has no AssetObservation table, so this derives the timeline from the
+    session-scoped asset rows. Guarded — any parse/lookup issue yields []."""
+    from apps.core.scans.models import ScanSession
+
+    dn = asset.domain.name
+    try:
+        if asset.kind == "subdomain":
+            from apps.core.assets.models import Subdomain
+            sids = Subdomain.objects.filter(session__domain=dn, subdomain=asset.key)
+        elif asset.kind == "ip":
+            from apps.core.assets.models import IPAddress
+            sids = IPAddress.objects.filter(session__domain=dn, address=asset.key)
+        elif asset.kind == "port":
+            from apps.core.assets.models import Port
+            addr, rest = asset.key.rsplit(":", 1)
+            port_num, proto = rest.split("/")
+            sids = Port.objects.filter(
+                session__domain=dn, address=addr, port=int(port_num), protocol=proto
+            )
+        elif asset.kind == "url":
+            from apps.core.web_assets.models import URL
+            sids = URL.objects.filter(session__domain=dn, url=asset.key)
+        else:
+            return []
+        session_ids = set(sids.values_list("session_id", flat=True))
+    except Exception:  # noqa: BLE001 — timeline is best-effort, never fail the request
+        logger.warning("asset_inventory: seen_in_scans lookup failed for asset %s", asset.id)
+        return []
+
+    sessions = ScanSession.objects.filter(id__in=session_ids).order_by("-start_time")
+    return [
+        {
+            "uuid": str(s.uuid),
+            "status": s.status,
+            "at": s.start_time.isoformat() if s.start_time else None,
+        }
+        for s in sessions
+    ]
+
+
+@router.get("/")
+def list_assets(request, domain: str = "", kind: str = "", status: str = "",
+                q: str = "", page: int = 1):
+    qs = Asset.objects.select_related("domain").annotate(**_severity_counts())
+    if domain:
+        qs = qs.filter(domain__name__icontains=domain)
+    if kind:
+        qs = qs.filter(kind=kind)
+    if status:
+        qs = qs.filter(status=status)
+    if q:
+        qs = qs.filter(key__icontains=q)
+    qs = qs.order_by("kind", "key")
+
+    paginator = Paginator(qs, 25)
+    p = paginator.get_page(page)
+    return {
+        "assets": [_row(a) for a in p],
+        "total": paginator.count,
+        "page": p.number,
+        "total_pages": paginator.num_pages,
+        "has_next": p.has_next(),
+        "has_previous": p.has_previous(),
+    }
+
+
+@router.get("/summary/")
+def assets_summary(request, domain: str = ""):
+    qs = Asset.objects.all()
+    if domain:
+        qs = qs.filter(domain__name__icontains=domain)
+
+    by_kind: dict[str, dict[str, int]] = {}
+    for row in qs.values("kind", "status").annotate(n=Count("id")):
+        by_kind.setdefault(row["kind"], {"active": 0, "gone": 0})[row["status"]] = row["n"]
+
+    return {
+        "total": qs.count(),
+        "active": qs.filter(status="active").count(),
+        "gone": qs.filter(status="gone").count(),
+        "by_kind": by_kind,
+    }
+
+
+@router.get("/{asset_id}/")
+def asset_detail(request, asset_id: int):
+    a = get_object_or_404(Asset.objects.select_related("domain"), id=asset_id)
+    findings = (
+        a.findings.select_related("session")
+        .order_by("-discovered_at")
+    )
+    return {
+        "id": a.id,
+        "kind": a.kind,
+        "key": a.key,
+        "domain": a.domain.name,
+        "status": a.status,
+        "first_seen": a.first_seen.isoformat(),
+        "last_seen": a.last_seen.isoformat(),
+        "extra": a.extra,
+        "last_scan": str(a.last_scan.uuid) if a.last_scan_id else None,
+        "findings": [_finding_brief(f) for f in findings],
+        "seen_in_scans": _seen_in_scans(a),
+    }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -239,6 +239,7 @@ GET  /api/scans/<uuid>/status/        lightweight status (React polls every 3s w
 POST /api/scans/<uuid>/subscan/       re-run a subset of tools against an existing scan
 GET  /api/scans/findings/             paginated findings (?severity= &domain= &status= &source=)
 GET  /api/insights/                   trends, top hosts, asset growth, Exposure Score
+GET  /api/assets/                     persistent asset inventory (?domain= &kind= &status= &q=)
 GET  /api/ai/triage/<uuid>/           AI triage status + ranked items + agent decisions
 GET  /api/version/  /health/          build provenance (unauthenticated)
 GET  /api/docs                        OpenAPI / Swagger UI

--- a/tests/unit/test_asset_inventory_api.py
+++ b/tests/unit/test_asset_inventory_api.py
@@ -1,0 +1,133 @@
+"""Tests for the /api/assets/ endpoints (asset inventory PR2)."""
+
+import pytest
+from django.contrib.auth.models import User
+from django.utils import timezone
+from ninja_jwt.tokens import AccessToken
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def auth_client(client):
+    user = User.objects.create_user(username="assettest", password="pass123")
+    client.defaults["HTTP_AUTHORIZATION"] = f"Bearer {AccessToken.for_user(user)}"
+    return client
+
+
+def _domain(name="example.com"):
+    from apps.core.domains.models import Domain
+    return Domain.objects.get_or_create(name=name)[0]
+
+
+def _asset(domain, kind, key, status="active", **extra):
+    from apps.core.asset_inventory.models import Asset
+    now = timezone.now()
+    return Asset.objects.create(
+        domain=domain, kind=kind, key=key, status=status,
+        first_seen=now, last_seen=now, extra=extra,
+    )
+
+
+def _session(domain="example.com", status="completed"):
+    from apps.core.scans.models import ScanSession
+    return ScanSession.objects.create(domain=domain, scan_type="full", status=status)
+
+
+def _finding(session, asset, severity="high"):
+    from apps.core.findings.models import Finding
+    return Finding.objects.create(
+        session=session, asset=asset, source="nmap", check_type="cve",
+        severity=severity, title="t", status="open",
+    )
+
+
+class TestAuth:
+    def test_list_requires_auth(self, client):
+        assert client.get("/api/assets/").status_code == 401
+
+    def test_detail_requires_auth(self, client):
+        assert client.get("/api/assets/1/").status_code == 401
+
+
+class TestList:
+    def test_returns_assets_with_pagination_shape(self, auth_client):
+        d = _domain()
+        _asset(d, "subdomain", "a.example.com")
+        _asset(d, "ip", "1.2.3.4")
+        body = auth_client.get("/api/assets/").json()
+        assert body["total"] == 2
+        assert {a["key"] for a in body["assets"]} == {"a.example.com", "1.2.3.4"}
+        assert body["page"] == 1 and "total_pages" in body and "has_next" in body
+
+    def test_filter_by_kind(self, auth_client):
+        d = _domain()
+        _asset(d, "subdomain", "a.example.com")
+        _asset(d, "ip", "1.2.3.4")
+        body = auth_client.get("/api/assets/?kind=ip").json()
+        assert [a["kind"] for a in body["assets"]] == ["ip"]
+
+    def test_filter_by_status(self, auth_client):
+        d = _domain()
+        _asset(d, "subdomain", "live.example.com", status="active")
+        _asset(d, "subdomain", "old.example.com", status="gone")
+        body = auth_client.get("/api/assets/?status=gone").json()
+        assert [a["key"] for a in body["assets"]] == ["old.example.com"]
+
+    def test_search_by_key(self, auth_client):
+        d = _domain()
+        _asset(d, "subdomain", "api.example.com")
+        _asset(d, "subdomain", "www.example.com")
+        body = auth_client.get("/api/assets/?q=api").json()
+        assert [a["key"] for a in body["assets"]] == ["api.example.com"]
+
+    def test_per_asset_open_finding_counts(self, auth_client):
+        d = _domain()
+        a = _asset(d, "port", "1.2.3.4:443/tcp")
+        s = _session()
+        _finding(s, a, "critical")
+        _finding(s, a, "high")
+        _finding(s, a, "high")
+        row = auth_client.get("/api/assets/").json()["assets"][0]
+        assert row["findings"]["critical"] == 1
+        assert row["findings"]["high"] == 2
+        assert row["findings"]["low"] == 0
+
+
+class TestSummary:
+    def test_summary_totals_and_by_kind(self, auth_client):
+        d = _domain()
+        _asset(d, "subdomain", "a.example.com", status="active")
+        _asset(d, "subdomain", "b.example.com", status="gone")
+        _asset(d, "ip", "1.2.3.4", status="active")
+        body = auth_client.get("/api/assets/summary/").json()
+        assert body["total"] == 3
+        assert body["active"] == 2 and body["gone"] == 1
+        assert body["by_kind"]["subdomain"] == {"active": 1, "gone": 1}
+        assert body["by_kind"]["ip"]["active"] == 1
+
+
+class TestDetail:
+    def test_detail_shape_and_findings(self, auth_client):
+        d = _domain()
+        a = _asset(d, "port", "1.2.3.4:22/tcp", service="ssh")
+        s = _session()
+        _finding(s, a, "high")
+        body = auth_client.get(f"/api/assets/{a.id}/").json()
+        assert body["key"] == "1.2.3.4:22/tcp"
+        assert body["extra"]["service"] == "ssh"
+        assert len(body["findings"]) == 1 and body["findings"][0]["severity"] == "high"
+
+    def test_detail_seen_in_scans(self, auth_client):
+        d = _domain()
+        a = _asset(d, "subdomain", "a.example.com")
+        s = _session()
+        from apps.core.assets.models import Subdomain
+        Subdomain.objects.create(
+            session=s, domain="example.com", subdomain="a.example.com", source="subfinder"
+        )
+        body = auth_client.get(f"/api/assets/{a.id}/").json()
+        assert [t["uuid"] for t in body["seen_in_scans"]] == [str(s.uuid)]
+
+    def test_detail_404(self, auth_client):
+        assert auth_client.get("/api/assets/99999/").status_code == 404


### PR DESCRIPTION
**PR2** of the asset-centric inventory spec. Read-only Ninja endpoints over the `Asset` inventory built in PR1 (#337).

## Endpoints (`apps/core/asset_inventory/api.py`, JWT-authed)
- **`GET /api/assets/`** — paginated inventory; filters `?domain=&kind=&status=&q=`; each row carries per-severity **open-finding counts** (conditional aggregation, no N+1).
- **`GET /api/assets/summary/`** — totals by kind + active/gone (for a future dashboard KPI).
- **`GET /api/assets/<id>/`** — asset metadata + `extra`, its findings across scans, and a best-effort **`seen_in_scans`** timeline (derived from the per-scan asset rows, since PR1 has no `AssetObservation` table yet — guarded, never fails the request).

Mounted at `/assets` in `ninja.py`. Flat JSON, same pagination/response shape as the rest of the API.

## Tests
`tests/unit/test_asset_inventory_api.py` (11): auth-required (401), list + each filter + pagination shape + per-asset severity counts, summary totals/by_kind, detail shape + findings + `seen_in_scans` + 404. ruff clean.

## Docs
CLAUDE.md (URL layout + router list + test table, total → 1752), DESIGN.md endpoint list, CHANGELOG.

Next: **PR3** — the Assets + AssetDetail frontend pages + nav (the asset-centric UI).
