### PR TITLE
fix: graceful timeout handling for asn_discovery and dnsx (re-applies #302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Fixed
+- **Graceful timeout handling for `asn_discovery` and `dnsx`.** `asn_discovery`
+  now catches `ToolTimeout` from `amass intel` and returns no findings instead of
+  failing the step (ASN/CIDR discovery is informational, so a slow BGP/registry
+  lookup should not flip a scan to `partial`); `dnsx`'s subprocess timeout is
+  raised 300s→600s so large subdomain sets resolve fully. Re-applied from a
+  contributor PR with the import path corrected for the core-app layer reorg
+  (`apps.core.engine.workflows.exceptions`) + a regression test.
+
 ## [v2.4.0] — 2026-09-09
 
 ### Added

--- a/apps/asn_discovery/scanner.py
+++ b/apps/asn_discovery/scanner.py
@@ -14,6 +14,7 @@ separate authorization decision — see collector.py / analyzer.py).
 import logging
 
 from apps.core.data.findings.models import Finding
+from apps.core.engine.workflows.exceptions import ToolTimeout
 
 from .analyzer import analyze
 from .collector import collect
@@ -23,7 +24,14 @@ logger = logging.getLogger(__name__)
 
 def run_asn_discovery(session) -> list[Finding]:
     """Discover owned ASNs/CIDRs for the session domain and persist Findings."""
-    records = collect(session)
+    try:
+        records = collect(session)
+    except ToolTimeout:
+        logger.warning(
+            "[asn_discovery:%s] amass intel timed out — skipping ASN discovery",
+            session.id,
+        )
+        return []
     if not records:
         return []
 

--- a/apps/dnsx/collector.py
+++ b/apps/dnsx/collector.py
@@ -31,7 +31,7 @@ def collect(session, subdomains: list[str]) -> list[dict]:
     logger.info(f"[dnsx:{session.id}] Resolving {len(subdomains)} subdomains")
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=300, stdin=subprocess.DEVNULL)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, stdin=subprocess.DEVNULL)
     except FileNotFoundError:
         logger.error(f"[dnsx:{session.id}] Binary not found: {binary}")
         raise ToolBinaryMissing(f"dnsx binary not found: {binary}")

--- a/tests/unit/test_asn_discovery.py
+++ b/tests/unit/test_asn_discovery.py
@@ -232,3 +232,11 @@ class TestAsnDiscoveryScanner:
         sess = _session()
         with patch("apps.asn_discovery.scanner.collect", return_value=[]):
             assert run_asn_discovery(sess) == []
+
+    def test_timeout_is_swallowed_not_raised(self):
+        """amass intel timing out must not fail the step — ASN discovery is
+        informational, so a ToolTimeout returns [] instead of propagating."""
+        from apps.core.engine.workflows.exceptions import ToolTimeout
+        sess = _session()
+        with patch("apps.asn_discovery.scanner.collect", side_effect=ToolTimeout("amass intel timed out")):
+            assert run_asn_discovery(sess) == []


### PR DESCRIPTION
Re-applies **#302** (which went `CONFLICTING` after the core-app layer reorg) on fresh `main`, with the import path corrected.

## Why #302 couldn't merge
It imported `apps.core.workflows.exceptions`, but the reorg moved that to **`apps.core.engine.workflows.exceptions`** — hence the conflict. This re-applies the same fix with the correct path.

## The fix (unchanged in intent)
- **`asn_discovery/scanner.py`** — catch `ToolTimeout` from `amass intel` and return `[]` instead of failing the step. ASN/CIDR discovery is informational, so a slow BGP/registry lookup should not flip a scan to `partial`.
- **`dnsx/collector.py`** — subprocess timeout **300s → 600s** so large subdomain sets resolve fully.

## Added
A regression test (`test_asn_discovery.py`): a `ToolTimeout` from the collector is swallowed → `run_asn_discovery` returns `[]` (the original PR had no test). 63 asn/dnsx tests green; ruff clean.

Credit to @vennela-cybersecify for the original fix (#302) — that PR can be closed in favour of this one.
