### PR TITLE
fix: make asn_discovery amass-cmd test robust to TOOL_AMASS path

### DIFF
--- a/tests/unit/test_asn_discovery.py
+++ b/tests/unit/test_asn_discovery.py
@@ -101,8 +101,13 @@ class TestAsnDiscoveryCollector:
             side_effect=[org_out, asn_out],
         ) as mock_run:
             records = collect(sess)
-        # First call: -org example ; second call: -asn 714
-        assert mock_run.call_args_list[0][0][0][:3] == ["amass", "intel", "-org"]
+        # First call: -org example ; second call: -asn 714.
+        # Assert the amass binary + args without pinning the exact binary path —
+        # TOOL_AMASS may be an absolute path (Docker/k8s set it), so check the
+        # binary component ends with "amass" and the args follow.
+        first_cmd = mock_run.call_args_list[0][0][0]
+        assert first_cmd[0].endswith("amass")
+        assert first_cmd[1:3] == ["intel", "-org"]
         assert mock_run.call_args_list[1][0][0][2:4] == ["-asn", "714"]
         assert len(records) == 1
         assert records[0]["asn"] == 714


### PR DESCRIPTION
## The bug (surfaced by running `just ci` locally with tool paths set)
`test_asn_discovery.py::test_happy_path_two_step` asserted the amass subprocess command's **binary component** equals the bare `"amass"`:
```python
assert mock_run.call_args_list[0][0][0][:3] == ["amass", "intel", "-org"]
```
But the collector resolves the binary via `getattr(settings, "TOOL_AMASS", "amass")`. So **any environment that sets `TOOL_AMASS` to an absolute path fails this test** — and Docker/k8s deployments set `TOOL_*` paths by design (as does a local `.env` used for running real scans). The code is correct; the test was over-specified.

CI stayed green only because CI doesn't set `TOOL_AMASS`.

## The fix
Assert the binary **ends with** `"amass"` and check the args separately — robust to an absolute path:
```python
first_cmd = mock_run.call_args_list[0][0][0]
assert first_cmd[0].endswith("amass")
assert first_cmd[1:3] == ["intel", "-org"]
```

## Verified
The test now passes **with `TOOL_AMASS=/opt/homebrew/bin/amass` set** (the previously-failing condition); all 23 asn_discovery tests green; ruff clean. It was the only test with this bare-binary assertion (others assert tool *lists*, not subprocess argv).
