### PR TITLE
chore: release v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.4.2] — 2026-09-09
+
+### Changed
+- **Settings split into a `settings/` package.** `openeasd/settings.py` is now
+  `openeasd/settings/` (`base.py` + `__init__.py`) — the standard, more-scalable
+  Django layout, so environment-specific overrides can layer on `base.py` if ever
+  needed. `DJANGO_SETTINGS_MODULE=openeasd.settings` is unchanged (resolves to the
+  package); behaviour is identical (no config values changed, full suite green).
+  Structural only — no user-facing change.
+
 ## [v2.4.1] — 2026-09-09
 
 ### Fixed
@@ -1089,7 +1099,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.4.1...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.4.2...HEAD
+[v2.4.2]: https://github.com/cybersecify/OpenEASD/compare/v2.4.1...v2.4.2
 [v2.4.1]: https://github.com/cybersecify/OpenEASD/compare/v2.4.0...v2.4.1
 [v2.4.0]: https://github.com/cybersecify/OpenEASD/compare/v2.3.0...v2.4.0
 [v2.3.0]: https://github.com/cybersecify/OpenEASD/compare/v2.2.0...v2.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.4.1 — 2026-09-09)
+## Status (v2.4.2 — 2026-09-09)
 
-- **Released**: v2.4.1 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.4.1` / `:v2.4` / `:latest`. 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.4.2 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.4.2` / `:v2.4` / `:latest`. 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 28 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.4.1"
+version = "2.4.2"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.4.1"
+version = "2.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Patch release for the settings-package refactor (#378).

## Changed
- **Settings split into a `settings/` package** — `openeasd/settings.py` → `openeasd/settings/` (`base.py` + `__init__.py`), the standard scalable Django layout. `DJANGO_SETTINGS_MODULE` unchanged; behaviour-identical (structural only).

## Change
- `pyproject.toml` + `uv.lock`: 2.4.1 → 2.4.2
- CHANGELOG `[Unreleased]` → `[v2.4.2]` + compare link; CLAUDE Status → v2.4.2

After merge I'll tag `v2.4.2` (CI publishes `:v2.4.2` + `:v2.4` + `:latest`) and cut the GitHub Release.
