### PR TITLE
docs: reflect the completed asset inventory in DESIGN + spec

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -48,6 +48,7 @@ data + DBOS checkpoints); there is no SQLite and no Django-Q/APScheduler.
 | `web_assets/` | `web_assets` | Web assets: `URL` |
 | `service_detection/` | `service_detection` | Enriches `Port.service` + `Port.is_web` via nmap -sV |
 | `findings/` | `findings` | Unified `Finding` model — all finding-producing tools write here |
+| `asset_inventory/` | `asset_inventory` | Persistent, deduplicated `Asset` inventory (domain-scoped, first/last-seen + status); populated by a fail-graceful rollup at finalize; `Finding.asset` links findings to it; `/api/assets/` + the Assets UI |
 | `scans/` | `scans` | `ScanSession`, `ScanDelta`, `ScheduledScan`, pipeline orchestrator |
 | `workflows/` | `workflow` | Workflow CRUD, dynamic runner, tool registry |
 | `scheduler/` | `scheduler` | Scan callables (daily/monitoring/user sweeps, watchdog, JWT purge) invoked by the DBOS `@scheduled` workflows |
@@ -145,7 +146,8 @@ POST /api/scans/start/  (authorization gate: active tools need DomainAuthorizati
 ```
 
 `_finalize_session` order: build deltas → coverage/WAF regression → `build_insights`
-(Exposure Score) → `run_ai_post_scan` (triage + summaries, inline) → `_dispatch_alerts`
+(Exposure Score) → asset-inventory rollup (`rollup_session`, fail-graceful) →
+`run_ai_post_scan` (triage + summaries, inline) → `_dispatch_alerts`
 (Slack/Teams) → `maybe_start_agent` (queues the bounded AI orchestration chain).
 
 ### Scan statuses

--- a/docs/specs/2026-09-06-asset-centric-inventory.md
+++ b/docs/specs/2026-09-06-asset-centric-inventory.md
@@ -1,8 +1,12 @@
 # Asset-Centric Inventory — Design Spec
 
-> **Status:** Draft for review. Execution belongs to a dedicated session, not the
-> session that authored this. This document is the design contract; an
-> implementation plan (`writing-plans`) should be derived from it before coding.
+> **Status:** ✅ Implemented — PR1 model + finalize rollup + `Finding.asset` +
+> backfill (#337), PR2 `/api/assets/` (#338), PR3 Assets + AssetDetail UI (#339),
+> PR4 dashboard KPI + Finding→asset cross-links (#340). Kept as the design
+> contract it was built to; the shipped architecture is described in DESIGN.md
+> and CLAUDE.md. One deviation from the draft: `Asset.domain` is an
+> `FK(Domain, CASCADE)` (resolved by name at rollup, skipped if no Domain row),
+> not left open — for automatic cleanup on domain delete.
 
 **Goal:** Give OpenEASD a persistent, deduplicated **asset inventory** — every
 subdomain / IP / port / URL a domain has ever exposed, with `first_seen` /


### PR DESCRIPTION
Answering "did we update all docs" — the asset-inventory feature shipped (#337–#340) but two docs lagged the code:

- **`docs/DESIGN.md`** (rewritten before the feature existed) was missing the **`asset_inventory/`** app from its core-apps table and the **rollup step** from the `_finalize_session` order. Both added.
- **The spec** still read *"Draft for review — execution belongs to a dedicated session"*; updated to **✅ Implemented** with the PR map (#337–#340) and the `Asset.domain` FK deviation noted.

Everything else was already current (CLAUDE.md core-apps/URL-layout/router/test tables, README feature bullet + 28-tool fix, CHANGELOG). Docs-only.
