### PR TITLE
chore: remove vestigial SQLite write-lock from workflow runner (+ log H4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Removed a vestigial SQLite write-lock from the workflow runner.** `runner.py`
+  serialised parallel `WorkflowStepResult` writes behind a `threading.Lock` left
+  over from the SQLite era. **Why:** on PostgreSQL concurrent writers are fine
+  (each tool thread uses its own connection), and a per-process lock wouldn't
+  serialise across worker replicas anyway — so it was needless intra-phase
+  contention + misleading comments. Correctness-neutral; restores true parallel
+  step-result writes. Also logged the watchdog↔DBOS-resume overlap as **H4** in
+  the PQC hardening plan.
+
 ### Fixed
 - **Alert idempotency on finalize replay (PQC hardening H1).** `_dispatch_alerts`
   now skips re-sending when the session already has a `sent` `Alert` row. **Why:**

--- a/apps/core/workflows/runner.py
+++ b/apps/core/workflows/runner.py
@@ -7,7 +7,6 @@ Tool runners are auto-discovered from AppConfig.tool_meta via the registry.
 
 import importlib
 import logging
-import threading
 from itertools import groupby
 from operator import itemgetter
 
@@ -16,11 +15,6 @@ from django.utils import timezone as django_tz
 from .models import WorkflowRun, WorkflowStepResult
 
 logger = logging.getLogger(__name__)
-
-# SQLite only allows one writer at a time. This lock serialises the brief
-# WorkflowStepResult INSERT/UPDATE from parallel tool threads — tool runners
-# are responsible for their own write safety.
-_step_result_write_lock = threading.Lock()
 
 
 def _get_runner(tool_name: str):
@@ -58,24 +52,22 @@ def _run_single_step(run, session, tool: str, order: int) -> None:
     """Execute one tool step, record its WorkflowStepResult, and persist timing.
 
     Calls close_old_connections() before touching the ORM so this function
-    is safe to dispatch from a ThreadPoolExecutor worker.
-
-    _step_result_write_lock serialises the brief WorkflowStepResult INSERT/UPDATE
-    so parallel threads don't race on SQLite's single-writer lock.
-    Tool runners are responsible for their own write safety.
+    is safe to dispatch from a ThreadPoolExecutor worker. Postgres handles the
+    concurrent WorkflowStepResult writes from parallel tool threads directly
+    (each thread uses its own connection); tool runners are responsible for
+    their own write safety.
     """
     from django.db import close_old_connections
     close_old_connections()
     from .registry import get_tool_produces_findings
 
-    with _step_result_write_lock:
-        step_result = WorkflowStepResult.objects.create(
-            run=run,
-            tool=tool,
-            order=order,
-            status="running",
-            started_at=django_tz.now(),
-        )
+    step_result = WorkflowStepResult.objects.create(
+        run=run,
+        tool=tool,
+        order=order,
+        status="running",
+        started_at=django_tz.now(),
+    )
 
     status = "completed"
     error_msg = ""
@@ -95,12 +87,11 @@ def _run_single_step(run, session, tool: str, order: int) -> None:
         status = "failed"
         error_msg = str(e)
 
-    with _step_result_write_lock:
-        step_result.status = status
-        step_result.findings_count = findings_count
-        step_result.error = error_msg
-        step_result.finished_at = django_tz.now()
-        step_result.save(update_fields=["status", "findings_count", "error", "finished_at"])
+    step_result.status = status
+    step_result.findings_count = findings_count
+    step_result.error = error_msg
+    step_result.finished_at = django_tz.now()
+    step_result.save(update_fields=["status", "findings_count", "error", "finished_at"])
 
 
 def resolve_phase_groups(workflow, only_tools: list | None = None) -> list:

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -116,6 +116,40 @@ no-op when disabled.
 
 **Effort:** ~1 PR. Slots into the existing `@scheduled` + scheduler-callable pattern.
 
+## 5b. Phase H4 — reconcile the watchdog with DBOS resume (design smell)
+
+**Problem:** `reap_stuck_scans` (the `scheduled_watchdog` cron) and DBOS's own
+crash-resume are **two uncoordinated recovery mechanisms** for the same scans.
+The watchdog reaps a `running` scan by `start_time` age → marks it `failed`/
+`partial` and fails its in-flight `WorkflowStepResult`s. But on worker restart
+DBOS **resumes** a crashed scan from its last checkpoint. In a narrow window — a
+scan that legitimately ran a long time, crashed, and whose worker was down past
+`SCAN_TIMEOUT_MINUTES` — the watchdog can reap a scan **while DBOS is resuming
+it**: conflicting `ScanSession.status`, spurious `failed` step rows, and status
+churn (DBOS usually wins if its resumed run finishes and calls `_finalize`).
+
+**Context:** low-probability today — `SCAN_TIMEOUT_MINUTES` is set very high
+(~24h) precisely so a healthy long run is never flipped mid-scan. The watchdog is
+a **Django-Q-era backstop** whose role narrowed once DBOS added real resume; it's
+now mostly needed for **orphaned `pending`** scans (enqueued but never picked up),
+not for reaping `running` ones (DBOS handles those).
+
+**Change (options, smallest first):**
+- **(A)** Gate the watchdog to **skip `running` sessions that still have a live
+  DBOS workflow** (query the `dbos` workflow-status for the session's handle;
+  only reap `running` scans with no active/enqueued DBOS workflow). Keep the
+  `pending`-reap path unchanged (that's the part still genuinely needed).
+- **(B)** Reframe the watchdog as a **pure DBOS-orphan reaper** — reap only
+  sessions whose DBOS workflow is terminal/absent but whose `ScanSession` is
+  still `running`/`pending`.
+Recommend **(A)** — smallest change, preserves the pending-orphan safety net.
+
+**Tests:** a `running` session with a live DBOS workflow is NOT reaped; a
+`pending` orphan past its cutoff still is; a `running` session with a
+terminal/absent DBOS workflow past cutoff is reaped as today.
+
+**Effort:** ~1 PR. **Priority:** low (narrow race, high timeout) — do after H2/H3.
+
 ## 6. Non-goals / explicitly out of scope
 
 - **Do NOT make the pattern "textbook pure."** The multi-producer (API +
@@ -128,10 +162,12 @@ no-op when disabled.
 ## 7. Sequencing (each independently shippable)
 
 1. **H1 — alert idempotency** (½ PR, no migration) — closes the one *correctness*
-   gap; highest leverage, lowest cost. Do first.
+   gap; highest leverage, lowest cost. **✅ Shipped (#355).**
 2. **H3 — retention** (1 PR, opt-in) — prevents slow-motion DB growth.
 3. **H2 — `/metrics`** (1 PR) — highest operational value; needs the multiprocess
    decision above, so worth reviewing this section before coding.
+4. **H4 — watchdog ↔ DBOS-resume reconcile** (1 PR) — closes the recovery-path
+   overlap. Lowest priority (narrow race, high timeout); do last.
 
 ## 8. Verification
 


### PR DESCRIPTION
Two items from the engine-apps review.

## B (fix) — remove the vestigial SQLite write-lock
`runner.py` serialised parallel `WorkflowStepResult` writes behind a `threading.Lock` whose comment read *"SQLite only allows one writer at a time."* On **PostgreSQL** that's obsolete:
- Concurrent writers are fine (each tool thread uses its own connection via `close_old_connections()`).
- A per-process `threading.Lock` wouldn't serialise across worker replicas anyway.

So it was **needless intra-phase contention** + misleading comments. Removed the lock, both `with` blocks, and the now-unused `import threading`. **Correctness-neutral** — restores true parallel step-result writes; 46 `test_workflow_runner` + `test_subscan` tests green, ruff clean.

## A (log) — watchdog ↔ DBOS-resume overlap → H4
Logged the recovery-path overlap (the watchdog can reap a `running` scan while DBOS is resuming it, in a narrow high-timeout window) as **H4** in `docs/specs/2026-09-07-producer-queue-consumer-hardening.md` — recommend gating the watchdog to skip `running` sessions with a live DBOS workflow, keeping the `pending`-orphan reap. Low priority; not fixed here.

Both from the engine review; H1 already shipped (#355), C already tracked.
