### PR TITLE
chore: release v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.9.1] — 2026-09-10
+
 ### Changed
 - **Pinned Django to the 5.2 LTS line.** The dependency was `django>=5.2.17`, an
   open lower bound that floated to the latest release — so on Python ≥3.12 it
@@ -1213,7 +1215,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.9.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.9.1...HEAD
+[v2.9.1]: https://github.com/cybersecify/OpenEASD/compare/v2.9.0...v2.9.1
 [v2.9.0]: https://github.com/cybersecify/OpenEASD/compare/v2.8.0...v2.9.0
 [v2.8.0]: https://github.com/cybersecify/OpenEASD/compare/v2.7.0...v2.8.0
 [v2.7.0]: https://github.com/cybersecify/OpenEASD/compare/v2.6.0...v2.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.9.0"
+version = "2.9.1"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.9.0"
+version = "2.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Patch release — two runtime-stability pins, both `fix:`.

### Changed
- **Pinned Django to the 5.2 LTS line** (#396) — `django>=5.2.17,<6.0`, so it stays on 5.2 LTS instead of floating to non-LTS 6.1. uv.lock re-resolved 6.1 → 5.2.17.
- **Standardized on Python 3.12 across every tier** (#395) — web image, CI, `requires-python`, `.python-version` all → 3.12 (was drifting between 3.11/3.12/3.14). One interpreter across dev, CI, web, and worker.

Net: both prod images now ship **Python 3.12 + Django 5.2 LTS**. Full suite verified green on both pins. Version bumped `2.9.0 → 2.9.1`; tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv