### PR TITLE
fix: pin Django to the 5.2 LTS line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Changed
+- **Pinned Django to the 5.2 LTS line.** The dependency was `django>=5.2.17`, an
+  open lower bound that floated to the latest release — so on Python ≥3.12 it
+  resolved to **Django 6.1 (non-LTS)**, and the web + worker images had silently
+  been running 6.1. Changed the constraint to `django>=5.2.17,<6.0` so it stays on
+  the **5.2 LTS** line (security-supported into ~2028) and never jumps to a non-LTS
+  6.x by accident. `uv.lock` re-resolved 6.1 → 5.2.17. **Why:** LTS gives a long,
+  predictable security-support window — the same conservative-stability reasoning
+  behind pinning Python to 3.12. Moving to the next Django LTS (6.2) becomes a
+  deliberate bump, not a silent float. Full suite re-verified on 5.2.17.
 - **Standardized on Python 3.12 across every tier.** The web image and CI had
   drifted onto Python 3.14 (a `python:3.14-slim` web base + `setup-python: 3.14`)
   while the worker ran Ubuntu 24.04's Python 3.12 — so CI tested a Python the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,8 @@ git describe --tags --abbrev=0
 ## Stack
 
 ### Backend
-- Django 5+ with plain Django views (no DRF, no Celery, no Redis)
+- Django 5.2 LTS with plain Django views (no DRF, no Celery, no Redis) — pinned to
+  the LTS line (`django>=5.2.17,<6.0`), not floated to non-LTS 6.x
 - **Django Ninja** REST API under `/api/` — Schema-based, auto-docs at `/api/docs`
 - **JWT Bearer auth** — access + refresh tokens via `djangorestframework-simplejwt` (ninja-jwt wrapper); token blacklist handled by simplejwt's built-in `OutstandingToken`/`BlacklistedToken` models
 - **DBOS** — durable-execution engine for scan execution AND all scheduling, backed by PostgreSQL (its checkpoint tables live in a `dbos` schema in the same DB). Scans are durable workflows whose phases are checkpointed steps, so a crashed/restarted worker RESUMES a scan instead of losing it. Scheduling is DBOS `@scheduled` cron workflows (daily scan, monitoring sweep, user-schedule sweep, stuck-scan watchdog, JWT token purge) registered by the `dbos_worker` process. Django-Q2 and APScheduler have been fully removed.

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ uv run pytest tests/
 ## Tech Stack
 
 **Backend:**
-- **Django 5**: Web framework
+- **Django 5.2 LTS**: Web framework
 - **Django Ninja**: REST API with OpenAPI docs
 - **DBOS**: Durable-execution engine — task queue + scheduler, Postgres-backed (crash-resumable scans)
 - **croniter**: Cron parsing for the DBOS user-schedule sweep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     # Web framework
-    "django>=5.2.17",
+    "django>=5.2.17,<6.0",  # pin to the 5.2 LTS line (security-supported ~2028); avoid floating to non-LTS 6.x
     "django-ninja>=1.6.2",
     # Configuration
     "python-decouple>=3.8",

--- a/uv.lock
+++ b/uv.lock
@@ -607,16 +607,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.1"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/9c/ce847620134cfab903e75690c498af73b46abbede2912ea89bd76d5c1e76/django-6.1-py3-none-any.whl", hash = "sha256:6c132cd980c9392b06807d4ca52d72530d631dc65a85d9dacede00a780cefbbe", size = 8417399, upload-time = "2026-08-05T19:21:47.285Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]
@@ -1182,7 +1182,7 @@ requires-dist = [
     { name = "dbos", specifier = ">=0.26" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "dj-database-url", specifier = ">=2.2" },
-    { name = "django", specifier = ">=5.2.17" },
+    { name = "django", specifier = ">=5.2.17,<6.0" },
     { name = "django-ninja", specifier = ">=1.6.2" },
     { name = "django-ninja-jwt", specifier = ">=5.0" },
     { name = "dnspython", specifier = ">=2.4" },


### PR DESCRIPTION
## Problem
The Django dependency was `django>=5.2.17` — an **open lower bound** that floats to the latest release. On Python ≥3.12 the resolver picked **Django 6.1**, which is **not an LTS release**. So the web + worker prod images had silently been running non-LTS 6.1, with no deliberate decision and a much shorter security-support window.

## Fix
Pin the constraint to **`django>=5.2.17,<6.0`** so it stays on the **5.2 LTS** line (security-supported into ~2028) and never jumps to a non-LTS 6.x by accident. Moving to the next Django LTS (6.2) becomes an explicit, tested bump instead of a silent float.

- `uv.lock` re-resolved **Django 6.1 → 5.2.17**.
- Docs updated: CLAUDE.md "Django 5+" → "Django 5.2 LTS (pinned)"; README "Django 5" → "Django 5.2 LTS".

## Verification (this is a 6.1 → 5.2 downgrade, so verified thoroughly)
On Django **5.2.17**:
- `manage.py check` — clean
- `makemigrations --check` — no drift (no 6.x-only model features in use)
- `ruff check` — clean
- Full fast suite — **1727 passed, 1 skipped** (identical to the prior 6.1 run)

## Context
Follows the Python-3.12 standardization (#395). Same conservative-stability reasoning: pin to the long-supported LTS rather than float to the newest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv