### PR TITLE
fix: ReportsPage read scans list from results key

### DIFF
--- a/frontend/src/pages/ReportsPage.jsx
+++ b/frontend/src/pages/ReportsPage.jsx
@@ -55,7 +55,7 @@ export default function ReportsPage() {
     queryFn: () => apiGet(`/scans/?domain=${domain}&status=completed&page=${page}`),
   });
 
-  const scans = data?.scans ?? [];
+  const scans = data?.results ?? [];
   const domains = domainsData || [];
 
   async function handleDownload(uuid, kind) {


### PR DESCRIPTION
## Problem
The **Reports** page (`/reports`) always showed *"No completed scans to report on"* even when completed scans existed. `GET /api/scans/` returned them correctly, but the page never rendered any row — so CSV/PDF export was unreachable from the Reports page entirely.

## Cause
`ReportsPage.jsx` read the paginated scans response as `data?.scans`, but the `/api/scans/` envelope keys the list under **`results`** (`{results, total, page, total_pages, ...}`). `ScansPage.jsx` already reads `data?.results` — Reports was simply reading the wrong key, so `scans` was always `[]`.

## Fix
```diff
- const scans = data?.scans ?? [];
+ const scans = data?.results ?? [];
```

## Verification
Reproduced against a completed scan and verified end-to-end in the browser after the fix:
- Reports page lists the completed scan (domain · Completed · findings count · date).
- **CSV** export → `GET /reports/<uuid>/csv/` → HTTP 200 (content verified).
- **PDF** export → `GET /reports/<uuid>/pdf/` → HTTP 200, valid PDF downloaded.

## Notes
- One-line source fix; the built bundle (`frontend/dist/`) is gitignored and rebuilt by CI/Docker, so nothing else to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv