### PR TITLE
feat: dedicated Reports page (/reports) with per-scan CSV/PDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **Dedicated Reports page** (`/reports`, new nav item). Lists completed scans
+  with per-scan **CSV/PDF export** and a `min_severity` filter, so you can export
+  without opening each scan (the Scan Detail export buttons stay too). Frontend-only
+  — reuses the existing `/reports/<uuid>/{csv,pdf}/` endpoints; the SPA `/reports`
+  route coexists with them via Django's SPA catch-all and a `^/reports/.+` Vite
+  dev-proxy regex.
+
 ## [v2.6.0] — 2026-09-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -788,6 +788,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 ### Other routes
 - `/reports/<uuid>/csv/` → CSV export (**synchronous** Django view on the web tier, `_report_auth_required` — accepts session auth or `?token=<access_token>`)
 - `/reports/<uuid>/pdf/` → PDF export (**synchronous** Django view on the web tier, rendered with WeasyPrint, `_report_auth_required` — accepts session auth or `?token=<access_token>`)
+- **Reports UI:** the React SPA has a dedicated **Reports page** (`/reports`, nav item + `ReportsPage.jsx`) listing completed scans with per-scan CSV/PDF export + a `min_severity` filter (auth'd fetch+Blob, JWT in header); also still available as CSV/PDF buttons on the Scan Detail page. The SPA `/reports` route and the Django `/reports/<uuid>/{csv,pdf}/` endpoints coexist — Django's SPA catch-all serves bare `/reports`, and the Vite dev proxy uses a `^/reports/.+` regex so only the endpoints proxy to Django.
 - `/admin/` → Django admin
 - `/api/docs` → Django Ninja auto-generated OpenAPI docs
 - `/*` → React SPA catch-all (`frontend/dist/index.html`)

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -13,6 +13,7 @@ const NAV = [
   { label: 'Findings',       path: '/findings' },
   { label: 'Workflows',      path: '/workflows' },
   { label: 'Insights',       path: '/insights' },
+  { label: 'Reports',        path: '/reports' },
   { label: 'Notifications',  path: '/notifications' },
   { label: 'Credentials',    path: '/credentials' },
   { label: 'AI Analysis',    path: '/ai' },

--- a/frontend/src/pages/ReportsPage.jsx
+++ b/frontend/src/pages/ReportsPage.jsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import { Layout } from '../components/Layout.jsx';
+import { Badge } from '../components/Badge.jsx';
+import { Spinner } from '../components/Spinner.jsx';
+import { Pagination } from '../components/Pagination.jsx';
+import { Button } from '../components/ui/button.jsx';
+import { Card } from '../components/ui/card.jsx';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
+import { toast } from '../components/Notification.jsx';
+import { apiGet } from '../api/client.js';
+import { auth } from '../auth.js';
+import { useQuery } from '@tanstack/react-query';
+
+const SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'];
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Download a report via authenticated fetch + Blob — the JWT travels in the
+// Authorization header, never in the URL (same approach as ScanDetailPage).
+async function downloadReport(uuid, kind, minSev) {
+  const token = auth.getToken();
+  const url = `/reports/${uuid}/${kind}/?min_severity=${encodeURIComponent(minSev)}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) throw new Error(`Server returned ${res.status}`);
+  const blob = await res.blob();
+  const dispo = res.headers.get('Content-Disposition') || '';
+  const match = dispo.match(/filename="?([^";]+)"?/);
+  const filename = match ? match[1] : `report.${kind}`;
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
+}
+
+export default function ReportsPage() {
+  const [domain, setDomain] = useState('');
+  const [minSev, setMinSev] = useState('info');
+  const [page, setPage] = useState(1);
+  const [busy, setBusy] = useState('');   // "<uuid>:<kind>" currently downloading
+
+  const { data: domainsData } = useQuery({
+    queryKey: ['/domains/'],
+    queryFn: () => apiGet('/domains/'),
+  });
+  // Reports are of a finished scan → list completed + partial only.
+  const { data, isLoading: loading, error } = useQuery({
+    queryKey: ['/scans/', 'reports', domain, page],
+    queryFn: () => apiGet(`/scans/?domain=${domain}&status=completed&page=${page}`),
+  });
+
+  const scans = data?.scans ?? [];
+  const domains = domainsData || [];
+
+  async function handleDownload(uuid, kind) {
+    const key = `${uuid}:${kind}`;
+    setBusy(key);
+    try {
+      await downloadReport(uuid, kind, minSev);
+    } catch (err) {
+      toast.error(err.message || `Failed to generate ${kind.toUpperCase()} report.`);
+    } finally {
+      setBusy('');
+    }
+  }
+
+  return (
+    <Layout>
+      <div className="space-y-5">
+        <div>
+          <h1 className="text-lit text-xl font-bold">Reports</h1>
+          <p className="text-dim text-sm mt-0.5">Export a CSV or PDF report for any completed scan</p>
+        </div>
+
+        <div className="flex gap-3 flex-wrap items-center">
+          <select value={domain} onChange={e => { setDomain(e.target.value); setPage(1); }} className="field w-52">
+            <option value="">All domains</option>
+            {domains.map(d => <option key={d.id} value={d.name}>{d.name}</option>)}
+          </select>
+          <label className="text-dim text-sm flex items-center gap-2">
+            Min severity
+            <select value={minSev} onChange={e => setMinSev(e.target.value)} className="field w-32">
+              {SEVERITIES.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </label>
+          <span className="text-dim text-xs">applies to the exported report contents</span>
+        </div>
+
+        <Card className="overflow-hidden">
+          {loading ? <div className="flex justify-center p-8"><Spinner /></div>
+          : error   ? <div className="p-6 text-red-400 text-sm">Error: {error?.message ?? String(error)}</div>
+          : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      {['Domain', 'Status', 'Findings', 'Completed', 'Report'].map(h => (
+                        <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim whitespace-nowrap">{h}</TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {scans.length === 0 ? (
+                      <TableRow><TableCell colSpan={5} className="px-4 py-10 text-center text-dim">No completed scans to report on.</TableCell></TableRow>
+                    ) : scans.map(s => (
+                      <TableRow key={s.uuid} className="hover:bg-hover transition-colors">
+                        <TableCell className="px-4 py-3 text-body font-medium">{s.domain_name}</TableCell>
+                        <TableCell className="px-4 py-3"><Badge value={s.status} /></TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-sm">{s.total_findings}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{fmtDate(s.end_time)}</TableCell>
+                        <TableCell className="px-4 py-3">
+                          <div className="flex gap-2">
+                            <Button variant="outline" size="sm" disabled={busy === `${s.uuid}:csv`}
+                              onClick={() => handleDownload(s.uuid, 'csv')}>
+                              {busy === `${s.uuid}:csv` ? '…' : 'CSV'}
+                            </Button>
+                            <Button variant="outline" size="sm" disabled={busy === `${s.uuid}:pdf`}
+                              onClick={() => handleDownload(s.uuid, 'pdf')}>
+                              {busy === `${s.uuid}:pdf` ? '…' : 'PDF'}
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+              {data?.total_pages > 1 && (
+                <div className="px-4 py-3 border-t border-border">
+                  <Pagination page={page} totalPages={data.total_pages} onPage={setPage} />
+                </div>
+              )}
+            </>
+          )}
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -16,6 +16,7 @@ import AssetDetailPage from './pages/AssetDetailPage.jsx';
 import WorkflowsPage from './pages/WorkflowsPage.jsx';
 import WorkflowDetailPage from './pages/WorkflowDetailPage.jsx';
 import InsightsPage from './pages/InsightsPage.jsx';
+import ReportsPage from './pages/ReportsPage.jsx';
 import NotificationsPage from './pages/NotificationsPage.jsx';
 import AiPage from './pages/AiPage.jsx';
 import CredentialsPage from './pages/CredentialsPage.jsx';
@@ -47,6 +48,7 @@ export const router = createBrowserRouter([
       { path: '/workflows', element: <WorkflowsPage /> },
       { path: '/workflows/:id', element: <WorkflowDetailPage /> },
       { path: '/insights', element: <InsightsPage /> },
+      { path: '/reports', element: <ReportsPage /> },
       { path: '/notifications', element: <NotificationsPage /> },
       { path: '/credentials', element: <CredentialsPage /> },
       { path: '/ai', element: <AiPage /> },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -18,7 +18,10 @@ export default defineConfig(({ command }) => ({
     proxy: {
       '/api': { target: 'http://localhost:8001', changeOrigin: true },
       '/accounts': { target: 'http://localhost:8001', changeOrigin: true },
-      '/reports': { target: 'http://localhost:8001', changeOrigin: true },
+      // Only proxy the report *endpoints* (/reports/<uuid>/csv|pdf/) to Django —
+      // a regex key (leading ^) so the bare /reports SPA page is served by Vite,
+      // not forwarded to the backend. (Production works via Django's SPA catch-all.)
+      '^/reports/.+': { target: 'http://localhost:8001', changeOrigin: true },
     },
   },
 }));


### PR DESCRIPTION
Adds the **dedicated Reports page** to the SPA (you flagged the UI had no such page — reports were only on Scan Detail).

## What it adds
- **`ReportsPage`** (`/reports`, new nav item between Insights & Notifications): lists **completed scans** with per-scan **CSV** and **PDF** export buttons + a **`min_severity`** filter and a **domain** filter — export without opening each scan.
- Scan Detail's CSV/PDF buttons **stay** (unchanged).

## Frontend-only — reuses existing endpoints
No backend change: it calls the existing `/reports/<uuid>/{csv,pdf}/` views via authenticated fetch + Blob (JWT in the header, never the URL).

## The route-collision fix (the subtle bit)
The SPA `/reports` page and the backend `/reports/<uuid>/…` endpoints share the `/reports` prefix:
- **Production**: already works — Django's `reports/` include only matches `<uuid>/{csv,pdf}/`, so bare `/reports` falls through to the SPA catch-all.
- **Vite dev**: the proxy forwarded *all* `/reports*` to Django. Changed it to a `^/reports/.+` **regex** so only the endpoints proxy to Django and the bare `/reports` page is served by Vite.

## Verified
**Live in-browser**: nav item + page render, domain/severity filters present, correct empty-state ("No completed scans to report on"). `npm run build` + **22 vitest** green.
