### PR TITLE
fix: use import.meta.dirname in vite.config (silence Vite 8 warning)

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig(({ command }) => ({
   base: command === 'build' ? '/static/' : '/',
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
   build: {


### PR DESCRIPTION
Silences the Vite 8 config-loader warning seen on `just dev`:
```
Your Vite config uses features that are unsupported by `configLoader: 'native'`:
  - `__dirname` (vite.config.js:10:25). Use `import.meta.dirname` instead
```

## Fix
`path.resolve(__dirname, './src')` → `path.resolve(import.meta.dirname, './src')` — the replacement Vite recommends. Vite 8 requires **Node ≥20.19**, which supports `import.meta.dirname`, so it's safe.

## Verified
`npm run build` runs **clean — no `__dirname`/unsupported warning** — and the `@` → `./src` alias still resolves. (Node v26 locally.) Cosmetic/dev-only; no runtime behaviour change.
