### PR TITLE
feat: asset inventory polish — dashboard KPI + Finding→asset cross-links (PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,12 @@ commits to recover the reasoning.
   a new **Assets** nav item + inventory page (filter by kind/status/domain, search,
   per-asset severity chips) and an **AssetDetail** page (metadata, findings across
   scans, and the scan-seen timeline) — the asset-centric view of the attack
-  surface. See `docs/specs/2026-09-06-asset-centric-inventory.md`. Additive: with
-  the inventory unused, scans behave exactly as before.
+  surface. **Polish (PR4):** a dashboard "Asset inventory" KPI (active/gone,
+  linking to the Assets page), a Finding→Asset cross-link (the findings API now
+  carries `asset_id`/`asset_key`/`asset_kind`, and the Findings page links each
+  finding to its asset), and README/DESIGN notes. See
+  `docs/specs/2026-09-06-asset-centric-inventory.md`. Additive: with the
+  inventory unused, scans behave exactly as before.
 - **Historical DNS Records tool (`dns_history`, tool #28) — passive.** Queries a
   passive-DNS dataset for a domain's historical A/AAAA/MX records and surfaces
   each as an informational finding (past hosting / stale records → recon and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -799,8 +799,8 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_login_ratelimit.py` | 13 | Login brute-force limiter — threshold lockout, window reset, success clears, X-Forwarded-For keying (+ untrusted-XFF fallback / spoof-evasion), middleware integration (per-IP isolation, disabled bypass, refresh endpoint unaffected) |
 
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
-| `tests/unit/test_asset_inventory_api.py` | 11 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404) |
+| `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1752 tests** (1700 fast + 52 slow domain_security)
+**Total: 1755 tests** (1703 fast + 52 slow domain_security)
 
 Frontend: **18 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, and the Assets `SeverityChips`. Run with `cd frontend && npm run test:run`.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline**: 27-tool scan workflow from domain to findings
+- **Automated pipeline**: 28-tool scan workflow from domain to findings
 - **Network attack surface scanning**: CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **CVE prioritisation**: EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows**: Create custom scan configurations, enable/disable tools per workflow
@@ -172,6 +172,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 - **Live scan progress**: Real-time pipeline status with per-tool step tracking
 - **Scan stop/cancel**: Graceful cancellation between tool steps
 - **Unified findings**: All tools write to a single Finding model with lifecycle tracking
+- **Asset inventory**: A persistent, deduplicated view of your attack surface across scans — every subdomain/IP/port/URL with first-seen / last-seen / active-or-gone status; pivot from any asset to its findings and scan history (Assets page + `/api/assets/`)
 - **Continuous monitoring**: Per-domain rescans on a configurable schedule (6h / 12h / 24h / 48h / weekly)
 - **Subscan**: Re-run specific tools on existing scan assets without full rediscovery
 - **Reports**: CSV and PDF export

--- a/apps/core/dashboard/api.py
+++ b/apps/core/dashboard/api.py
@@ -11,6 +11,7 @@ from apps.core.domains.models import Domain
 from apps.core.insights.models import ScanSummary
 from apps.core.assets.models import Subdomain, IPAddress, Port
 from apps.core.web_assets.models import URL
+from apps.core.asset_inventory.models import Asset
 
 router = Router(auth=JWTAuth())
 
@@ -95,9 +96,17 @@ def api_dashboard(request):
         "urls": URL.objects.filter(session_id__in=latest_completed_ids).count(),
     }
 
+    # Persistent asset-inventory KPI (spans scan history, not just the latest
+    # scan): total tracked assets that are currently live vs. gone.
+    inventory = Asset.objects.filter(domain__in=active_domains)
+    assets_active = inventory.filter(status="active").count()
+    assets_gone = inventory.filter(status="gone").count()
+
     return {
         "kpi_domains": len(active_domains),
         "kpi_active_scans": running_count,
+        "kpi_assets_active": assets_active,
+        "kpi_assets_gone": assets_gone,
         "kpi_critical": current_critical,
         "kpi_high": current_high,
         "kpi_subdomains": asset_counts["subdomains"],

--- a/apps/core/scans/api.py
+++ b/apps/core/scans/api.py
@@ -127,6 +127,9 @@ def _serialize_finding(finding) -> dict:
         "description": finding.description,
         "remediation": finding.remediation,
         "target": finding.target,
+        "asset_id": finding.asset_id,
+        "asset_key": finding.asset.key if finding.asset_id else None,
+        "asset_kind": finding.asset.kind if finding.asset_id else None,
         "extra": finding.extra,
         "discovered_at": finding.discovered_at.isoformat(),
         "status": finding.status,
@@ -354,7 +357,7 @@ def list_findings(
         session_id = session.id
 
     latest_ids = latest_session_ids()
-    base_qs = Finding.objects.select_related("session")
+    base_qs = Finding.objects.select_related("session", "asset")
     if not session_id:
         base_qs = base_qs.filter(session_id__in=latest_ids)
 
@@ -500,18 +503,18 @@ def scan_detail(request, session_uuid: uuid.UUID):
     # which would otherwise fire one query per finding (N+1) on this detail load.
     nmap_findings = list(
         Finding.objects.filter(session=session, source="nmap")
-        .select_related("port", "session")
+        .select_related("port", "session", "asset")
         .order_by("-discovered_at")
     )
     domain_findings = list(
         Finding.objects.filter(session=session, source="domain_security")
-        .select_related("subdomain", "session")
+        .select_related("subdomain", "session", "asset")
         .order_by("-severity", "-discovered_at")
     )
     other_findings = list(
         Finding.objects.filter(session=session)
         .exclude(source__in=["nmap", "domain_security"])
-        .select_related("port", "url", "session")
+        .select_related("port", "url", "session", "asset")
         .order_by("-discovered_at")
     )
 

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -41,6 +41,7 @@ export default function DashboardPage() {
   const {
     kpi_domains = 0, kpi_active_scans = 0, kpi_critical = 0, kpi_high = 0,
     kpi_subdomains = 0, kpi_ips = 0, kpi_ports = 0, kpi_urls = 0,
+    kpi_assets_active = 0, kpi_assets_gone = 0,
     domain_status = [], urgent_findings = [],
   } = data;
 
@@ -65,6 +66,18 @@ export default function DashboardPage() {
           <AssetCard label="Ports"      value={kpi_ports} />
           <AssetCard label="URLs"       value={kpi_urls} />
         </div>
+
+        <button onClick={() => navigate('/assets')}
+          className="w-full text-left bg-card border border-rim rounded-xl p-4 hover:bg-hover transition-colors flex items-center justify-between">
+          <div>
+            <div className="text-xs text-dim uppercase tracking-wider">Asset inventory</div>
+            <div className="text-body text-sm mt-0.5">
+              <span className="text-green-400 font-semibold">{kpi_assets_active}</span> active
+              <span className="text-dim"> · {kpi_assets_gone} gone</span>
+            </div>
+          </div>
+          <span className="text-dim text-xs">View all →</span>
+        </button>
 
         <Card className="overflow-hidden">
           <CardHeader className="border-b border-border px-4 py-3">

--- a/frontend/src/pages/FindingsPage.jsx
+++ b/frontend/src/pages/FindingsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Layout } from '../components/Layout.jsx';
 import { Badge } from '../components/Badge.jsx';
 import { Spinner } from '../components/Spinner.jsx';
@@ -46,6 +47,7 @@ function StatusEditor({ findingId, current, onUpdated }) {
 }
 
 export default function FindingsPage() {
+  const navigate = useNavigate();
   const params = new URLSearchParams(window.location.search);
   const [severity, setSeverity] = useState(params.get('severity') || '');
   const [status,   setStatus]   = useState('open');
@@ -96,19 +98,25 @@ export default function FindingsPage() {
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      {['Severity', 'Title', 'Target', 'Source', 'Status', 'Found'].map(h => (
+                      {['Severity', 'Title', 'Target', 'Asset', 'Source', 'Status', 'Found'].map(h => (
                         <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim whitespace-nowrap">{h}</TableHead>
                       ))}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
                     {findings.length === 0 ? (
-                      <TableRow><TableCell colSpan={6} className="px-4 py-10 text-center text-dim">No findings.</TableCell></TableRow>
+                      <TableRow><TableCell colSpan={7} className="px-4 py-10 text-center text-dim">No findings.</TableCell></TableRow>
                     ) : findings.map(f => (
                       <TableRow key={f.id} className="hover:bg-hover transition-colors">
                         <TableCell className="px-4 py-3"><Badge value={f.severity} /></TableCell>
                         <TableCell className="px-4 py-3 text-body font-medium max-w-xs truncate">{f.title}</TableCell>
                         <TableCell className="px-4 py-3 font-mono text-dim text-xs">{f.target}</TableCell>
+                        <TableCell className="px-4 py-3 text-xs">
+                          {f.asset_id
+                            ? <button onClick={() => navigate(`/assets/${f.asset_id}`)}
+                                className="text-green-400 hover:underline font-mono truncate max-w-[12rem] inline-block align-bottom">{f.asset_key}</button>
+                            : <span className="text-dim">—</span>}
+                        </TableCell>
                         <TableCell className="px-4 py-3 text-dim text-xs">{f.source}</TableCell>
                         <TableCell className="px-4 py-3">
                           <StatusEditor findingId={f.id} current={f.status || 'open'}

--- a/tests/unit/test_asset_inventory_api.py
+++ b/tests/unit/test_asset_inventory_api.py
@@ -131,3 +131,35 @@ class TestDetail:
 
     def test_detail_404(self, auth_client):
         assert auth_client.get("/api/assets/99999/").status_code == 404
+
+
+class TestCrossLinks:
+    def test_findings_api_carries_asset_link(self, auth_client):
+        d = _domain()
+        a = _asset(d, "port", "1.2.3.4:443/tcp")
+        s = _session()
+        f = _finding(s, a, "high")
+        body = auth_client.get(f"/api/scans/findings/?session_uuid={s.uuid}").json()
+        row = next(x for x in body["findings"] if x["id"] == f.id)
+        assert row["asset_id"] == a.id
+        assert row["asset_key"] == "1.2.3.4:443/tcp"
+        assert row["asset_kind"] == "port"
+
+    def test_findings_api_null_asset_when_unlinked(self, auth_client):
+        _domain()
+        s = _session()
+        f = _finding(s, asset=None, severity="low")
+        body = auth_client.get(f"/api/scans/findings/?session_uuid={s.uuid}").json()
+        row = next(x for x in body["findings"] if x["id"] == f.id)
+        assert row["asset_id"] is None and row["asset_key"] is None
+
+
+class TestDashboardKpi:
+    def test_dashboard_reports_inventory_counts(self, auth_client):
+        d = _domain()
+        _asset(d, "subdomain", "a.example.com", status="active")
+        _asset(d, "ip", "1.2.3.4", status="active")
+        _asset(d, "subdomain", "old.example.com", status="gone")
+        body = auth_client.get("/api/dashboard/").json()
+        assert body["kpi_assets_active"] == 2
+        assert body["kpi_assets_gone"] == 1


### PR DESCRIPTION
**PR4** — final polish of the asset-centric inventory arc (PRs #337/#338/#339).

## What it adds
- **Dashboard "Asset inventory" KPI** — active/gone counts (from the `Asset` model, spanning scan history), clickable to the Assets page. `/api/dashboard/` gains `kpi_assets_active` / `kpi_assets_gone`.
- **Finding→Asset cross-link (the reverse pivot)** — `_serialize_finding` now carries `asset_id` / `asset_key` / `asset_kind` (with `select_related("asset")` added to `list_findings` + `scan_detail` to avoid N+1), and the **Findings page** links each finding to its asset. Combined with PR3's asset→findings, the pivot is now bidirectional.
- **README** — asset-inventory feature bullet, and fixed a stale "27-tool" → "28-tool" count.

## Tests
+3 (`test_asset_inventory_api` → 14): findings API carries the asset link / null when unlinked, and the dashboard reports inventory counts. Backend total 1755. Full API smoke suite (113) still green; frontend build + 18 Vitest pass.

`dist/` not rebuilt (Docker/k8s rebuild the frontend). Completes the 4-PR asset-inventory feature.
