### PR TITLE
feat: @durable_task engine adapter — convert one-step tasks (PQC H6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Changed
+- **`@durable_task` engine adapter (PQC hardening H6, slice 1).** New
+  `apps/core/engine/durable/task.py` — a thin decorator over DBOS so task bodies
+  don't import the engine: `task()` runs the body in-process (testable without a
+  DBOS engine), `task.delay()` durably enqueues (with an optional `dedupe`
+  template → DBOS `deduplication_id`). The two one-step tasks `ai_triage` and
+  `agent_step` are converted; the `enqueue_*` helpers now delegate to `.delay()`.
+  `run_scan` stays an explicit multi-step workflow (its per-phase checkpointing is
+  the point). Workflow names/dedup unchanged → no behaviour change; DBOS
+  construction + registration verified. Principle #11 (keep the engine behind an
+  adapter). Plan: `docs/specs/2026-09-07-producer-queue-consumer-hardening.md`.
 - **Reorganised the core apps into layer subpackages.** The 15 `apps/core/*` apps
   now live under **`apps/core/console/`** (dashboard, insights, reports,
   notifications, ai, api), **`apps/core/engine/`** (scans, workflows, durable,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -765,6 +765,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_nuclei_network.py` | 28 | Network-template parsing, non-web targeting, collector |
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
 | `tests/unit/test_qcluster_config.py` | 3 | Scan-timeout invariants (Q_CLUSTER removed; SCAN_TASK_TIMEOUT + watchdog bound) |
+| `tests/unit/test_durable_task.py` | 7 | `@durable_task` engine adapter (H6) — in-process call, `.delay()` enqueue, dedupe template + override, registry, real tasks are DurableTasks, enqueue_* wrappers delegate |
 | `tests/unit/test_reports.py` | 57 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block, AI Analyst Summary block (absent without AI rows) |
 | `tests/unit/test_waf_detection.py` | 16 | WAF/block/challenge classifier (spec C1) — vendor fingerprint, false-positive guards, analyzer wiring |
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
@@ -808,6 +809,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1758 tests** (1706 fast + 52 slow domain_security)
+**Total: 1765 tests** (1713 fast + 52 slow domain_security)
 
 Frontend: **18 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, and the Assets `SeverityChips`. Run with `cd frontend && npm run test:run`.

--- a/apps/core/engine/durable/client.py
+++ b/apps/core/engine/durable/client.py
@@ -1,0 +1,45 @@
+"""Enqueue-only DBOS client + system-database URL — a **leaf** module.
+
+Deliberately kept separate from `dbos_app` (which imports `workflows` to register
+the workflow/step decorators): `task.py` and `workflows.py` enqueue via
+`get_client()`, and if they imported it from `dbos_app` the chain
+`workflows → task → dbos_app → workflows` would form an import cycle. This module
+imports nothing from the package except leaf `constants`, so it closes no cycle.
+"""
+
+from django.conf import settings
+
+from .constants import SYSTEM_SCHEMA as _SYSTEM_SCHEMA
+
+_client = None
+
+
+def system_database_url() -> str:
+    """SQLAlchemy URL for DBOS, derived from Django's default DATABASES entry
+    (psycopg3 driver), unless DBOS_DATABASE_URL overrides it."""
+    override = getattr(settings, "DBOS_DATABASE_URL", "")
+    if override:
+        return override
+    db = settings.DATABASES["default"]
+    return "postgresql+psycopg://{user}:{password}@{host}:{port}/{name}".format(
+        user=db["USER"],
+        password=db["PASSWORD"],
+        host=db["HOST"],
+        port=db["PORT"] or "5432",
+        name=db["NAME"],
+    )
+
+
+def get_client():
+    """Process-wide DBOSClient for enqueue-only callers (web/gunicorn, and the
+    `.delay()` path of `@durable_task`)."""
+    global _client
+    if _client is None:
+        from dbos import DBOSClient
+
+        _client = DBOSClient(
+            system_database_url=system_database_url(),
+            dbos_system_schema=_SYSTEM_SCHEMA,
+            application_name=getattr(settings, "DBOS_APP_NAME", "openeasd"),
+        )
+    return _client

--- a/apps/core/engine/durable/dbos_app.py
+++ b/apps/core/engine/durable/dbos_app.py
@@ -1,10 +1,14 @@
-"""DBOS wiring — one place that knows how to reach the system database.
+"""DBOS engine wiring for the worker.
 
-Two entry points share the config:
-  * `get_client()` — a lightweight DBOSClient used by the web process (and any
-    caller that only needs to ENQUEUE work, never execute it).
-  * `configure_dbos()` — builds the full DBOS engine for the worker process
-    (`manage.py dbos_worker`), which executes and recovers workflows.
+`configure_dbos()` builds the full DBOS engine for the worker process
+(`manage.py dbos_worker`), which executes and recovers workflows. Importing the
+workflow module registers the `@DBOS.workflow`/`@DBOS.step`/`@durable_task`
+definitions.
+
+The enqueue-only client + system-database URL live in `client.py` (a leaf), so
+`task.py`/`workflows.py` can enqueue without forming an import cycle through this
+module (which imports `workflows`). `get_client`/`system_database_url` are
+re-exported here for backward compatibility.
 
 The system database is the app's own Postgres, isolated in a `dbos` schema, so
 there is still just one database to run (no second service).
@@ -12,30 +16,13 @@ there is still just one database to run (no second service).
 
 from django.conf import settings
 
+from .client import get_client, system_database_url  # noqa: F401 (re-exported)
 from .constants import SYSTEM_SCHEMA as _SYSTEM_SCHEMA
-
-_client = None
-
-
-def system_database_url() -> str:
-    """SQLAlchemy URL for DBOS, derived from Django's default DATABASES entry
-    (psycopg3 driver), unless DBOS_DATABASE_URL overrides it."""
-    override = getattr(settings, "DBOS_DATABASE_URL", "")
-    if override:
-        return override
-    db = settings.DATABASES["default"]
-    return "postgresql+psycopg://{user}:{password}@{host}:{port}/{name}".format(
-        user=db["USER"],
-        password=db["PASSWORD"],
-        host=db["HOST"],
-        port=db["PORT"] or "5432",
-        name=db["NAME"],
-    )
 
 
 def configure_dbos():
     """Construct (but do not launch) the DBOS engine for the worker. Importing
-    the workflow module registers @DBOS.workflow/@DBOS.step definitions."""
+    the workflow module registers @DBOS.workflow/@DBOS.step/@durable_task defs."""
     from dbos import DBOS, DBOSConfig
 
     config: DBOSConfig = {
@@ -44,20 +31,6 @@ def configure_dbos():
         "dbos_system_schema": _SYSTEM_SCHEMA,
     }
     dbos = DBOS(config=config)
-    # Registers the scan queue + workflow/step decorators with the engine.
+    # Registers the scan queue + workflow/step/task decorators with the engine.
     from apps.core.engine.durable import workflows  # noqa: F401
     return dbos
-
-
-def get_client():
-    """Process-wide DBOSClient for enqueue-only callers (web/gunicorn)."""
-    global _client
-    if _client is None:
-        from dbos import DBOSClient
-
-        _client = DBOSClient(
-            system_database_url=system_database_url(),
-            dbos_system_schema=_SYSTEM_SCHEMA,
-            application_name=getattr(settings, "DBOS_APP_NAME", "openeasd"),
-        )
-    return _client

--- a/apps/core/engine/durable/dbos_app.py
+++ b/apps/core/engine/durable/dbos_app.py
@@ -7,8 +7,7 @@ definitions.
 
 The enqueue-only client + system-database URL live in `client.py` (a leaf), so
 `task.py`/`workflows.py` can enqueue without forming an import cycle through this
-module (which imports `workflows`). `get_client`/`system_database_url` are
-re-exported here for backward compatibility.
+module (which imports `workflows`). Import `get_client` from `.client` directly.
 
 The system database is the app's own Postgres, isolated in a `dbos` schema, so
 there is still just one database to run (no second service).
@@ -16,7 +15,7 @@ there is still just one database to run (no second service).
 
 from django.conf import settings
 
-from .client import get_client, system_database_url  # noqa: F401 (re-exported)
+from .client import system_database_url
 from .constants import SYSTEM_SCHEMA as _SYSTEM_SCHEMA
 
 

--- a/apps/core/engine/durable/task.py
+++ b/apps/core/engine/durable/task.py
@@ -83,7 +83,7 @@ class DurableTask:
         """Durably enqueue this task's DBOS workflow; returns the workflow id."""
         from dbos import EnqueueOptions
 
-        from .dbos_app import get_client
+        from .client import get_client
 
         options: EnqueueOptions = {
             "workflow_name": self.name,

--- a/apps/core/engine/durable/task.py
+++ b/apps/core/engine/durable/task.py
@@ -1,0 +1,114 @@
+"""`@durable_task` — a thin adapter over DBOS (pipeline principle #11).
+
+Keeps a task body free of any `dbos` import: the decorator registers the body as
+a **one-step DBOS workflow** (so the worker executes, checkpoints, and resumes it)
+and exposes a small, uniform surface:
+
+    task(*args)                 run the body NOW, in-process — no DBOS engine
+                                needed (tests, or a deliberate inline call)
+    task.delay(*args)           durably enqueue the task's DBOS workflow on its
+                                queue (dedup id derived from `dedupe` if set)
+    task.delay(*args, dedupe_id="…")   override the dedup id per call
+
+Design boundary: this adapter is for **one-step** tasks (ai_triage, agent_step,
+hygiene jobs). `run_scan` stays an explicit *multi-step* `@DBOS.workflow` in
+`workflows.py` because its per-phase checkpointing (resume at the first unfinished
+phase) is the whole point of the durable engine — collapsing it into a one-step
+task would lose that. See docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+(H6).
+
+Registration timing mirrors the previous explicit decorators exactly: the DBOS
+workflow/step are built when the defining module (`workflows.py`) is imported,
+which in the worker happens right after `configure_dbos()` constructs the engine.
+The web process never imports `workflows.py`; it enqueues by name via `get_client`,
+so `.delay()` works there without any DBOS decorator having run.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Callable
+
+from .constants import QUEUE_NAME
+
+logger = logging.getLogger(__name__)
+
+# name -> DurableTask, for introspection/tests and any registry-driven dispatch.
+REGISTRY: dict[str, "DurableTask"] = {}
+
+
+class DurableTask:
+    """A callable that runs in-process, plus `.delay()` to durably enqueue."""
+
+    def __init__(self, func: Callable, name: str, queue: str, dedupe: str | None):
+        self._func = func
+        self.name = name
+        self.queue = queue
+        self._dedupe = dedupe  # e.g. "triage-{0}" (str.format over positional args)
+        functools.update_wrapper(self, func)
+        # Build the DBOS one-step workflow now, exactly as the old explicit
+        # @DBOS.workflow/@DBOS.step did (same import-time registration). Guarded so
+        # importing this module where `dbos` is unavailable degrades to
+        # in-process-only (the body + .delay-by-name still work via the client).
+        self._dbos_workflow = self._register_dbos_workflow()
+
+    def _register_dbos_workflow(self):
+        try:
+            from dbos import DBOS
+        except Exception:  # noqa: BLE001 — no engine available; in-process still works
+            return None
+
+        step = DBOS.step()(self._func)
+
+        @DBOS.workflow(name=self.name)
+        @functools.wraps(self._func)
+        def _workflow(*args, **kwargs):
+            return step(*args, **kwargs)
+
+        return _workflow
+
+    def __call__(self, *args, **kwargs):
+        """Run the task body NOW, in-process. No DBOS engine involved."""
+        return self._func(*args, **kwargs)
+
+    def _resolve_dedupe_id(self, args, dedupe_id):
+        if dedupe_id is not None:
+            return dedupe_id
+        if self._dedupe:
+            return self._dedupe.format(*args)
+        return None
+
+    def delay(self, *args, dedupe_id: str | None = None) -> str:
+        """Durably enqueue this task's DBOS workflow; returns the workflow id."""
+        from dbos import EnqueueOptions
+
+        from .dbos_app import get_client
+
+        options: EnqueueOptions = {
+            "workflow_name": self.name,
+            "queue_name": self.queue,
+        }
+        did = self._resolve_dedupe_id(args, dedupe_id)
+        if did:
+            options["deduplication_id"] = did
+            options["duplication_policy"] = "return-existing"
+        handle = get_client().enqueue(options, *args)
+        return handle.workflow_id
+
+
+def durable_task(name: str, *, queue: str = QUEUE_NAME, dedupe: str | None = None):
+    """Register `func` as a durable task named `name`.
+
+    `dedupe` is an optional `str.format` template over the call's positional args
+    (e.g. "triage-{0}") — when set, `.delay()` uses it as the DBOS
+    `deduplication_id` with `return-existing`, so the same work is never enqueued
+    twice concurrently (pipeline principle #5).
+    """
+
+    def decorator(func: Callable) -> DurableTask:
+        task = DurableTask(func, name=name, queue=queue, dedupe=dedupe)
+        REGISTRY[name] = task
+        return task
+
+    return decorator

--- a/apps/core/engine/durable/workflows.py
+++ b/apps/core/engine/durable/workflows.py
@@ -84,7 +84,7 @@ def enqueue_scan(session_id: int) -> str:
     can never start two runs of the same scan."""
     from dbos import EnqueueOptions
 
-    from .dbos_app import get_client
+    from .client import get_client
 
     options: EnqueueOptions = {
         "workflow_name": "run_scan",

--- a/apps/core/engine/durable/workflows.py
+++ b/apps/core/engine/durable/workflows.py
@@ -13,6 +13,7 @@ from dbos import DBOS, Queue
 from django.conf import settings
 
 from .constants import QUEUE_NAME
+from .task import durable_task
 
 logger = logging.getLogger(__name__)
 
@@ -59,31 +60,21 @@ def run_scan_workflow(session_id: int) -> None:
     logger.info("[dbos] scan workflow complete for session %s", session_id)
 
 
-@DBOS.step()
-def _run_ai_triage(session_id: int) -> None:
+@durable_task("ai_triage", dedupe="triage-{0}")
+def ai_triage(session_id: int) -> None:
+    """Manual (re-)triage of a finished scan, durably (one-step task)."""
     from apps.core.console.ai.tasks import run_triage_and_summaries
 
     run_triage_and_summaries(session_id)
 
 
-@DBOS.workflow(name="ai_triage")
-def ai_triage_workflow(session_id: int) -> None:
-    """Manual (re-)triage of a finished scan, durably."""
-    _run_ai_triage(session_id)
-
-
-@DBOS.step()
-def _run_agent_step(root_session_id: int) -> None:
+@durable_task("agent_step")
+def agent_step(root_session_id: int) -> None:
+    """One adaptive-orchestration decision step (one-step task). The chain
+    continues when a launched subscan's finalize enqueues the next agent_step."""
     from apps.core.console.ai.tasks import run_agent_step_safe
 
     run_agent_step_safe(root_session_id)
-
-
-@DBOS.workflow(name="agent_step")
-def agent_step_workflow(root_session_id: int) -> None:
-    """One adaptive-orchestration decision step. The chain continues when a
-    launched subscan's finalize enqueues the next agent_step."""
-    _run_agent_step(root_session_id)
 
 
 # --- Enqueue helpers (called from the web process via the client) -----------
@@ -106,31 +97,13 @@ def enqueue_scan(session_id: int) -> str:
 
 
 def enqueue_ai_triage(session_id: int) -> str:
-    from dbos import EnqueueOptions
-
-    from .dbos_app import get_client
-
-    options: EnqueueOptions = {
-        "workflow_name": "ai_triage",
-        "queue_name": QUEUE_NAME,
-        "deduplication_id": f"triage-{session_id}",
-        "duplication_policy": "return-existing",
-    }
-    handle = get_client().enqueue(options, session_id)
-    return handle.workflow_id
+    """Thin wrapper kept for callers; delegates to the durable task's .delay()."""
+    return ai_triage.delay(session_id)
 
 
 def enqueue_agent_step(root_session_id: int) -> str:
-    from dbos import EnqueueOptions
-
-    from .dbos_app import get_client
-
-    options: EnqueueOptions = {
-        "workflow_name": "agent_step",
-        "queue_name": QUEUE_NAME,
-    }
-    handle = get_client().enqueue(options, root_session_id)
-    return handle.workflow_id
+    """Thin wrapper kept for callers; delegates to the durable task's .delay()."""
+    return agent_step.delay(root_session_id)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -186,7 +186,17 @@ duplicate findings/assets; a clean re-run of a completed scan is a no-op.
 **Effort:** ~1 PR (A). **Priority:** medium — it's the one *correctness* gap in the
 "durable" claim after H1 (alerts). Do after H2/H3, before or with H4.
 
-## 5d. Phase H6 — `@durable_task` engine adapter (pipeline principle #11)
+## 5d. Phase H6 — `@durable_task` engine adapter (pipeline principle #11) — ✅ SHIPPED (slice 1)
+
+> **Status:** ✅ Slice 1 shipped — `apps/core/engine/durable/task.py` (`@durable_task`
+> with in-process `task()`, `task.delay()`, `dedupe` template). The two **one-step**
+> tasks `ai_triage` + `agent_step` are converted; `enqueue_ai_triage`/`enqueue_agent_step`
+> now delegate to `.delay()`. `run_scan` stays an explicit **multi-step** workflow
+> (per-phase checkpointing) — by design, not converted. The `@scheduled` hygiene crons
+> are left for **H7** (they fit the `ScheduledJob` model better than a one-step task).
+> Verified: `configure_dbos()` builds the engine and registers the adapter workflows;
+> 7 adapter tests + 97 enqueue/integration tests green. Tests:
+> `tests/unit/test_durable_task.py`.
 
 **Problem:** workflow bodies use `@DBOS.workflow`/`@DBOS.step` **directly**, so the
 engine leaks into every task: tasks can't run without a DBOS engine (harder to

--- a/tests/unit/test_durable_task.py
+++ b/tests/unit/test_durable_task.py
@@ -1,0 +1,100 @@
+"""Tests for the @durable_task engine adapter (PQC hardening H6)."""
+
+from unittest.mock import MagicMock, patch
+
+from apps.core.engine.durable.task import DurableTask, REGISTRY, durable_task
+
+
+def test_in_process_call_runs_body_without_dbos():
+    """task(*args) runs the body directly — no DBOS engine needed."""
+    calls = []
+
+    @durable_task("t_inproc")
+    def t(x):
+        calls.append(x)
+        return x * 2
+
+    assert t(21) == 42
+    assert calls == [21]
+
+
+def test_registry_registration():
+    @durable_task("t_reg")
+    def t():
+        return None
+
+    assert REGISTRY["t_reg"] is t
+    assert isinstance(t, DurableTask)
+    assert t.name == "t_reg"
+
+
+def test_delay_enqueues_with_name_and_queue():
+    @durable_task("t_delay", queue="scans")
+    def t(x):
+        return None
+
+    fake_client = MagicMock()
+    fake_client.enqueue.return_value = MagicMock(workflow_id="wf-1")
+    with patch("apps.core.engine.durable.dbos_app.get_client", return_value=fake_client):
+        wid = t.delay(7)
+
+    assert wid == "wf-1"
+    opts, arg = fake_client.enqueue.call_args[0]
+    assert opts["workflow_name"] == "t_delay"
+    assert opts["queue_name"] == "scans"
+    assert "deduplication_id" not in opts  # no dedupe template → no dedup id
+    assert arg == 7
+
+
+def test_delay_uses_dedupe_template():
+    @durable_task("t_dedupe", dedupe="triage-{0}")
+    def t(x):
+        return None
+
+    fake_client = MagicMock()
+    fake_client.enqueue.return_value = MagicMock(workflow_id="wf-2")
+    with patch("apps.core.engine.durable.dbos_app.get_client", return_value=fake_client):
+        t.delay(99)
+
+    opts = fake_client.enqueue.call_args[0][0]
+    assert opts["deduplication_id"] == "triage-99"
+    assert opts["duplication_policy"] == "return-existing"
+
+
+def test_delay_dedupe_id_override_wins():
+    @durable_task("t_override", dedupe="x-{0}")
+    def t(x):
+        return None
+
+    fake_client = MagicMock()
+    fake_client.enqueue.return_value = MagicMock(workflow_id="w")
+    with patch("apps.core.engine.durable.dbos_app.get_client", return_value=fake_client):
+        t.delay(1, dedupe_id="custom-id")
+
+    assert fake_client.enqueue.call_args[0][0]["deduplication_id"] == "custom-id"
+
+
+def test_real_tasks_are_durable_tasks_with_expected_names():
+    """The converted one-step tasks keep their DBOS workflow names + dedup."""
+    from apps.core.engine.durable import workflows
+
+    assert isinstance(workflows.ai_triage, DurableTask)
+    assert workflows.ai_triage.name == "ai_triage"
+    assert workflows.ai_triage._dedupe == "triage-{0}"
+
+    assert isinstance(workflows.agent_step, DurableTask)
+    assert workflows.agent_step.name == "agent_step"
+    assert workflows.agent_step._dedupe is None
+
+
+def test_enqueue_wrappers_delegate_to_delay():
+    """The kept enqueue_* helpers route through the task's .delay()."""
+    from apps.core.engine.durable import workflows
+
+    with patch.object(workflows.ai_triage, "delay", return_value="wid-t") as m_t:
+        assert workflows.enqueue_ai_triage(5) == "wid-t"
+        m_t.assert_called_once_with(5)
+
+    with patch.object(workflows.agent_step, "delay", return_value="wid-a") as m_a:
+        assert workflows.enqueue_agent_step(9) == "wid-a"
+        m_a.assert_called_once_with(9)

--- a/tests/unit/test_durable_task.py
+++ b/tests/unit/test_durable_task.py
@@ -35,7 +35,7 @@ def test_delay_enqueues_with_name_and_queue():
 
     fake_client = MagicMock()
     fake_client.enqueue.return_value = MagicMock(workflow_id="wf-1")
-    with patch("apps.core.engine.durable.dbos_app.get_client", return_value=fake_client):
+    with patch("apps.core.engine.durable.client.get_client", return_value=fake_client):
         wid = t.delay(7)
 
     assert wid == "wf-1"
@@ -53,7 +53,7 @@ def test_delay_uses_dedupe_template():
 
     fake_client = MagicMock()
     fake_client.enqueue.return_value = MagicMock(workflow_id="wf-2")
-    with patch("apps.core.engine.durable.dbos_app.get_client", return_value=fake_client):
+    with patch("apps.core.engine.durable.client.get_client", return_value=fake_client):
         t.delay(99)
 
     opts = fake_client.enqueue.call_args[0][0]
@@ -68,7 +68,7 @@ def test_delay_dedupe_id_override_wins():
 
     fake_client = MagicMock()
     fake_client.enqueue.return_value = MagicMock(workflow_id="w")
-    with patch("apps.core.engine.durable.dbos_app.get_client", return_value=fake_client):
+    with patch("apps.core.engine.durable.client.get_client", return_value=fake_client):
         t.delay(1, dedupe_id="custom-id")
 
     assert fake_client.enqueue.call_args[0][0]["deduplication_id"] == "custom-id"


### PR DESCRIPTION
**Slice 1 of H6** (pipeline principle #11 — keep the engine behind an adapter), modeled on the sibling `backend` repo's `durable/task.py`.

## What it adds
`apps/core/engine/durable/task.py` — a thin `@durable_task` decorator over DBOS:
```python
@durable_task("ai_triage", dedupe="triage-{0}")
def ai_triage(session_id): ...
ai_triage(session_id)        # run body in-process — NO DBOS engine (testable)
ai_triage.delay(session_id)  # durably enqueue (dedupe → DBOS deduplication_id)
```
Task bodies no longer import `dbos`.

## Scope (deliberately bounded)
- **Converted** the two *one-step* tasks: `ai_triage`, `agent_step`. `enqueue_ai_triage`/`enqueue_agent_step` now delegate to `.delay()`.
- **`run_scan` stays explicit multi-step** — its per-phase checkpointing (resume at first unfinished phase) is the whole point; collapsing it into a one-step task would lose that.
- The `@scheduled` hygiene crons are left for **H7** (they fit `ScheduledJob`).

## Safety
- Workflow **names + dedup unchanged** → no behaviour change.
- Verified `configure_dbos()` builds the engine and **registers the adapter workflows** (`_dbos_workflow` built for both).
- **7 adapter tests** + **97 enqueue/integration tests** green; Django check + ruff clean. Total → 1765.

Docs: spec H6 marked ✅ slice-1 shipped, CHANGELOG, CLAUDE.
