### PR TITLE
docs: add Keep a Changelog compare-URL version links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1031,3 +1031,17 @@ security learners. The pre-launch work below tightens the load-bearing
   (Flagged during test as a possible bug because `head -30` truncation showed
   only Full Scan with `is_default=false`; rebuilding the test with a higher
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
+
+<!-- Version compare links (Keep a Changelog) -->
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.3.0...HEAD
+[v2.3.0]: https://github.com/cybersecify/OpenEASD/compare/v2.2.0...v2.3.0
+[v2.2.0]: https://github.com/cybersecify/OpenEASD/compare/v2.1.1...v2.2.0
+[v2.1.1]: https://github.com/cybersecify/OpenEASD/compare/v2.1.0...v2.1.1
+[v2.1.0]: https://github.com/cybersecify/OpenEASD/compare/v2.0.0...v2.1.0
+[v2.0.0]: https://github.com/cybersecify/OpenEASD/compare/v0.10.0...v2.0.0
+[v0.10.0]: https://github.com/cybersecify/OpenEASD/compare/v0.9.0...v0.10.0
+[v0.9.0]: https://github.com/cybersecify/OpenEASD/compare/v0.8.0...v0.9.0
+[v0.8.0]: https://github.com/cybersecify/OpenEASD/compare/v0.7.1...v0.8.0
+[v0.7.1]: https://github.com/cybersecify/OpenEASD/compare/v0.7...v0.7.1
+[v0.7]: https://github.com/cybersecify/OpenEASD/compare/v0.6...v0.7
+[v0.5]: https://github.com/cybersecify/OpenEASD/compare/v0.4...v0.5


### PR DESCRIPTION
Closes the one strict-Keep-a-Changelog element the CHANGELOG was missing: **reference-style version links** at the bottom.

- Each `[vX.Y.Z]` → a GitHub **compare URL** against the previous tag (e.g. `[v2.3.0]: …/compare/v2.2.0...v2.3.0`), and `[Unreleased]` → `v2.3.0...HEAD`.
- Covers **all 12 version headers** (v2.3.0 … v0.5); every referenced tag verified to exist.
- Version headers now render as clickable links to each release's diff.

Docs-only. OpenEASD's CHANGELOG now fully matches Keep a Changelog (previously "loosely follows" — the compare links were the only gap; the "Why:" note enhancement stays).
