### PR TITLE
docs: fix stale core sub-app count (16 → 15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,7 +314,7 @@ request-counting proxy C4 is deferred).
 
 ## Architecture
 
-### Core infrastructure — `apps/core/` (16 sub-apps)
+### Core infrastructure — `apps/core/` (15 sub-apps)
 
 | App | Label | Purpose |
 |---|---|---|


### PR DESCRIPTION
The CLAUDE.md core-infrastructure heading said **16 sub-apps**, but `INSTALLED_APPS` and the table beneath it both list **15** `apps.core.*` apps (verified: `grep -c 'apps.core.' settings.py` = 15, table rows = 15). The heading was off by one and the count carried the error forward. Corrected to 15. Docs-only.