### PR TITLE
chore: release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.2.0] — 2026-09-07
+
 ### Added
 - **Asset inventory — backend foundation (PR1).** A new `apps/core/asset_inventory`
   layer builds a persistent, deduplicated `Asset` record per unique

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.1.1"
+version = "2.2.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.1.1"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release for the 13 commits merged since v2.1.1.

## Highlights
- **Asset-centric inventory** — a persistent, deduplicated view of the attack surface across scans (Asset model + finalize rollup, `/api/assets/`, Assets + AssetDetail UI, dashboard KPI, bidirectional Finding↔Asset cross-links). #337–#341
- **`dns_history` passive tool (#28)** — historical A/AAAA/MX records via a passive-DNS dataset. #332
- **k8s: web/worker split** into separate Deployments (independent scaling; NET_RAW off the web tier). #329
- **Cleanup** — dead code/docs removed (main.py, SQLite WAL, superpowers, duplicate PRD, stale specs); DESIGN.md refreshed.

## Change
- `pyproject.toml` + `uv.lock`: 2.1.1 → 2.2.0
- `CHANGELOG.md`: `[Unreleased]` → `[v2.2.0]`

After merge I'll tag `v2.2.0` (CI publishes `:v2.2.0` + floating `:v2.2` + refreshes `:latest`) and cut the GitHub Release.
