### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.4.1] — 2026-09-09
+
+### Fixed
+- **Subdomain-takeover false positives suppressed via a live HTTP probe** — a
+  dangling-DNS candidate is only reported when the probe confirms it, cutting
+  noise from stale-but-harmless records (contributor fix).
+
 ### Changed
+- **Dependency bumps:** worker base image `debian` 12-slim → 13-slim; dev deps
+  `postcss` 8.5.26 → 8.5.28 and `autoprefixer` 10.5.4 → 10.5.5; CI action
+  `peter-evans/create-pull-request` pinned to a newer SHA.
 - **Frontend test-tooling major upgrades (coordinated).** `vitest` 4→5,
   `@vitest/ui` 4→5, and `@testing-library/jest-dom` 6→7, bumped together (vitest
   and its UI must share a major). Dev-only; no product code. All 22 Vitest tests
@@ -1079,7 +1089,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.4.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.4.1...HEAD
+[v2.4.1]: https://github.com/cybersecify/OpenEASD/compare/v2.4.0...v2.4.1
 [v2.4.0]: https://github.com/cybersecify/OpenEASD/compare/v2.3.0...v2.4.0
 [v2.3.0]: https://github.com/cybersecify/OpenEASD/compare/v2.2.0...v2.3.0
 [v2.2.0]: https://github.com/cybersecify/OpenEASD/compare/v2.1.1...v2.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.4.0 — 2026-09-09)
+## Status (v2.4.1 — 2026-09-09)
 
-- **Released**: v2.4.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.4.0` / `:v2.4` / `:latest`. 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.4.1 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.4.1` / `:v2.4` / `:latest`. 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 28 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.4.0"
+version = "2.4.1"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Patch release for the fixes + dependency bumps merged since v2.4.0.

## Fixed
- Subdomain-takeover **false positives suppressed** via a live HTTP probe (#291)
- **Graceful timeout handling** for `asn_discovery` + `dnsx` (#375)

## Changed (deps)
- Worker base image **debian 12→13-slim** (#347)
- `postcss`, `autoprefixer` patch bumps; `create-pull-request` GHA action bump
- **Frontend test tooling** — vitest 5 / @vitest/ui 5 / jest-dom 7 (#376)

## Change
- `pyproject.toml` + `uv.lock`: 2.4.0 → 2.4.1
- CHANGELOG `[Unreleased]` → `[v2.4.1]` + compare link; CLAUDE Status → v2.4.1

After merge I'll tag `v2.4.1` (CI publishes `:v2.4.1` + refreshes `:v2.4` / `:latest`) and cut the GitHub Release.
