### PR TITLE
fix: alert idempotency on finalize replay (PQC hardening H1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Fixed
+- **Alert idempotency on finalize replay (PQC hardening H1).** `_dispatch_alerts`
+  now skips re-sending when the session already has a `sent` `Alert` row. **Why:**
+  scan finalize is a durable DBOS step that can be *replayed* after a partial crash
+  (worker dies after the Slack/Teams webhook POST but before the step checkpoints);
+  without the guard, resume re-fired the alerts → duplicate notifications. Only
+  `sent` rows count, so a prior attempt that failed entirely is still retried. Plan:
+  `docs/specs/2026-09-07-producer-queue-consumer-hardening.md`.
+
 ## [v2.2.0] — 2026-09-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -753,7 +753,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_naabu.py` | 10 | JSON parser, FK to IPAddress |
 | `tests/unit/test_nmap.py` | 26 |
 | `tests/unit/test_nmap_backports.py` | 16 | Backport-aware CVE demotion engine — Debian/Ubuntu version compare, check_backport, `protocol 2.0` false-positive guard | Severity mapping, vulners XML parser, web/non-web exclusion, backport matching |
-| `tests/unit/test_notifications.py` | 32 | NotificationConfig, Slack/Teams alerts, alert-history API, AI summary block/fact (absent = payload byte-identical) |
+| `tests/unit/test_notifications.py` | 35 | NotificationConfig, Slack/Teams alerts, alert-history API, AI summary block/fact (absent = payload byte-identical), alert idempotency on finalize replay (skip when already sent, retry when only failed) |
 | `tests/unit/test_nuclei.py` | 33 | CVE parsing, severity, dedup, URL linking, collector, honest UA |
 | `tests/unit/test_nuclei_network.py` | 28 | Network-template parsing, non-web targeting, collector |
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
@@ -801,6 +801,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1755 tests** (1703 fast + 52 slow domain_security)
+**Total: 1758 tests** (1706 fast + 52 slow domain_security)
 
 Frontend: **18 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, and the Assets `SeverityChips`. Run with `cd frontend && npm run test:run`.

--- a/apps/core/scans/pipeline.py
+++ b/apps/core/scans/pipeline.py
@@ -632,6 +632,17 @@ def _dispatch_alerts(session):
     from django.conf import settings
     from apps.core.notifications.models import NotificationConfig
 
+    # Idempotency guard (H1): finalize is a DBOS step that can be replayed after a
+    # partial crash (e.g. worker dies after the webhook POST but before the step
+    # checkpoints). If this session already dispatched alerts successfully, skip on
+    # replay — re-sending would double-notify. Only "sent" rows count, so a prior
+    # attempt that failed entirely is still retried on the next finalize.
+    if session.alerts.filter(status="sent").exists():
+        logger.info(
+            f"[scan:{session.id}] Alerts already dispatched; skipping re-send on replay"
+        )
+        return
+
     cfg = NotificationConfig.get()
     # DB config takes precedence; fall back to env vars for Docker/K8s deployments
     slack_url  = cfg.slack_webhook_url  or getattr(settings, "SLACK_WEBHOOK_URL", "")

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -40,7 +40,12 @@ with three contained changes.
 3. **Single-user.** No per-user concerns (see `docs/DECISIONS.md`).
 4. **Opt-in where destructive.** Retention (which deletes data) defaults OFF.
 
-## 3. Phase H1 — Consumer idempotency (exactly-once side-effects)
+## 3. Phase H1 — Consumer idempotency (exactly-once side-effects) — ✅ SHIPPED
+
+> **Status:** ✅ Implemented — `_dispatch_alerts` guards on
+> `session.alerts.filter(status="sent").exists()`; tests in
+> `test_notifications.py::TestAlertIdempotency` (skip-when-sent, dispatch-when-none,
+> retry-when-only-failed). No migration.
 
 **Problem:** `_dispatch_alerts` (in the finalize step) can fire twice if the step
 is replayed after a partial crash → duplicate Slack/Teams alerts.

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -367,6 +367,52 @@ class TestAlertAiSummary:
         payload = _build_teams_payload(sess, _GROUPED, "high")
         assert [f["name"] for f in payload["sections"][0]["facts"]] == ["HIGH"]
 
+
+# ---------------------------------------------------------------------------
+# H1 — alert idempotency on finalize replay (apps/core/scans/pipeline)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestAlertIdempotency:
+    def _configure_slack(self):
+        from apps.core.notifications.models import NotificationConfig
+        cfg = NotificationConfig.get()
+        cfg.slack_webhook_url = "https://hooks.slack.com/test"
+        cfg.save()
+
+    def test_skips_resend_when_already_sent(self):
+        """A finalize replay must NOT re-dispatch when a 'sent' Alert exists."""
+        from apps.core.scans.pipeline import _dispatch_alerts
+        from apps.core.notifications.models import Alert
+        self._configure_slack()
+        sess = _alert_session()
+        Alert.objects.create(session=sess, alert_type="slack",
+                             severity_threshold="high", status="sent")
+        with patch("apps.core.notifications.dispatcher.dispatch_alerts") as mock_dispatch:
+            _dispatch_alerts(sess)
+        mock_dispatch.assert_not_called()
+
+    def test_dispatches_when_no_prior_alert(self):
+        """First finalize (no prior Alert rows) dispatches normally."""
+        from apps.core.scans.pipeline import _dispatch_alerts
+        self._configure_slack()
+        sess = _alert_session()
+        with patch("apps.core.notifications.dispatcher.dispatch_alerts") as mock_dispatch:
+            _dispatch_alerts(sess)
+        mock_dispatch.assert_called_once()
+
+    def test_retries_when_prior_attempt_only_failed(self):
+        """A prior fully-failed attempt (no 'sent' row) is still retried."""
+        from apps.core.scans.pipeline import _dispatch_alerts
+        from apps.core.notifications.models import Alert
+        self._configure_slack()
+        sess = _alert_session()
+        Alert.objects.create(session=sess, alert_type="slack",
+                             severity_threshold="high", status="failed")
+        with patch("apps.core.notifications.dispatcher.dispatch_alerts") as mock_dispatch:
+            _dispatch_alerts(sess)
+        mock_dispatch.assert_called_once()
+
     def test_report_kind_not_used_for_alerts(self):
         from apps.core.ai.models import AISummary
         from apps.core.notifications.dispatcher import _get_triage_summary


### PR DESCRIPTION
**H1** of the producer-queue-consumer hardening plan — the smallest, highest-leverage item: makes the consumer's alert side-effect **exactly-once**.

## The bug it closes
Scan finalize is a durable DBOS step. If the worker crashes **after** the Slack/Teams webhook POST but **before** the step checkpoints, DBOS **replays** the step on resume → the alert fires **again** → duplicate notifications. This is the standard "at-least-once execution" con of a durable queue.

## The fix
One early-return guard at the top of `_dispatch_alerts` (`apps/core/scans/pipeline.py`):
```python
if session.alerts.filter(status="sent").exists():
    return   # already dispatched — don't re-send on replay
```
Only `sent` rows count, so a prior attempt that **failed entirely** is still retried on the next finalize. **No migration** — reuses the existing `Alert` table as the idempotency key.

## Tests
`TestAlertIdempotency` (3): skip-when-already-sent, dispatch-when-none, retry-when-only-failed. Full notifications suite 32 → **35**; total **1758**. `test_scans` + `test_ai_pipeline` + `test_scan_flow` confirm the finalize path is otherwise unchanged.

Plan + status: `docs/specs/2026-09-07-producer-queue-consumer-hardening.md` (H1 marked ✅ shipped).
