### PR TITLE
chore: release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.4.0] — 2026-09-09
+
 ### Added
 - **UI-managed BYOK credentials — foundation (C1).** New
   `apps/core/console/credentials` app: a `ToolCredentials` encrypted singleton
@@ -1061,7 +1063,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.4.0...HEAD
+[v2.4.0]: https://github.com/cybersecify/OpenEASD/compare/v2.3.0...v2.4.0
 [v2.3.0]: https://github.com/cybersecify/OpenEASD/compare/v2.2.0...v2.3.0
 [v2.2.0]: https://github.com/cybersecify/OpenEASD/compare/v2.1.1...v2.2.0
 [v2.1.1]: https://github.com/cybersecify/OpenEASD/compare/v2.1.0...v2.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.3.0 — 2026-09-09)
+## Status (v2.4.0 — 2026-09-09)
 
-- **Released**: v2.3.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.3.0` / `:v2.3` / `:latest`. 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.4.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.4.0` / `:v2.4` / `:latest`. 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 28 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.3.0"
+version = "2.4.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release for the **credential-management feature** merged since v2.3.0.

## Highlights
- **UI-managed BYOK credentials** (end-to-end): a console **Credentials page** to enter tool API keys (Shodan / HIBP / GitHub / DNS-history), stored **encrypted in the DB**, that **override the env var with no redeploy**.
  - C1 — `ToolCredentials` encrypted model + `get_credential()` resolver + write-only `/api/credentials/` (#370)
  - C3 — the 5 tools read via the resolver; DB key wins, env fallback (#371)
  - C5 — the `CredentialsPage` UI (#373)

## Change
- `pyproject.toml` + `uv.lock`: 2.3.0 → 2.4.0
- `CHANGELOG.md`: `[Unreleased]` → `[v2.4.0]` + compare link
- CLAUDE Status header → v2.4.0

After merge I'll tag `v2.4.0` (CI publishes `:v2.4.0` + `:v2.4` + `:latest`) and cut the GitHub Release.
