### PR TITLE
feat: wire tools to get_credential — DB keys override env (credentials C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ commits to recover the reasoning.
   the resolver yet (that's C3), so scans are unchanged. Bootstrap secrets
   (`FIELD_ENCRYPTION_KEY`, `SECRET_KEY`, `DB_*`) deliberately stay env-only. Spec:
   `docs/specs/2026-09-09-credential-management.md`.
+- **UI-managed BYOK credentials — tools wired (C3).** `shodan`, `breach_check`,
+  `github_recon`, `github_secrets`, and `dns_history` now read their key via
+  `get_credential()` instead of `settings` directly, so a key stored in the DB
+  (`ToolCredentials`) **overrides the env var with no redeploy**; an unset DB key
+  falls back to env exactly as before. Existing tool tests unchanged (env fallback
+  preserves them); a new test proves a DB key drives `shodan` onto the paid host
+  tier with no env key. Cloudflare still defers to `AISettings`. **Why:** this is
+  where UI/DB keys start taking effect. Next: the CredentialsPage UI (C5).
 
 ## [v2.3.0] — 2026-09-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ Django labels are unchanged — the nesting is organisational only (import paths
 | `insights/` | `insights` | ScanSummary (incl. per-scan Exposure Score + grade, `scoring.py`), FindingTypeSummary, charts |
 | `reports/` | `reports` | CSV + PDF export (synchronous, served by the web tier) |
 | `ai/` | `ai` | AI analysis (Cloudflare Workers AI, BYOK): finding triage, bounded adaptive orchestration, report/alert summaries, consent + per-call audit log |
-| `credentials/` | `credentials` | UI-managed BYOK API keys — `ToolCredentials` encrypted singleton + `get_credential()` resolver (DB-wins-over-env) + write-only `/api/credentials/` (C1; tools not wired yet) |
+| `credentials/` | `credentials` | UI-managed BYOK API keys — `ToolCredentials` encrypted singleton + `get_credential()` resolver (DB-wins-over-env) + write-only `/api/credentials/`. Tools read via the resolver (shodan/breach_check/github_recon/github_secrets/dns_history) — a DB key overrides env with no redeploy. UI page pending (C5) |
 | `api/` | — | Django Ninja API — routers, JWT auth, error handlers |
 
 ### REST API module — `apps/core/console/api/`
@@ -821,7 +821,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
 | `tests/unit/test_qcluster_config.py` | 3 | Scan-timeout invariants (Q_CLUSTER removed; SCAN_TASK_TIMEOUT + watchdog bound) |
 | `tests/unit/test_durable_task.py` | 7 | `@durable_task` engine adapter (H6) — in-process call, `.delay()` enqueue, dedupe template + override, registry, real tasks are DurableTasks, enqueue_* wrappers delegate |
-| `tests/unit/test_credentials.py` | 12 | UI-managed BYOK credentials (C1) — singleton, ciphertext-at-rest/plaintext-via-ORM, resolver DB-wins-over-env + env fallback + source + never-raises, write-only API (presence-only never values, set/none-unchanged/clear) |
+| `tests/unit/test_credentials.py` | 13 | UI-managed BYOK credentials (C1+C3) — singleton, ciphertext-at-rest/plaintext-via-ORM, resolver DB-wins-over-env + env fallback + source + never-raises, write-only API (presence-only never values, set/none-unchanged/clear), and a DB key reaching `shodan.collect` (paid tier, no env key) |
 | `tests/unit/test_reports.py` | 57 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block, AI Analyst Summary block (absent without AI rows) |
 | `tests/unit/test_waf_detection.py` | 16 | WAF/block/challenge classifier (spec C1) — vendor fingerprint, false-positive guards, analyzer wiring |
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
@@ -865,6 +865,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1777 tests** (1725 fast + 52 slow domain_security)
+**Total: 1778 tests** (1726 fast + 52 slow domain_security)
 
 Frontend: **18 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, and the Assets `SeverityChips`. Run with `cd frontend && npm run test:run`.

--- a/apps/breach_check/collector.py
+++ b/apps/breach_check/collector.py
@@ -37,6 +37,7 @@ import time
 
 import requests
 from django.conf import settings
+from apps.core.console.credentials.resolver import get_credential
 
 logger = logging.getLogger(__name__)
 
@@ -212,7 +213,7 @@ def collect(domain: str) -> dict:
     Picks the authoritative HIBP tier when ``HIBP_API_KEY`` is set, else the free
     keyless XposedOrNot tier. Always returns a dict; never raises.
     """
-    key = getattr(settings, "HIBP_API_KEY", "")
+    key = get_credential("HIBP_API_KEY")
     if key:
         logger.info("[breach_check] HIBP_API_KEY set — using HIBP breacheddomain for %s", domain)
         return _collect_hibp(domain, key)

--- a/apps/dns_history/collector.py
+++ b/apps/dns_history/collector.py
@@ -21,6 +21,7 @@ import logging
 
 import requests
 from django.conf import settings
+from apps.core.console.credentials.resolver import get_credential
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ _MAX_RECORDS = 50  # cap the records returned so a noisy dataset can't flood fin
 
 
 def _api_url() -> str:
-    return getattr(settings, "DNS_HISTORY_API_URL", "").rstrip("/")
+    return get_credential("DNS_HISTORY_API_URL").rstrip("/")
 
 
 def _user_agent() -> str:

--- a/apps/github_recon/collector.py
+++ b/apps/github_recon/collector.py
@@ -29,6 +29,7 @@ import time
 
 import requests
 from django.conf import settings
+from apps.core.console.credentials.resolver import get_credential
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ def _headers() -> dict:
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    token = getattr(settings, "GITHUB_TOKEN", "")
+    token = get_credential("GITHUB_TOKEN")
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers
@@ -276,7 +277,7 @@ def collect(domain: str) -> dict:
     logger.info(
         "github_recon: org '%s' (%s) — %d public repo(s) inspected in %d API call(s)%s",
         login, kind, len(repos), budget["used"],
-        "" if getattr(settings, "GITHUB_TOKEN", "") else " (unauthenticated free tier)",
+        "" if get_credential("GITHUB_TOKEN") else " (unauthenticated free tier)",
     )
     return {
         "org": login,

--- a/apps/github_secrets/collector.py
+++ b/apps/github_secrets/collector.py
@@ -33,6 +33,7 @@ import time
 
 import requests
 from django.conf import settings
+from apps.core.console.credentials.resolver import get_credential
 
 from apps.core.engine.workflows.exceptions import ToolBinaryMissing, ToolTimeout
 
@@ -308,7 +309,7 @@ def collect(session) -> list[dict]:
     metadata (``_source_url``, ``_repo``, ``_html_url``). Always returns a list;
     the GitHub API side never raises (only a missing gitleaks binary does).
     """
-    token = (getattr(settings, "GITHUB_TOKEN", "") or "").strip()
+    token = (get_credential("GITHUB_TOKEN") or "").strip()
     if not token:
         # No token -> logged no-op. GitHub code-search requires auth; a keyless
         # Full Scan must not be broken by this tool.

--- a/apps/shodan/collector.py
+++ b/apps/shodan/collector.py
@@ -27,6 +27,7 @@ import time
 
 import requests
 from django.conf import settings
+from apps.core.console.credentials.resolver import get_credential
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +149,7 @@ def collect(session) -> list[dict]:
         logger.info("[shodan:%s] no resolved public IPs — skipping", session.id)
         return []
 
-    key = getattr(settings, "SHODAN_API_KEY", "")
+    key = get_credential("SHODAN_API_KEY")
     results: list[dict] = []
 
     if key:

--- a/docs/specs/2026-09-09-credential-management.md
+++ b/docs/specs/2026-09-09-credential-management.md
@@ -1,9 +1,14 @@
 # Credential Management — UI-managed BYOK keys — Design Spec
 
-> **Status:** 🟡 In progress — **C1 shipped** (`apps/core/console/credentials/`:
-> `ToolCredentials` encrypted singleton + `get_credential()` resolver +
-> write-only `/api/credentials/`; 12 tests). No tool wired yet (C3), no UI (C5) —
-> so nothing changes for scans until C3. Implement the rest PR-by-PR from Section 9.
+> **Status:** 🟡 In progress — **C1 + C3 shipped.** C1: `apps/core/console/credentials/`
+> (`ToolCredentials` encrypted singleton + `get_credential()` resolver + write-only
+> `/api/credentials/`). **C3: the 5 tools now read via `get_credential()`** —
+> `shodan` (SHODAN_API_KEY), `breach_check` (HIBP_API_KEY), `github_recon` +
+> `github_secrets` (GITHUB_TOKEN), `dns_history` (DNS_HISTORY_API_URL) — so a
+> DB-stored key overrides the env with no redeploy (proven by
+> `test_credentials.py::TestToolWiring`). Cloudflare still defers to `AISettings`
+> (Section 6). `github_secret` field kept but unconsumed (no tool reads it).
+> **Remaining: C5 (the CredentialsPage UI).**
 
 **Goal:** let the operator manage the tools' bring-your-own-key (BYOK) API keys
 from a **single console page**, stored **encrypted in the DB**, instead of

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -142,3 +142,34 @@ class TestApi:
             content_type="application/json",
         )
         assert ToolCredentials.get().shodan_api_key == ""
+
+
+# --- C3: a DB-stored key actually reaches a tool -------------------------
+
+class TestToolWiring:
+    def test_db_key_drives_shodan_paid_tier_without_env(self, settings, monkeypatch):
+        """A DB Shodan key (no env key) makes shodan.collect take the keyed path."""
+        from unittest.mock import MagicMock
+        from apps.shodan import collector
+        from apps.core.console.credentials.models import ToolCredentials
+
+        settings.SHODAN_API_KEY = ""  # no env key
+        cfg = ToolCredentials.get()
+        cfg.shodan_api_key = "db-shodan-key"
+        cfg.save()
+
+        # capture the key the paid host API is called with
+        seen = {}
+
+        def fake_get_json(url, params=None):
+            seen["url"] = url
+            seen["key"] = (params or {}).get("key")
+            return None  # short-circuit; we only assert the tier/key choice
+
+        monkeypatch.setattr(collector, "_get_json", fake_get_json)
+        monkeypatch.setattr(collector, "_session_ips", lambda s: ["1.2.3.4"])
+        session = MagicMock(id=1)
+
+        collector.collect(session)
+        assert seen.get("key") == "db-shodan-key"  # DB key reached the tool
+        assert "/shodan/host/" in seen.get("url", "")  # paid tier, not free InternetDB


### PR DESCRIPTION
**C3** of the credential-management spec (#369) — this is where DB-stored BYOK keys start taking effect.

## What changed
The 5 tools with in-scope keys now read via **`get_credential()`** instead of `settings` directly:
| Tool | Key |
|---|---|
| `shodan` | `SHODAN_API_KEY` |
| `breach_check` | `HIBP_API_KEY` |
| `github_recon` + `github_secrets` | `GITHUB_TOKEN` |
| `dns_history` | `DNS_HISTORY_API_URL` |

A key stored in the DB (`ToolCredentials`, via `/api/credentials/`) now **overrides the env var with no redeploy**; an unset DB key **falls back to env exactly as before**.

## Safety
- **Additive / backward-compatible** — the resolver's env-fallback means every existing tool test passes unchanged (empty DB row → falls back to the `settings` value the tests set).
- Cloudflare still defers to `AISettings` (spec §6); `github_secret` field stays unconsumed (no tool reads it).
- No migration (no model change).

## Tests
`test_credentials.py` +1 (→13): a DB key drives `shodan.collect` onto the **paid host tier with no env key** — proves the DB→tool path end-to-end. Verified locally: ruff clean, no migration drift, the 5 tool suites (144) + credentials (13) green. (Local `scan_flow` runs were flaky due to test-DB connection churn on my box — CI runs it clean; unrelated to this change, which only adds env-fallback reads.)

Next: **C5** — the CredentialsPage UI.
