### PR TITLE
feat: surface Exposure Score on Dashboard and Insights

### DIFF
--- a/frontend/src/components/Exposure.jsx
+++ b/frontend/src/components/Exposure.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+// Exposure Score is a 0-100 risk index (higher = MORE exposed = worse), graded
+// A–F. The backend computes it per scan (insights `exposure` block + per-domain
+// `exposure_score`/`exposure_grade` on the dashboard); these components surface it.
+
+// Grade → theme colours. A/B are green (good), C yellow, D orange, F red.
+export function gradeClasses(grade) {
+  switch ((grade || '').toUpperCase()) {
+    case 'A': return { text: 'text-green-400',  border: 'border-green-800',  bg: 'bg-green-900/10' };
+    case 'B': return { text: 'text-brand',      border: 'border-brand/30',   bg: 'bg-brand/10' };
+    case 'C': return { text: 'text-yellow-400', border: 'border-yellow-800', bg: 'bg-yellow-900/10' };
+    case 'D': return { text: 'text-orange-400', border: 'border-orange-800', bg: 'bg-orange-900/10' };
+    case 'F': return { text: 'text-red-400',    border: 'border-red-800',    bg: 'bg-red-900/10' };
+    default:  return { text: 'text-body',       border: 'border-rim',        bg: 'bg-card' };
+  }
+}
+
+// Compact grade+score pill for table cells (Dashboard Domain Status).
+export function ExposureBadge({ score, grade }) {
+  if (score == null && !grade) return <span className="text-dim">—</span>;
+  const g = gradeClasses(grade);
+  return (
+    <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-xs font-semibold ${g.border} ${g.bg} ${g.text}`}>
+      <span>{grade || '?'}</span>
+      {score != null && <span className="opacity-80">{score}</span>}
+    </span>
+  );
+}
+
+// Higher exposure = worse, so an upward move is red and a downward move green.
+function ExposureTrend({ direction, change, hasBaseline }) {
+  if (!hasBaseline) {
+    return <div className="text-dim text-xs text-right leading-snug">No prior scan<br />to compare</div>;
+  }
+  const up = direction === 'up';
+  const down = direction === 'down';
+  const cls = up ? 'text-red-400' : down ? 'text-green-400' : 'text-dim';
+  const arrow = up ? '↑' : down ? '↓' : '→';
+  const label = up ? 'more exposure' : down ? 'less exposure' : 'no change';
+  return (
+    <div className={`text-right ${cls}`}>
+      <div className="text-2xl font-bold leading-none">{arrow} {Math.abs(change ?? 0)}</div>
+      <div className="text-xs mt-1">{label} vs last scan</div>
+    </div>
+  );
+}
+
+// Hero card for the Insights page. Returns null when no score is available so
+// pages can render it unconditionally.
+export function ExposureCard({ exposure }) {
+  if (!exposure || exposure.score == null) return null;
+  const { score, grade, direction, change, previous_score } = exposure;
+  const g = gradeClasses(grade);
+  return (
+    <div className={`rounded-xl border p-5 flex items-center gap-5 sm:gap-6 ${g.border} ${g.bg}`}>
+      <div className={`flex items-center justify-center w-16 h-16 shrink-0 rounded-xl border text-3xl font-bold ${g.border} ${g.text}`}>
+        {grade || '—'}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-semibold uppercase tracking-wider text-dim">Exposure Score</div>
+        <div className="flex items-baseline gap-1.5 mt-0.5">
+          <span className={`text-4xl font-bold leading-none ${g.text}`}>{score}</span>
+          <span className="text-dim text-sm">/ 100</span>
+        </div>
+        <div className="text-dim text-xs mt-1.5">Lower is better — weighted by severity, exposure &amp; exploitability</div>
+      </div>
+      <ExposureTrend direction={direction} change={change} hasBaseline={previous_score != null} />
+    </div>
+  );
+}

--- a/frontend/src/components/Exposure.test.jsx
+++ b/frontend/src/components/Exposure.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ExposureBadge, ExposureCard, gradeClasses } from './Exposure.jsx';
+
+describe('gradeClasses', () => {
+  it('maps good grades (A/B) to green and bad grades (F) to red', () => {
+    expect(gradeClasses('A').text).toContain('green');
+    expect(gradeClasses('B').text).toContain('brand');
+    expect(gradeClasses('F').text).toContain('red');
+  });
+
+  it('is case-insensitive and falls back for unknown grades', () => {
+    expect(gradeClasses('c').text).toBe(gradeClasses('C').text);
+    expect(gradeClasses(null).text).toContain('body');
+  });
+});
+
+describe('ExposureBadge', () => {
+  it('renders the grade and score together', () => {
+    render(<ExposureBadge score={27} grade="B" />);
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('27')).toBeInTheDocument();
+  });
+
+  it('shows a dash when there is no score or grade', () => {
+    render(<ExposureBadge score={null} grade={null} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});
+
+describe('ExposureCard', () => {
+  it('renders nothing when exposure is absent or scoreless', () => {
+    const { container } = render(<ExposureCard exposure={null} />);
+    expect(container).toBeEmptyDOMElement();
+    const { container: c2 } = render(<ExposureCard exposure={{ grade: 'B' }} />);
+    expect(c2).toBeEmptyDOMElement();
+  });
+
+  it('renders the score, grade, and "no prior scan" when there is no baseline', () => {
+    render(<ExposureCard exposure={{ score: 27, grade: 'B', previous_score: null, direction: 'flat', change: 0 }} />);
+    expect(screen.getByText('27')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText(/no prior scan/i)).toBeInTheDocument();
+  });
+
+  it('shows a rising exposure as worse (more exposure) when the score climbs', () => {
+    render(<ExposureCard exposure={{ score: 40, grade: 'C', previous_score: 27, direction: 'up', change: 13 }} />);
+    expect(screen.getByText(/more exposure/i)).toBeInTheDocument();
+    expect(screen.getByText(/↑ 13/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Layout } from '../components/Layout.jsx';
 import { Badge } from '../components/Badge.jsx';
+import { ExposureBadge } from '../components/Exposure.jsx';
 import { Spinner } from '../components/Spinner.jsx';
 import { Button } from '../components/ui/button.jsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
@@ -88,18 +89,19 @@ export default function DashboardPage() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    {['Domain', 'Status', 'Last Scan', 'Critical', 'High', 'Actions'].map(h => (
+                    {['Domain', 'Status', 'Exposure', 'Last Scan', 'Critical', 'High', 'Actions'].map(h => (
                       <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim whitespace-nowrap">{h}</TableHead>
                     ))}
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {domain_status.length === 0 ? (
-                    <TableRow><TableCell colSpan={6} className="px-4 py-8 text-center text-dim">No domains yet.</TableCell></TableRow>
+                    <TableRow><TableCell colSpan={7} className="px-4 py-8 text-center text-dim">No domains yet.</TableCell></TableRow>
                   ) : domain_status.map(d => (
                     <TableRow key={d.id} className="hover:bg-hover transition-colors">
                       <TableCell className="px-4 py-3 text-lit font-mono font-medium">{d.domain}</TableCell>
                       <TableCell className="px-4 py-3"><Badge value={d.scan_status || 'idle'} /></TableCell>
+                      <TableCell className="px-4 py-3"><ExposureBadge score={d.exposure_score} grade={d.exposure_grade} /></TableCell>
                       <TableCell className="px-4 py-3 text-dim">{d.last_scan ? new Date(d.last_scan).toLocaleDateString() : '—'}</TableCell>
                       <TableCell className="px-4 py-3 text-red-400 font-semibold">{d.critical ?? 0}</TableCell>
                       <TableCell className="px-4 py-3 text-orange-400 font-semibold">{d.high ?? 0}</TableCell>

--- a/frontend/src/pages/InsightsPage.jsx
+++ b/frontend/src/pages/InsightsPage.jsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
 import { useQuery } from '@tanstack/react-query';
 import { apiGet } from '../api/client.js';
+import { ExposureCard } from '../components/Exposure.jsx';
 
 function fmtDate(iso) {
   if (!iso) return '—';
@@ -64,6 +65,7 @@ export default function InsightsPage() {
     kpi_open_critical = 0, kpi_open_high = 0, kpi_new = 0, kpi_fixed = 0,
     scan_trend = [], delta_trend = [], top_hosts = [], top_finding_types = [],
     severity_distribution = {}, top_services = [], asset_growth = [],
+    exposure = null,
   } = data;
 
   return (
@@ -73,6 +75,8 @@ export default function InsightsPage() {
           <h1 className="text-lit text-xl font-bold">Insights</h1>
           <p className="text-dim text-sm mt-0.5">Trends and security metrics across all scans</p>
         </div>
+
+        <ExposureCard exposure={exposure} />
 
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <KpiCard label="Open Critical"   value={kpi_open_critical} colorCls="text-red-400 border-red-800 bg-red-900/10" />


### PR DESCRIPTION
## What
Renders the **Exposure Score** (0–100, graded A–F) in the app UI, on two pages:

- **Insights** — a hero card above the KPI row: grade badge, `score / 100`, the "lower is better" explainer, and a trend vs. the last scan.
- **Dashboard** — a new **Exposure** column on the Domain Status table (compact `grade score` pill).

## Why
The backend already computes this per scan and returns it on both endpoints:
- `GET /api/insights/` → `exposure: {score, grade, direction, change, previous_score}`
- `GET /api/dashboard/` → per-domain `exposure_score` / `exposure_grade`

…but the frontend dropped it — the score only appeared in the exported PDF. It's arguably the single best at-a-glance risk metric, so this surfaces it where users actually look. **No backend change** — this reads fields the API already provides.

## Design notes
- New shared component `frontend/src/components/Exposure.jsx`:
  - `gradeClasses()` — grade → theme colours (A/B green, C yellow, D orange, F red)
  - `ExposureBadge` — compact grade+score pill for table cells
  - `ExposureCard` — hero card (returns `null` when no score, so pages render it unconditionally)
- **Trend semantics:** higher exposure = worse, so an *upward* move is red ("more exposure") and *downward* is green — deliberately the inverse of a typical "up is good" metric.
- Renders gracefully with no baseline ("No prior scan to compare").

## Verification
- Verified in the browser against live API data: Insights shows **B / 27 / 100**; Dashboard shows a green **B 27** pill for the domain.
- `npm run build` clean; `npm run test:run` → **29 passed** (22 existing + 7 new for the Exposure component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv