### PR TITLE
feat: just deploy-dev — dev deployment from CI :latest images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **Dev deployment via `just` (production stays on the GitHub pipeline).** Clean
+  split: the **dev** lifecycle lives in `just` — `just setup`, `just dev` (hot
+  reload), `just up` (build+run the 3-container stack locally), and new
+  **`just deploy-dev`** (run the CI-published `:latest` images via
+  `docker-compose.dev.yml`, no local build). **Production is unchanged** — still
+  `git tag vX.Y.Z` → the GitHub pipeline builds & publishes pinned `:vX.Y.Z`
+  images to GHCR; `just` is not used for prod.
 - **`justfile` task runner** (alongside the existing `Makefile`) with matching
   recipes plus extras: **`just ci`** runs the full CI pipeline locally (ruff +
   pytest w/ 80% coverage gate + bandit + pip-audit + vitest + build, mirroring

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+# Dev-deployment override: run the CI-published :latest images instead of a local
+# build. Used by `just deploy-dev` for a quick dev deploy that consumes the real
+# GHCR artifacts. Production is unchanged — it uses the base docker-compose.yml
+# with pinned :vX.Y.Z images (published by the GitHub tag pipeline).
+#
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --no-build --pull always
+#
+services:
+  web:
+    image: ghcr.io/cybersecify/openeasd-web:latest
+    pull_policy: always
+
+  worker:
+    image: ghcr.io/cybersecify/openeasd-worker:latest
+    pull_policy: always

--- a/justfile
+++ b/justfile
@@ -92,11 +92,20 @@ ci-frontend:
 ci: ci-backend ci-frontend
     @echo "✅ local CI passed (ruff + pytest+coverage + bandit + pip-audit + vitest + build)"
 
-# ── Docker (production-like 3-container stack: db + web + worker) ──────────────
+# ── Dev deployment (3-container stack: db + web + worker) ─────────────────────
+# NOTE ON THE SPLIT:
+#   • DEV lifecycle lives here in `just` — setup, dev, up, deploy-dev.
+#   • PRODUCTION is the GitHub pipeline (unchanged): `git tag vX.Y.Z` → CI builds
+#     & publishes pinned :vX.Y.Z images to GHCR; deploy them via the base
+#     docker-compose.yml. `just` is NOT used for production.
 
-# Build + start the 3-container stack (http://localhost:8000)
+# Dev deploy: build the stack locally from source (http://localhost:8000)
 up:
     docker compose up -d --build
+
+# Dev deploy from the CI-published :latest images (no local build — pulls GHCR)
+deploy-dev:
+    docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --no-build --pull always
 
 # Stop the stack (keep the db volume)
 down:


### PR DESCRIPTION
Implements the **dev/prod split** you asked for: **production stays on the GitHub pipeline (unchanged); `just` owns the dev lifecycle including dev deployment.**

## Dev (via `just`)
| Recipe | What |
|---|---|
| `just setup` | dev environment setup |
| `just dev` | local dev servers (hot reload) |
| `just up` | build + run the 3-container stack **locally from source** |
| **`just deploy-dev`** *(new)* | run the **CI-published `:latest`** images (no local build — pulls GHCR) via `docker-compose.dev.yml` |

## Production (unchanged — GitHub pipeline)
`git tag vX.Y.Z` → CI builds & publishes pinned **`:vX.Y.Z`** images to GHCR → deploy via the base `docker-compose.yml`. **`just` is not used for production.**

## Files
- **`docker-compose.dev.yml`** — override pointing `web`/`worker` at `ghcr.io/cybersecify/openeasd-{web,worker}:latest` (`pull_policy: always`).
- **`justfile`** — `deploy-dev` recipe + a header documenting the split.

## Validated
`just --list` clean; **`docker compose config` merges the override to the `:latest` images** (confirmed); dry-run shows the expected `up --no-build --pull always`. No changes to `ci.yml` or the production flow.
