### PR TITLE
fix: bump weasyprint to 70.0 (CVE-2026-55073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Security
+- **weasyprint 69.0 → 70.0 (CVE-2026-55073).** pip-audit (the CI CVE gate)
+  flagged a newly-disclosed vulnerability in weasyprint 69.0 — the PDF report
+  renderer. Raised the floor to `weasyprint>=70` and refreshed `uv.lock` to the
+  fixed 70.0. PDF export verified unaffected; the report tests mock the renderer
+  so behaviour is unchanged.
+
 ## [v2.7.0] — 2026-09-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "paramiko>=5.0.0",
     # Reports (PDF generation) — WeasyPrint renders full CSS (backgrounds,
     # @page rules, rounded corners); needs pango/gdk-pixbuf system libs.
-    "weasyprint>=63",
+    "weasyprint>=70",
     # Task queue
     "croniter>=2.0",
     # XML parsing (safe)

--- a/uv.lock
+++ b/uv.lock
@@ -1420,7 +1420,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "urllib3", specifier = ">=2.7.0" },
-    { name = "weasyprint", specifier = ">=63" },
+    { name = "weasyprint", specifier = ">=70" },
     { name = "whitenoise", specifier = ">=6.7" },
 ]
 provides-extras = ["prod"]
@@ -2378,7 +2378,7 @@ wheels = [
 
 [[package]]
 name = "weasyprint"
-version = "69.0"
+version = "70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
@@ -2390,9 +2390,9 @@ dependencies = [
     { name = "tinycss2" },
     { name = "tinyhtml5" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/53/dcc3885c2f7a47faa45f6b8b801412f5f9e055173a52801ef01c09943c5a/weasyprint-69.0.tar.gz", hash = "sha256:a7a32f39ca16bd82ef11de99c92ea4b5f14951c9033af035e451ce4f4ee0a88c", size = 1549834, upload-time = "2026-06-02T14:42:17.765Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/0e/461aeb736762862b511034933d5b98d68f812431b7393b026d9ace5f6b42/weasyprint-70.0.tar.gz", hash = "sha256:c263abf0e86c747b12af678b67f85f4abbfb97d18a20503031e7ba94e4b8cf8c", size = 1565482, upload-time = "2026-09-08T12:25:41.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/cb/208525c6bd5033d7b2589b55e07bec23d9c61bb00703cbaf20ef52c3811f/weasyprint-69.0-py3-none-any.whl", hash = "sha256:475951cfd917014de6d4d005caff48c6aa867e7e42b80cd5b16a0484a1609ee6", size = 322872, upload-time = "2026-06-02T14:42:15.871Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8b/0c53c869f29d3273536b896dd17f092549e34e35ffba4c7a60a6de1cb1c2/weasyprint-70.0-py3-none-any.whl", hash = "sha256:5043e55e38d2a2af2b2b871e869697b1f65dad5f8b4a3677961d04ceacf9c5fe", size = 328889, upload-time = "2026-09-08T12:25:39.796Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem
CI's `pip-audit` CVE gate started failing on **CVE-2026-55073** in **weasyprint 69.0** (the PDF report renderer). The advisory was disclosed after the last green run, so it now blocks every PR — not a regression from any code change.

```
Found 1 known vulnerability in 1 package
Name       Version ID             Fix Versions
weasyprint 69.0    CVE-2026-55073 70.0
```

## Fix
- Raise the pin `weasyprint>=63` → `weasyprint>=70` in `pyproject.toml`.
- Refresh `uv.lock` (weasyprint 69.0 → 70.0). No other packages moved.

## Verification
- `uv run pip-audit --ignore-vuln PYSEC-2025-183` → **No known vulnerabilities found**.
- PDF export re-rendered on 70.0 (2896-byte PDF) — works. The report tests mock the renderer (`_render_pdf`), so rendering behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv