### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.7.0] — 2026-09-09
+
+### Fixed
+- **Vite config `__dirname` warning.** `vite.config.js` used the CJS `__dirname`
+  global, which Vite 8's native config loader warns is unsupported; switched to
+  `import.meta.dirname` (supported on the Node ≥20.19 Vite 8 requires). Dev-only.
+
 ### Added
 - **Dedicated Reports page** (`/reports`, new nav item). Lists completed scans
   with per-scan **CSV/PDF export** and a `min_severity` filter, so you can export
@@ -1142,7 +1149,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.6.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.7.0...HEAD
+[v2.7.0]: https://github.com/cybersecify/OpenEASD/compare/v2.6.0...v2.7.0
 [v2.6.0]: https://github.com/cybersecify/OpenEASD/compare/v2.5.0...v2.6.0
 [v2.5.0]: https://github.com/cybersecify/OpenEASD/compare/v2.4.2...v2.5.0
 [v2.4.2]: https://github.com/cybersecify/OpenEASD/compare/v2.4.1...v2.4.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.6.0 — 2026-09-09)
+## Status (v2.7.0 — 2026-09-09)
 
-- **Released**: v2.6.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.6.0` / `:v2.6` / `:latest` (web on Python 3.14, worker on Ubuntu 24.04/3.12). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.7.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.7.0` / `:v2.7` / `:latest` (web on Python 3.14, worker on Ubuntu 24.04/3.12). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 28 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.6.0"
+version = "2.7.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1354,7 +1354,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release for the dedicated **Reports page**.

## Highlights
- **Dedicated Reports page** (`/reports`, new nav item) — list completed scans + per-scan CSV/PDF export + domain/severity filters (#387)
- **Fix**: Vite config `__dirname` → `import.meta.dirname` (silences the Vite 8 warning) (#386)

## Change
- `pyproject.toml` + `uv.lock`: 2.6.0 → 2.7.0
- CHANGELOG `[Unreleased]` → `[v2.7.0]` + compare link; CLAUDE Status → v2.7.0

After merge I'll tag `v2.7.0` (CI publishes `:v2.7.0` + `:v2.7` + `:latest`) and cut the GitHub Release.
