### PR TITLE
chore: release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.6.0] — 2026-09-09
+
+### Fixed
+- **asn_discovery test robust to `TOOL_AMASS` path.** `test_happy_path_two_step`
+  pinned the amass command's binary to the bare `"amass"`; any environment that
+  sets `TOOL_AMASS` to an absolute path (Docker/k8s deployments, or a local `.env`
+  for running scans) failed the test though the code was correct. Now asserts the
+  binary ends with `amass` and checks the args separately.
+
 ### Added
 - **Dev deployment via `just` (production stays on the GitHub pipeline).** Clean
   split: the **dev** lifecycle lives in `just` — `just setup`, `just dev` (hot
@@ -1125,7 +1134,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.6.0...HEAD
+[v2.6.0]: https://github.com/cybersecify/OpenEASD/compare/v2.5.0...v2.6.0
 [v2.5.0]: https://github.com/cybersecify/OpenEASD/compare/v2.4.2...v2.5.0
 [v2.4.2]: https://github.com/cybersecify/OpenEASD/compare/v2.4.1...v2.4.2
 [v2.4.1]: https://github.com/cybersecify/OpenEASD/compare/v2.4.0...v2.4.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.5.0 — 2026-09-09)
+## Status (v2.6.0 — 2026-09-09)
 
-- **Released**: v2.5.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.5.0` / `:v2.5` / `:latest` (web on Python 3.14, worker on Ubuntu 24.04/3.12). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.6.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.6.0` / `:v2.6` / `:latest` (web on Python 3.14, worker on Ubuntu 24.04/3.12). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 28 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.5.0"
+version = "2.6.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.5.0"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release for the dev-tooling work since v2.5.0.

## Highlights
- **`justfile` task runner** + **`just ci`** (runs the full CI pipeline locally) (#382)
- **Dev/prod split**: `just` owns the dev lifecycle (`setup`/`dev`/`up`/**`deploy-dev`**); production is unchanged on the GitHub tag pipeline. `just deploy-dev` runs the CI-published `:latest` images (#384)
- **Fix**: asn_discovery test robust to `TOOL_AMASS` absolute path (#383)

## Change
- `pyproject.toml` + `uv.lock`: 2.5.0 → 2.6.0
- CHANGELOG `[Unreleased]` → `[v2.6.0]` + compare link; CLAUDE Status → v2.6.0

After merge I'll tag `v2.6.0` (CI publishes `:v2.6.0` + `:v2.6` + `:latest`) and cut the GitHub Release.
