### PR TITLE
feat: asset-centric UI — Assets + AssetDetail pages (PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ commits to recover the reasoning.
   from existing scan history. **Read API (PR2):** `GET /api/assets/` (paginated,
   filterable by domain/kind/status/search, each row with per-severity open-finding
   counts), `GET /api/assets/summary/` (totals by kind + active/gone), and
-  `GET /api/assets/<id>/` (metadata + findings + scan timeline). The Assets UI is
-  the next PR (see `docs/specs/2026-09-06-asset-centric-inventory.md`). Additive:
-  with the inventory unused, scans behave exactly as before.
+  `GET /api/assets/<id>/` (metadata + findings + scan timeline). **Assets UI (PR3):**
+  a new **Assets** nav item + inventory page (filter by kind/status/domain, search,
+  per-asset severity chips) and an **AssetDetail** page (metadata, findings across
+  scans, and the scan-seen timeline) — the asset-centric view of the attack
+  surface. See `docs/specs/2026-09-06-asset-centric-inventory.md`. Additive: with
+  the inventory unused, scans behave exactly as before.
 - **Historical DNS Records tool (`dns_history`, tool #28) — passive.** Queries a
   passive-DNS dataset for a domain's historical A/AAAA/MX records and surfaces
   each as an informational finding (past hosting / stale records → recon and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -803,4 +803,4 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 
 **Total: 1752 tests** (1700 fast + 52 slow domain_security)
 
-Frontend: **15 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, and the axios 401-refresh interceptor. Run with `cd frontend && npm run test:run`.
+Frontend: **18 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, and the Assets `SeverityChips`. Run with `cd frontend && npm run test:run`.

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -9,6 +9,7 @@ const NAV = [
   { label: 'Dashboard',      path: '/' },
   { label: 'Domains',        path: '/domains' },
   { label: 'Scans',          path: '/scans' },
+  { label: 'Assets',         path: '/assets' },
   { label: 'Findings',       path: '/findings' },
   { label: 'Workflows',      path: '/workflows' },
   { label: 'Insights',       path: '/insights' },

--- a/frontend/src/pages/AssetDetailPage.jsx
+++ b/frontend/src/pages/AssetDetailPage.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Layout } from '../components/Layout.jsx';
+import { Badge } from '../components/Badge.jsx';
+import { Spinner } from '../components/Spinner.jsx';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
+import { apiGet } from '../api/client.js';
+import { useQuery } from '@tanstack/react-query';
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export default function AssetDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const { data: a, isLoading: loading, error } = useQuery({
+    queryKey: [`/assets/${id}/`],
+    queryFn: () => apiGet(`/assets/${id}/`),
+  });
+
+  if (loading) return <Layout><div className="flex justify-center p-8"><Spinner /></div></Layout>;
+  if (error) return <Layout><div className="p-6 text-red-400 text-sm">Error: {error?.message ?? String(error)}</div></Layout>;
+
+  const findings = a?.findings ?? [];
+  const timeline = a?.seen_in_scans ?? [];
+  const extra = a?.extra ?? {};
+
+  return (
+    <Layout>
+      <div className="space-y-5">
+        <button onClick={() => navigate('/assets')} className="text-dim text-sm hover:text-body">← Assets</button>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <Badge value={a.kind} />
+          <h1 className="text-lit text-xl font-bold font-mono break-all">{a.key}</h1>
+          <Badge value={a.status} />
+        </div>
+
+        <Card>
+          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-2 p-5 text-sm md:grid-cols-4">
+            <div><div className="text-dim text-xs uppercase">Domain</div><div className="text-body">{a.domain}</div></div>
+            <div><div className="text-dim text-xs uppercase">First seen</div><div className="text-body">{fmtDate(a.first_seen)}</div></div>
+            <div><div className="text-dim text-xs uppercase">Last seen</div><div className="text-body">{fmtDate(a.last_seen)}</div></div>
+            <div><div className="text-dim text-xs uppercase">Last scan</div>
+              <div className="text-body">
+                {a.last_scan ? <button className="text-green-400 hover:underline font-mono text-xs" onClick={() => navigate(`/scans/${a.last_scan}`)}>{a.last_scan.slice(0, 8)}</button> : '—'}
+              </div>
+            </div>
+            {Object.entries(extra).filter(([, v]) => v !== '' && v !== null && v !== undefined).map(([k, v]) => (
+              <div key={k}><div className="text-dim text-xs uppercase">{k.replace(/_/g, ' ')}</div>
+                <div className="text-body break-all">{Array.isArray(v) ? (v.join(', ') || '—') : String(v)}</div></div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="overflow-hidden">
+          <CardHeader className="px-5 pt-4 pb-0"><CardTitle className="text-base">Findings ({findings.length})</CardTitle></CardHeader>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {['Severity', 'Title', 'Source', 'Status', 'Scan'].map(h => (
+                    <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim">{h}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {findings.length === 0 ? (
+                  <TableRow><TableCell colSpan={5} className="px-4 py-8 text-center text-dim">No findings linked to this asset.</TableCell></TableRow>
+                ) : findings.map(f => (
+                  <TableRow key={f.id} className="hover:bg-hover transition-colors">
+                    <TableCell className="px-4 py-3"><Badge value={f.severity} /></TableCell>
+                    <TableCell className="px-4 py-3 text-body max-w-md truncate">{f.title}</TableCell>
+                    <TableCell className="px-4 py-3 text-dim text-xs">{f.source}</TableCell>
+                    <TableCell className="px-4 py-3"><Badge value={f.status || 'open'} /></TableCell>
+                    <TableCell className="px-4 py-3">
+                      {f.session_uuid ? <button className="text-green-400 hover:underline font-mono text-xs" onClick={() => navigate(`/scans/${f.session_uuid}`)}>{f.session_uuid.slice(0, 8)}</button> : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </Card>
+
+        <Card className="overflow-hidden">
+          <CardHeader className="px-5 pt-4 pb-0"><CardTitle className="text-base">Seen in scans ({timeline.length})</CardTitle></CardHeader>
+          <CardContent className="p-5 space-y-2">
+            {timeline.length === 0 ? <div className="text-dim text-sm">No scan history.</div>
+            : timeline.map(t => (
+              <div key={t.uuid} className="flex items-center gap-3 text-sm">
+                <button className="text-green-400 hover:underline font-mono text-xs" onClick={() => navigate(`/scans/${t.uuid}`)}>{t.uuid.slice(0, 8)}</button>
+                <Badge value={t.status} />
+                <span className="text-dim text-xs">{fmtDate(t.at)}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/AssetsPage.jsx
+++ b/frontend/src/pages/AssetsPage.jsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Layout } from '../components/Layout.jsx';
+import { Badge } from '../components/Badge.jsx';
+import { Spinner } from '../components/Spinner.jsx';
+import { Pagination } from '../components/Pagination.jsx';
+import { Card } from '../components/ui/card.jsx';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
+import { apiGet } from '../api/client.js';
+import { useQuery } from '@tanstack/react-query';
+
+const KINDS    = ['subdomain', 'ip', 'port', 'url'];
+const STATUSES = ['active', 'gone'];
+const SEV      = ['critical', 'high', 'medium', 'low', 'info'];
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Compact per-severity finding counts — only render the non-zero buckets.
+export function SeverityChips({ counts }) {
+  const shown = SEV.filter(s => (counts?.[s] ?? 0) > 0);
+  if (shown.length === 0) return <span className="text-dim text-xs">—</span>;
+  return (
+    <span className="inline-flex gap-1">
+      {shown.map(s => <Badge key={s} value={s} label={`${counts[s]} ${s}`} />)}
+    </span>
+  );
+}
+
+export default function AssetsPage() {
+  const navigate = useNavigate();
+  const [kind,   setKind]   = useState('');
+  const [status, setStatus] = useState('');
+  const [domain, setDomain] = useState('');
+  const [q,      setQ]      = useState('');
+  const [page,   setPage]   = useState(1);
+
+  const { data: domainsData } = useQuery({
+    queryKey: ['/domains/'],
+    queryFn: () => apiGet('/domains/'),
+  });
+  const { data, isLoading: loading, error } = useQuery({
+    queryKey: ['/assets/', kind, status, domain, q, page],
+    queryFn: () => apiGet(`/assets/?kind=${kind}&status=${status}&domain=${domain}&q=${encodeURIComponent(q)}&page=${page}`),
+  });
+
+  const assets  = data?.assets ?? [];
+  const domains = domainsData || [];
+
+  return (
+    <Layout>
+      <div className="space-y-5">
+        <div>
+          <h1 className="text-lit text-xl font-bold">Assets</h1>
+          <p className="text-dim text-sm mt-0.5">Everything discovered across all scans — your attack surface over time</p>
+        </div>
+
+        <div className="flex gap-3 flex-wrap">
+          <select value={kind} onChange={e => { setKind(e.target.value); setPage(1); }} className="field w-36">
+            <option value="">All kinds</option>
+            {KINDS.map(k => <option key={k} value={k}>{k}</option>)}
+          </select>
+          <select value={status} onChange={e => { setStatus(e.target.value); setPage(1); }} className="field w-32">
+            <option value="">Any status</option>
+            {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <select value={domain} onChange={e => { setDomain(e.target.value); setPage(1); }} className="field w-52">
+            <option value="">All domains</option>
+            {domains.map(d => <option key={d.id} value={d.name}>{d.name}</option>)}
+          </select>
+          <input value={q} onChange={e => { setQ(e.target.value); setPage(1); }}
+            placeholder="Search key…" className="field w-52" />
+        </div>
+
+        <Card className="overflow-hidden">
+          {loading ? <div className="flex justify-center p-8"><Spinner /></div>
+          : error   ? <div className="p-6 text-red-400 text-sm">Error: {error?.message ?? String(error)}</div>
+          : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      {['Kind', 'Asset', 'Domain', 'Status', 'Open findings', 'First seen', 'Last seen'].map(h => (
+                        <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim whitespace-nowrap">{h}</TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {assets.length === 0 ? (
+                      <TableRow><TableCell colSpan={7} className="px-4 py-10 text-center text-dim">No assets.</TableCell></TableRow>
+                    ) : assets.map(a => (
+                      <TableRow key={a.id} onClick={() => navigate(`/assets/${a.id}`)}
+                        className="hover:bg-hover transition-colors cursor-pointer">
+                        <TableCell className="px-4 py-3"><Badge value={a.kind} /></TableCell>
+                        <TableCell className="px-4 py-3 font-mono text-body text-xs max-w-xs truncate">{a.key}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{a.domain}</TableCell>
+                        <TableCell className="px-4 py-3"><Badge value={a.status} /></TableCell>
+                        <TableCell className="px-4 py-3"><SeverityChips counts={a.findings} /></TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{fmtDate(a.first_seen)}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{fmtDate(a.last_seen)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+              {data?.total_pages > 1 && (
+                <div className="px-4 py-3 border-t border-border">
+                  <Pagination page={page} totalPages={data.total_pages} onPage={setPage} />
+                </div>
+              )}
+            </>
+          )}
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/AssetsPage.test.jsx
+++ b/frontend/src/pages/AssetsPage.test.jsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SeverityChips } from './AssetsPage.jsx';
+
+describe('SeverityChips', () => {
+  it('renders a chip only for non-zero severities', () => {
+    render(<SeverityChips counts={{ critical: 2, high: 0, medium: 1, low: 0, info: 0 }} />);
+    expect(screen.getByText('2 critical')).toBeInTheDocument();
+    expect(screen.getByText('1 medium')).toBeInTheDocument();
+    expect(screen.queryByText(/high/)).not.toBeInTheDocument();
+  });
+
+  it('renders an em dash when there are no findings', () => {
+    render(<SeverityChips counts={{ critical: 0, high: 0, medium: 0, low: 0, info: 0 }} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('handles a missing counts object', () => {
+    render(<SeverityChips counts={undefined} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -11,6 +11,8 @@ import ScansPage from './pages/ScansPage.jsx';
 import ScanStartPage from './pages/ScanStartPage.jsx';
 import ScanDetailPage from './pages/ScanDetailPage.jsx';
 import FindingsPage from './pages/FindingsPage.jsx';
+import AssetsPage from './pages/AssetsPage.jsx';
+import AssetDetailPage from './pages/AssetDetailPage.jsx';
 import WorkflowsPage from './pages/WorkflowsPage.jsx';
 import WorkflowDetailPage from './pages/WorkflowDetailPage.jsx';
 import InsightsPage from './pages/InsightsPage.jsx';
@@ -38,6 +40,8 @@ export const router = createBrowserRouter([
       { path: '/scans', element: <ScansPage /> },
       { path: '/scans/start', element: <ScanStartPage /> },
       { path: '/scans/:uuid', element: <ScanDetailPage /> },
+      { path: '/assets', element: <AssetsPage /> },
+      { path: '/assets/:id', element: <AssetDetailPage /> },
       { path: '/findings', element: <FindingsPage /> },
       { path: '/workflows', element: <WorkflowsPage /> },
       { path: '/workflows/:id', element: <WorkflowDetailPage /> },


### PR DESCRIPTION
**PR3** of the asset-centric inventory spec — the payoff UI on the `/api/assets/` endpoints from PR2 (#338). This is the asset-centric view you originally asked about.

## What it adds
- **`AssetsPage`** (`/assets`) — the persistent inventory table: filter by **kind / status / domain** + key **search**, per-asset **severity chips** (open-finding counts), first/last-seen. Rows link to the detail.
- **`AssetDetailPage`** (`/assets/:id`) — asset metadata + `extra`, its **findings across scans** (each linking to its scan), and the **`seen_in_scans` timeline**.
- **Nav:** a new **Assets** item (between Scans and Findings) in `Layout.jsx`.
- **Routes:** `/assets` and `/assets/:id` in `router.jsx`.

Same patterns as `FindingsPage` — react-query `useQuery` + `apiGet`, `Badge`, `Pagination`, `useNavigate`.

## Tests
`SeverityChips` extracted and unit-tested (Vitest, 3 tests → **18** frontend total): non-zero chips only, em-dash when clean, missing-counts guard. `npm run build` succeeds.

## Notes
- `dist/` intentionally **not rebuilt** in this PR — Docker/k8s rebuild the frontend at image build, and `make dev` (Vite) serves the source directly; committing the minified bundle would just bloat the diff (same as the frontend-tests PR).
- Finding→asset cross-links (from the Findings page back to an asset) are a small follow-up — the findings serializer doesn't carry `asset_id` yet.

Completes the 4-PR asset-inventory arc: model+rollup (#337) → API (#338) → **UI (this)**. Docs (DESIGN/README polish + dashboard KPI) are the optional PR4.
