### PR TITLE
docs: update CLAUDE.md status to v2.9.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.7.0 — 2026-09-09)
+## Status (v2.9.1 — 2026-09-10)
 
-- **Released**: v2.7.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.7.0` / `:v2.7` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.9.1 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.9.1` / `:v2.9` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 28 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.


### PR DESCRIPTION
The CLAUDE.md **Status** header and the released-image line still referenced **v2.7.0** / `:v2.7.0` / date 2026-09-09, but the project is now at **v2.9.1** (Python 3.12 + Django 5.2 LTS, both pinned).

Updated:
- `## Status (v2.7.0 — 2026-09-09)` → `## Status (v2.9.1 — 2026-09-10)`
- Released image tags `:v2.7.0 / :v2.7` → `:v2.9.1 / :v2.9`
- Added the Django 5.2 LTS note to the runtime line

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv