### PR TITLE
chore: release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.5.0] — 2026-09-09
+
 ### Changed
 - **Web image on Python 3.14; CI tests on 3.14.** The `web` runtime image moves
   `python:3.12-slim` → `python:3.14-slim`, and the CI test job moves 3.12 → 3.14
@@ -1109,7 +1111,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.4.2...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.5.0...HEAD
+[v2.5.0]: https://github.com/cybersecify/OpenEASD/compare/v2.4.2...v2.5.0
 [v2.4.2]: https://github.com/cybersecify/OpenEASD/compare/v2.4.1...v2.4.2
 [v2.4.1]: https://github.com/cybersecify/OpenEASD/compare/v2.4.0...v2.4.1
 [v2.4.0]: https://github.com/cybersecify/OpenEASD/compare/v2.3.0...v2.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.4.2 — 2026-09-09)
+## Status (v2.5.0 — 2026-09-09)
 
-- **Released**: v2.4.2 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.4.2` / `:v2.4` / `:latest`. 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.5.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.5.0` / `:v2.5` / `:latest` (web on Python 3.14, worker on Ubuntu 24.04/3.12). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 28 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.4.2"
+version = "2.5.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.4.2"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release for the **Python 3.14** runtime bump (#380).

## Highlights
- **Web image → Python 3.14** (`python:3.14-slim`), **CI tests on 3.14** — verified: full dep set installs on 3.14 and the whole suite passes on 3.14. Worker stays Ubuntu 24.04 (3.12) by design.

## Change
- `pyproject.toml` + `uv.lock`: 2.4.2 → 2.5.0
- CHANGELOG `[Unreleased]` → `[v2.5.0]` + compare link; CLAUDE Status → v2.5.0

After merge I'll tag `v2.5.0` (CI publishes `:v2.5.0` + `:v2.5` + `:latest`) and cut the GitHub Release.
