### PR TITLE
chore: release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.3.0] — 2026-09-08
+
 ### Changed
 - **`@durable_task` engine adapter (PQC hardening H6, slice 1).** New
   `apps/core/engine/durable/task.py` — a thin decorator over DBOS so task bodies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.2.0"
+version = "2.3.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.2.0"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release for the work merged since v2.2.0.

## Highlights
- **`@durable_task` engine adapter (H6)** — task bodies no longer import DBOS; `task()` runs in-process (testable), `task.delay()` enqueues. Engine behind an adapter (principle #11); also broke a pre-existing import cycle. #365
- **Core apps reorganised into layer subpackages** — `apps/core/console|engine|data/` (Django labels unchanged → DB untouched). #362
- **Alert idempotency (H1)** — no duplicate Slack/Teams alerts on a finalize replay. #355
- **Removed a vestigial SQLite write-lock** from the workflow runner. #360

## Change
- `pyproject.toml` + `uv.lock`: 2.2.0 → 2.3.0
- `CHANGELOG.md`: `[Unreleased]` → `[v2.3.0]`

After merge I'll tag `v2.3.0` (CI publishes `:v2.3.0` + floating `:v2.3` + refreshes `:latest`) and cut the GitHub Release.
