### PR TITLE
docs: refresh stale facts (PRD / DECISIONS / ops learnings)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -173,9 +173,9 @@ to one and patronizing the other.
 10. Web Vulnerability Scanning (Nuclei community)
 11. HTTP Security Headers / Cookies / CORS (Web Checker)
 
-**Note on 11 vs 13.** The internal pipeline has 13 phases. Internal phases
+**Note on 11 vs 12.** The internal pipeline has 12 phases. Internal phases
 like `service_detection` aren't customer-facing vectors — they're
-classification steps that feed other tools. Don't reconcile 11 and 13;
+classification steps that feed other tools. Don't reconcile 11 and 12;
 they're different abstractions.
 
 ---

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -30,7 +30,7 @@ nuclei, subfinder, and nmap are and prefer a GUI over manual CLI orchestration.
 | Small security consultancies | Core use case — repeatable scans across client domains |
 | Security learners | Strong fit — GUI makes the toolchain visible and approachable |
 | Bug bounty hunters / elite red-teamers | Weak fit — prefer raw CLI speed |
-| Enterprise SOCs | Out of scope — no RBAC, SAML, HA, or Postgres |
+| Enterprise SOCs | Out of scope — no RBAC, SAML, or HA |
 | Non-technical end users | Out of scope — Workflows page and tool labels assume security literacy |
 
 See [D-001](DECISIONS.md#d-001--audience-security-literate-users-not-non-technical-end-users).
@@ -88,10 +88,10 @@ These are the customer-facing attack vectors in canonical order
 | Constraint | Value |
 |---|---|
 | Auth | Single admin user, JWT (no RBAC, no SAML) |
-| Database | SQLite (configurable via `DB_NAME`; Postgres not supported) |
-| Concurrency | `replicas: 1` — SQLite RWO |
-| Background tasks | Django-Q2 (ORM broker, no Redis/Celery) |
-| External binaries | subfinder, dnsx, naabu, httpx, nuclei, nmap, amass — must be present on PATH or via `TOOL_*` env vars |
+| Database | **PostgreSQL** (via `DB_*` env or `DATABASE_URL`) — holds app data **and** the DBOS checkpoint schema |
+| Concurrency | The worker scales independently (Postgres has no single-writer lock); `DBOS_SCAN_CONCURRENCY` caps parallel scans |
+| Background tasks | **DBOS** durable workflows (checkpoint/resume) + `@scheduled` crons — no Django-Q/Celery/Redis |
+| External binaries | subfinder, dnsx, naabu, httpx, nuclei, nmap, amass (+ the passive-tool CLIs) — on PATH or via `TOOL_*` env vars |
 | Capabilities | `NET_RAW` required on the worker container for nmap raw socket scanning |
 
 ---
@@ -101,12 +101,15 @@ These are the customer-facing attack vectors in canonical order
 See [D-008](DECISIONS.md#d-008--things-we-deliberately-dont-have-anti-features)
 for the full rationale.
 
-- No RBAC, SAML, or multi-tenant support
-- No Postgres or horizontal scaling
-- No hosted "scan any domain" UI
-- No A–F letter grades, typosquatting, or brand impersonation — these are
-  brand-monitoring, not external-attack-surface scanning (out of scope by focus)
-- No "AI-powered" features in marketing copy
+- No RBAC, SAML, or multi-tenant support (single-user by design)
+- No hosted "scan any domain" UI — domain-ownership verification for a public
+  scanner isn't built
+- No deep brand-impersonation / dark-web monitoring — out of scope by focus
+  (note: a *passive* typosquat/lookalike-domain check and a per-scan Exposure
+  Score with an A–F grade **were** added since the original PRD; the boundary is
+  brand *monitoring*, not the surface-adjacent signals now included)
+- No "AI-powered" marketing copy — the optional AI analysis layer (BYOK,
+  off by default) is described by what it does, never as "AI-powered" (D-008)
 
 ---
 

--- a/docs/SCAN_OPERATIONAL_LEARNINGS.md
+++ b/docs/SCAN_OPERATIONAL_LEARNINGS.md
@@ -11,7 +11,7 @@ recur. Add to this list whenever a scan misbehaves.
 **all** ~13,500 templates into RAM up front (~500 MB, fixed) and *then* applies
 `-severity`/`-tags` filters. So severity scoping does **NOT** shrink the startup
 parse — it only cuts the *executed* set. The startup parse (~500 MB) on top of
-gunicorn + qcluster + Django is what tips a 1 GB box; runtime peak is
+the DBOS worker + Django is what tips a 1 GB box; runtime peak is
 `concurrency × bulk-size × per-host buffer`. The levers that actually prevent the
 **freeze** are `GOMEMLIMIT` + a small **`-bulk-size`**, not `-severity`.
 


### PR DESCRIPTION
Fixes the staleness found in the `docs/` review.

## PRD.md (the substantive one — it was a pre-v2.0 snapshot)
- **Key Constraints** described the old stack — corrected:
  - Database: ~~SQLite (Postgres not supported)~~ → **PostgreSQL** (holds app data + the DBOS checkpoint schema)
  - Concurrency: ~~replicas:1, SQLite RWO~~ → **worker scales independently**, `DBOS_SCAN_CONCURRENCY` caps parallel scans
  - Background tasks: ~~Django-Q2~~ → **DBOS** durable workflows + `@scheduled`
- **Anti-features:** dropped the now-false "no Postgres/scaling" and "no A–F grades / typosquatting" (the app has an **Exposure Score A–F grade** + a passive **typosquat** tool since the original PRD); reworded the AI-copy note.
- **"Who" table:** Postgres removed from the enterprise out-of-scope gap.

## DECISIONS.md
- "internal pipeline has **13** phases" → **12** (matches the code; distinct phases 1–12).

## SCAN_OPERATIONAL_LEARNINGS.md
- "gunicorn + **qcluster**" → "the **DBOS worker**" (Django-Q removed).

## Deliberately not touched
Decision-record *bodies* (D-005/D-014/D-016) that mention SQLite/Django-Q are **left intact** — they're historical snapshots, and D-016 already documents the SQLite→Postgres/DBOS move. Rewriting them would rewrite decision history.

Docs-only.
