### PR TITLE
feat: in-app finding detail modal (Findings + Scan Detail)

### DIFF
--- a/frontend/src/components/FindingDetailModal.jsx
+++ b/frontend/src/components/FindingDetailModal.jsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { Badge } from './Badge.jsx';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog.jsx';
+
+// Read-only detail view for a single Finding. Both the Findings page and the
+// Scan Detail findings tab already carry the full row (description, remediation,
+// extra, …), so this renders from the passed object — no extra fetch.
+
+function fmtDateTime(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function Meta({ label, children }) {
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase tracking-wider text-dim">{label}</div>
+      <div className="text-body text-sm mt-0.5 break-words">{children}</div>
+    </div>
+  );
+}
+
+function Section({ title, children }) {
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase tracking-wider text-dim mb-1">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+// Pull the well-known CVE/exploitability fields out of `extra` and show them as
+// labelled chips; the rest of `extra` falls through to a generic key/value list.
+const KNOWN_EXTRA = new Set([
+  'cve', 'cve_id', 'cve_ids', 'cvss', 'cvss_score', 'epss', 'epss_score',
+  'kev', 'cisa_kev', 'is_kev',
+]);
+
+function ExtraDetails({ extra }) {
+  if (!extra || typeof extra !== 'object' || Object.keys(extra).length === 0) return null;
+
+  const cves = []
+    .concat(extra.cve_ids || [])
+    .concat(extra.cve ? [extra.cve] : [])
+    .concat(extra.cve_id ? [extra.cve_id] : []);
+  const uniqueCves = [...new Set(cves.filter(Boolean))];
+  const cvss = extra.cvss_score ?? extra.cvss;
+  const epss = extra.epss_score ?? extra.epss;
+  const isKev = extra.kev ?? extra.cisa_kev ?? extra.is_kev;
+
+  const chips = [];
+  if (cvss != null) chips.push(['CVSS', String(cvss)]);
+  if (epss != null) {
+    const pct = typeof epss === 'number' && epss <= 1 ? `${(epss * 100).toFixed(1)}%` : String(epss);
+    chips.push(['EPSS', pct]);
+  }
+  if (isKev) chips.push(['CISA KEV', 'yes']);
+
+  // Remaining keys not already surfaced above.
+  const rest = Object.entries(extra).filter(([k, v]) =>
+    !KNOWN_EXTRA.has(k) && v != null && v !== '' && !(Array.isArray(v) && v.length === 0));
+
+  if (!uniqueCves.length && !chips.length && !rest.length) return null;
+
+  return (
+    <Section title="Vulnerability Intelligence">
+      <div className="space-y-2">
+        {uniqueCves.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {uniqueCves.map(cve => (
+              <span key={cve} className="rounded-md border border-red-800 bg-red-900/20 text-red-300 text-xs font-mono px-2 py-0.5">{cve}</span>
+            ))}
+          </div>
+        )}
+        {chips.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {chips.map(([k, v]) => (
+              <span key={k} className="rounded-md border border-rim bg-canvas text-xs px-2 py-0.5">
+                <span className="text-dim">{k}: </span><span className="text-body font-semibold">{v}</span>
+              </span>
+            ))}
+          </div>
+        )}
+        {rest.length > 0 && (
+          <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+            {rest.map(([k, v]) => (
+              <React.Fragment key={k}>
+                <dt className="text-dim font-mono">{k}</dt>
+                <dd className="text-body break-words font-mono">
+                  {typeof v === 'object' ? JSON.stringify(v) : String(v)}
+                </dd>
+              </React.Fragment>
+            ))}
+          </dl>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+export function FindingDetailModal({ finding, onClose }) {
+  if (!finding) return null;
+  const f = finding;
+
+  return (
+    <AlertDialog open onOpenChange={open => !open && onClose()}>
+      <AlertDialogContent className="bg-card border border-rim max-w-2xl max-h-[85vh] overflow-y-auto">
+        <AlertDialogHeader>
+          <div className="flex items-start gap-3">
+            <Badge value={f.severity} />
+            <AlertDialogTitle className="text-lit text-base leading-snug">{f.title}</AlertDialogTitle>
+          </div>
+        </AlertDialogHeader>
+
+        <div className="space-y-4 py-1 text-left">
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <Meta label="Source"><span className="font-mono text-xs">{f.source || '—'}</span></Meta>
+            <Meta label="Check type"><span className="font-mono text-xs">{f.check_type || '—'}</span></Meta>
+            <Meta label="Status"><Badge value={f.status || 'open'} /></Meta>
+            <Meta label="Target"><span className="font-mono text-xs break-all">{f.target || '—'}</span></Meta>
+            {f.asset_key && <Meta label="Asset"><span className="font-mono text-xs break-all">{f.asset_key}</span></Meta>}
+            <Meta label="Discovered">{fmtDateTime(f.discovered_at)}</Meta>
+          </div>
+
+          {f.description && (
+            <Section title="Description">
+              <p className="text-body text-sm whitespace-pre-wrap break-words">{f.description}</p>
+            </Section>
+          )}
+
+          {f.remediation && (
+            <Section title="Remediation">
+              <p className="text-body text-sm whitespace-pre-wrap break-words">{f.remediation}</p>
+            </Section>
+          )}
+
+          <ExtraDetails extra={f.extra} />
+
+          {f.resolution_note && (
+            <Section title="Resolution note">
+              <p className="text-body text-sm whitespace-pre-wrap break-words">{f.resolution_note}</p>
+            </Section>
+          )}
+        </div>
+
+        <div className="flex justify-end pt-2 border-t border-rim">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-md text-sm text-dim hover:text-body hover:bg-hover transition-colors">
+            Close
+          </button>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/FindingDetailModal.test.jsx
+++ b/frontend/src/components/FindingDetailModal.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FindingDetailModal } from './FindingDetailModal.jsx';
+
+const base = {
+  id: 1,
+  severity: 'high',
+  title: 'MTA-STS not configured',
+  source: 'domain_security',
+  check_type: 'email',
+  status: 'open',
+  target: 'example.com',
+  description: 'No MTA-STS policy — TLS downgrade risk.',
+  remediation: '1. Add DNS TXT record\n2. Host the policy file',
+  extra: {},
+  discovered_at: '2026-09-09T15:56:45Z',
+};
+
+describe('FindingDetailModal', () => {
+  it('renders nothing when no finding is passed', () => {
+    const { container } = render(<FindingDetailModal finding={null} onClose={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the title, severity, description and remediation', () => {
+    render(<FindingDetailModal finding={base} onClose={() => {}} />);
+    expect(screen.getByText('MTA-STS not configured')).toBeInTheDocument();
+    expect(screen.getByText('high')).toBeInTheDocument();
+    expect(screen.getByText(/No MTA-STS policy/)).toBeInTheDocument();
+    expect(screen.getByText(/Add DNS TXT record/)).toBeInTheDocument();
+  });
+
+  it('surfaces CVE / CVSS / EPSS / KEV from extra', () => {
+    const f = {
+      ...base,
+      title: 'OpenSSH vuln',
+      extra: { cve_ids: ['CVE-2024-1234', 'CVE-2024-5678'], cvss_score: 9.8, epss_score: 0.42, kev: true },
+    };
+    render(<FindingDetailModal finding={f} onClose={() => {}} />);
+    expect(screen.getByText('Vulnerability Intelligence')).toBeInTheDocument();
+    expect(screen.getByText('CVE-2024-1234')).toBeInTheDocument();
+    expect(screen.getByText('CVE-2024-5678')).toBeInTheDocument();
+    expect(screen.getByText('9.8')).toBeInTheDocument();
+    expect(screen.getByText('42.0%')).toBeInTheDocument();     // epss 0.42 → 42.0%
+    expect(screen.getByText(/CISA KEV/)).toBeInTheDocument();  // label chip: "CISA KEV: yes"
+  });
+
+  it('omits the vulnerability block when extra is empty', () => {
+    render(<FindingDetailModal finding={base} onClose={() => {}} />);
+    expect(screen.queryByText('Vulnerability Intelligence')).not.toBeInTheDocument();
+  });
+
+  it('renders unknown extra keys as a generic key/value list', () => {
+    const f = { ...base, extra: { banner: 'nginx/1.18.0', port: 8080 } };
+    render(<FindingDetailModal finding={f} onClose={() => {}} />);
+    expect(screen.getByText('banner')).toBeInTheDocument();
+    expect(screen.getByText('nginx/1.18.0')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the Close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<FindingDetailModal finding={base} onClose={onClose} />);
+    fireEvent.click(screen.getByText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/FindingsPage.jsx
+++ b/frontend/src/pages/FindingsPage.jsx
@@ -4,6 +4,7 @@ import { Layout } from '../components/Layout.jsx';
 import { Badge } from '../components/Badge.jsx';
 import { Spinner } from '../components/Spinner.jsx';
 import { Pagination } from '../components/Pagination.jsx';
+import { FindingDetailModal } from '../components/FindingDetailModal.jsx';
 import { Card, CardContent } from '../components/ui/card.jsx';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
 import { toast } from '../components/Notification.jsx';
@@ -53,6 +54,7 @@ export default function FindingsPage() {
   const [status,   setStatus]   = useState('open');
   const [domain,   setDomain]   = useState(params.get('domain') || '');
   const [page,     setPage]     = useState(1);
+  const [selected, setSelected] = useState(null);   // finding open in the detail modal
 
   const { data: domainsData } = useQuery({
     queryKey: ['/domains/'],
@@ -109,7 +111,13 @@ export default function FindingsPage() {
                     ) : findings.map(f => (
                       <TableRow key={f.id} className="hover:bg-hover transition-colors">
                         <TableCell className="px-4 py-3"><Badge value={f.severity} /></TableCell>
-                        <TableCell className="px-4 py-3 text-body font-medium max-w-xs truncate">{f.title}</TableCell>
+                        <TableCell className="px-4 py-3 max-w-xs">
+                          <button onClick={() => setSelected(f)}
+                            className="text-body font-medium hover:text-brand hover:underline text-left truncate max-w-full block"
+                            title="View details">
+                            {f.title}
+                          </button>
+                        </TableCell>
                         <TableCell className="px-4 py-3 font-mono text-dim text-xs">{f.target}</TableCell>
                         <TableCell className="px-4 py-3 text-xs">
                           {f.asset_id
@@ -137,6 +145,8 @@ export default function FindingsPage() {
           )}
         </Card>
       </div>
+
+      {selected && <FindingDetailModal finding={selected} onClose={() => setSelected(null)} />}
     </Layout>
   );
 }

--- a/frontend/src/pages/ScanDetailPage.jsx
+++ b/frontend/src/pages/ScanDetailPage.jsx
@@ -5,6 +5,7 @@ import { Spinner } from '../components/Spinner.jsx';
 import { ConfirmButton } from '../components/ConfirmButton.jsx';
 import { toast } from '../components/Notification.jsx';
 import { Pagination } from '../components/Pagination.jsx';
+import { FindingDetailModal } from '../components/FindingDetailModal.jsx';
 import { Button } from '../components/ui/button.jsx';
 import { Card, CardContent } from '../components/ui/card.jsx';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
@@ -170,6 +171,7 @@ export default function ScanDetailPage() {
   const [page, setPage] = useState(1);
   const [busy, setBusy] = useState(false);
   const [showSubScan, setShowSubScan] = useState(false);
+  const [selectedFinding, setSelectedFinding] = useState(null);
   const [schemeFilter, setSchemeFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [minSev, setMinSev] = useState('info');
@@ -444,7 +446,13 @@ export default function ScanDetailPage() {
                         : paged.map(f => (
                           <TableRow key={f.id} id={`finding-${f.id}`} className="hover:bg-hover">
                             <TableCell className="px-4 py-3"><Badge value={f.severity} /></TableCell>
-                            <TableCell className="px-4 py-3 text-body font-medium max-w-xs truncate">{f.title}</TableCell>
+                            <TableCell className="px-4 py-3 max-w-xs">
+                              <button onClick={() => setSelectedFinding(f)}
+                                className="text-body font-medium hover:text-brand hover:underline text-left truncate max-w-full block"
+                                title="View details">
+                                {f.title}
+                              </button>
+                            </TableCell>
                             <TableCell className="px-4 py-3 font-mono text-dim text-xs">{f.target}</TableCell>
                             <TableCell className="px-4 py-3 text-dim text-xs">{f.source}</TableCell>
                           </TableRow>
@@ -470,6 +478,10 @@ export default function ScanDetailPage() {
           onClose={() => setShowSubScan(false)}
           onStarted={newUuid => navigate(`/scans/${newUuid}`)}
         />
+      )}
+
+      {selectedFinding && (
+        <FindingDetailModal finding={selectedFinding} onClose={() => setSelectedFinding(null)} />
       )}
     </Layout>
   );


### PR DESCRIPTION
## What
Clicking a finding **title** now opens a detail modal with the full **description**, **remediation**, and **vulnerability intelligence** (CVE / CVSS / EPSS / CISA-KEV pulled from `extra`). Wired into both places findings are listed:
- **Findings** page (`/findings`)
- **Scan Detail** → Findings tab

Titles become clickable buttons with a hover affordance; the modal closes on backdrop click, Escape, or the Close button.

## Why
This was review item #2 from the UI/UX pass. Previously, clicking a finding did nothing — the description/remediation/CVE detail existed (it fills the PDF) but was **unreachable in the app**; you had to export CSV/PDF to learn *why* a finding matters or *how* to fix it.

The finding rows already carry the full object (`description`, `remediation`, `extra`, …) on both the `/api/scans/findings/` and scan-detail endpoints, so the modal renders from the row — **no extra fetch, no backend change**.

## Design
- New shared `frontend/src/components/FindingDetailModal.jsx`, built on the existing `AlertDialog` primitive (Escape/backdrop close come for free, consistent with `SubScanDialog`).
- `ExtraDetails` sub-renderer: surfaces known keys (CVE ids, CVSS, EPSS as a %, CISA-KEV) as labelled chips and falls back to a generic key/value list for anything else; the whole block hides when `extra` is empty.
- `description` / `remediation` render with `whitespace-pre-wrap` so numbered remediation steps keep their formatting.

## Verification
- Verified in-browser on both the Findings page and the Scan Detail findings tab: title → modal with description + remediation; Escape and Close both dismiss.
- `npm run test:run` → **35 passed** (6 new for the modal: description/remediation, CVE/CVSS/EPSS/KEV chips, generic-extra fallback, empty-state hiding, onClose). `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv