### PR TITLE
feat: make Domain Intelligence the primary scan category (UI)

### DIFF
--- a/apps/core/console/dashboard/api.py
+++ b/apps/core/console/dashboard/api.py
@@ -1,6 +1,6 @@
 """Dashboard API router."""
 
-from django.db.models import Max
+from django.db.models import Count, Max
 
 from ninja import Router
 
@@ -12,6 +12,10 @@ from apps.core.console.insights.models import ScanSummary
 from apps.core.data.assets.models import Subdomain, IPAddress, Port
 from apps.core.data.web_assets.models import URL
 from apps.core.data.asset_inventory.models import Asset
+from apps.core.engine.workflows.registry import get_tool_phase_groups
+
+# The primary recon category, surfaced as a featured card on the dashboard.
+PRIMARY_CATEGORY = "Domain Intelligence"
 
 router = Router(auth=JWTAuth())
 
@@ -102,6 +106,28 @@ def api_dashboard(request):
     assets_active = inventory.filter(status="active").count()
     assets_gone = inventory.filter(status="gone").count()
 
+    # Featured "Domain Intelligence" category card — findings from the primary
+    # recon category (its tools resolved from the registry, so it stays correct
+    # as tools are added/removed) on the latest completed scans, by severity.
+    di_sources = [t for t, g in get_tool_phase_groups().items() if g == PRIMARY_CATEGORY]
+    di_by_sev = {
+        row["severity"]: row["c"]
+        for row in Finding.objects
+        .filter(session_id__in=latest_completed_ids, source__in=di_sources)
+        .values("severity")
+        .annotate(c=Count("id"))
+    }
+    domain_intelligence = {
+        "category": PRIMARY_CATEGORY,
+        "tool_count": len(di_sources),
+        "total": sum(di_by_sev.values()),
+        "critical": di_by_sev.get("critical", 0),
+        "high": di_by_sev.get("high", 0),
+        "medium": di_by_sev.get("medium", 0),
+        "low": di_by_sev.get("low", 0),
+        "info": di_by_sev.get("info", 0),
+    }
+
     return {
         "kpi_domains": len(active_domains),
         "kpi_active_scans": running_count,
@@ -113,6 +139,7 @@ def api_dashboard(request):
         "kpi_ips": asset_counts["ips"],
         "kpi_ports": asset_counts["ports"],
         "kpi_urls": asset_counts["urls"],
+        "domain_intelligence": domain_intelligence,
         "domain_status": domain_status,
         "urgent_findings": [
             {

--- a/apps/core/engine/workflows/api.py
+++ b/apps/core/engine/workflows/api.py
@@ -12,6 +12,7 @@ from apps.core.engine.workflows.models import Workflow, WorkflowStep
 from apps.core.engine.workflows.registry import (
     get_registry,
     get_tool_choices,
+    get_tool_phase_groups,
     get_tool_phases,
     get_tool_produces_findings,
     get_tool_requires,
@@ -64,11 +65,13 @@ def _serialize_step_result(sr) -> dict:
 def list_tools(request):
     phases = get_tool_phases()
     produces = get_tool_produces_findings()
+    groups = get_tool_phase_groups()
     tools = [
         {
             "key": key,
             "label": label,
             "phase": phases.get(key, 99),
+            "phase_group": groups.get(key, ""),
             "produces_findings": produces.get(key, False),
         }
         for key, label in get_tool_choices()

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -28,6 +28,39 @@ function AssetCard({ label, value }) {
   );
 }
 
+const DI_SEV = [
+  ['critical', 'text-red-400   border-red-800   bg-red-900/20'],
+  ['high',     'text-orange-400 border-orange-800 bg-orange-900/20'],
+  ['medium',   'text-yellow-400 border-yellow-800 bg-yellow-900/20'],
+  ['low',      'text-blue-400  border-blue-800  bg-blue-900/20'],
+  ['info',     'text-gray-400  border-gray-700  bg-gray-800/40'],
+];
+
+// Featured card for the primary recon category. Clickable → findings.
+function DomainIntelligenceCard({ di, onOpen }) {
+  return (
+    <button onClick={onOpen}
+      className="w-full text-left rounded-xl border border-brand/30 bg-brand/10 p-5 hover:bg-brand/15 transition-colors flex items-center gap-5">
+      <div className="shrink-0">
+        <div className="text-[10px] font-semibold uppercase tracking-wider text-brand/80">Primary category</div>
+        <div className="text-lit text-lg font-bold leading-tight">Domain Intelligence</div>
+        <div className="text-dim text-xs mt-0.5">{di.tool_count} passive &amp; DNS/email checks — the first recon layer</div>
+      </div>
+      <div className="flex items-baseline gap-1.5 ml-auto">
+        <span className="text-3xl font-bold text-brand leading-none">{di.total ?? 0}</span>
+        <span className="text-dim text-xs">findings</span>
+      </div>
+      <div className="flex flex-wrap gap-1.5 justify-end">
+        {DI_SEV.filter(([k]) => (di[k] ?? 0) > 0).map(([k, cls]) => (
+          <span key={k} className={`rounded-md border px-2 py-0.5 text-xs font-semibold ${cls}`}>
+            {di[k]} {k}
+          </span>
+        ))}
+      </div>
+    </button>
+  );
+}
+
 export default function DashboardPage() {
   const navigate = useNavigate();
   const { data, isLoading: loading, error } = useQuery({
@@ -44,6 +77,7 @@ export default function DashboardPage() {
     kpi_subdomains = 0, kpi_ips = 0, kpi_ports = 0, kpi_urls = 0,
     kpi_assets_active = 0, kpi_assets_gone = 0,
     domain_status = [], urgent_findings = [],
+    domain_intelligence = null,
   } = data;
 
   return (
@@ -53,6 +87,10 @@ export default function DashboardPage() {
           <h1 className="text-lit text-xl font-bold">Dashboard</h1>
           <p className="text-dim text-sm mt-0.5">Attack surface overview</p>
         </div>
+
+        {domain_intelligence && (
+          <DomainIntelligenceCard di={domain_intelligence} onOpen={() => navigate('/findings')} />
+        )}
 
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <KpiCard label="Domains"       value={kpi_domains}      colorCls="text-body border-rim bg-card" />

--- a/frontend/src/pages/WorkflowsPage.jsx
+++ b/frontend/src/pages/WorkflowsPage.jsx
@@ -24,6 +24,22 @@ function CreateWorkflowForm({ onCreated }) {
   });
   const allTools = toolsData?.tools || [];
 
+  // Group tools by category (phase_group), ordered by the earliest phase in each
+  // group — so Domain Intelligence (phase 1) leads, matching scan execution order.
+  const groupedTools = React.useMemo(() => {
+    const byGroup = new Map();
+    for (const t of allTools) {
+      const g = t.phase_group || 'Other';
+      if (!byGroup.has(g)) byGroup.set(g, { group: g, minPhase: t.phase ?? 99, tools: [] });
+      const entry = byGroup.get(g);
+      entry.tools.push(t);
+      entry.minPhase = Math.min(entry.minPhase, t.phase ?? 99);
+    }
+    return [...byGroup.values()]
+      .map(e => ({ ...e, tools: e.tools.sort((a, b) => (a.phase ?? 99) - (b.phase ?? 99)) }))
+      .sort((a, b) => a.minPhase - b.minPhase);
+  }, [allTools]);
+
   function toggleTool(key) {
     setSel(prev => prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]);
   }
@@ -68,16 +84,23 @@ function CreateWorkflowForm({ onCreated }) {
                 <span className="text-xs text-dim">·</span>
                 <span className="text-xs text-dim italic">Service Detection is always included automatically — it identifies services on open ports (nmap -sV) and is required by TLS Checker, SSH Checker, and Nmap to work correctly</span>
               </div>
-              <div className="flex flex-wrap gap-2">
-                {allTools.map(tool => (
-                  <label key={tool.key}
-                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs cursor-pointer border transition-colors
-                      ${selected.includes(tool.key)
-                        ? 'bg-brand/10 border-brand/40 text-brand'
-                        : 'bg-canvas border-rim text-body hover:border-dim'}`}>
-                    <input type="checkbox" className="hidden" checked={selected.includes(tool.key)} onChange={() => toggleTool(tool.key)} />
-                    {tool.label || tool.key}
-                  </label>
+              <div className="space-y-3">
+                {groupedTools.map(({ group, tools }) => (
+                  <div key={group}>
+                    <p className="text-xs font-semibold uppercase tracking-wider text-dim mb-1.5">{group}</p>
+                    <div className="flex flex-wrap gap-2">
+                      {tools.map(tool => (
+                        <label key={tool.key}
+                          className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs cursor-pointer border transition-colors
+                            ${selected.includes(tool.key)
+                              ? 'bg-brand/10 border-brand/40 text-brand'
+                              : 'bg-canvas border-rim text-body hover:border-dim'}`}>
+                          <input type="checkbox" className="hidden" checked={selected.includes(tool.key)} onChange={() => toggleTool(tool.key)} />
+                          {tool.label || tool.key}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
                 ))}
               </div>
             </div>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -322,6 +322,15 @@ class TestDashboard:
         res = client.get("/api/dashboard/")
         assert res.status_code == 401
 
+    def test_features_domain_intelligence_category(self, auth_client, db):
+        """The dashboard surfaces the primary Domain Intelligence category card."""
+        res = auth_client.get("/api/dashboard/")
+        di = res.json()["domain_intelligence"]
+        assert di["category"] == "Domain Intelligence"
+        assert di["tool_count"] >= 1
+        for k in ("total", "critical", "high", "medium", "low", "info"):
+            assert k in di
+
 
 # ---------------------------------------------------------------------------
 # Domains
@@ -707,6 +716,13 @@ class TestWorkflowTools:
         data = res.json()
         assert "tools" in data
         assert "requires" in data
+
+    def test_tools_carry_phase_group_for_ui_categorization(self, auth_client):
+        """Each tool exposes its phase_group so the UI can group by category."""
+        tools = auth_client.get("/api/workflows/tools/").json()["tools"]
+        assert tools
+        assert all("phase_group" in t for t in tools)
+        assert any(t["phase_group"] == "Domain Intelligence" for t in tools)
 
     def test_requires_auth(self, client):
         assert client.get("/api/workflows/tools/").status_code == 401


### PR DESCRIPTION
Surfaces the category taxonomy (`phase_group`) — until now an internal execution-ordering concept — as a first-class UI element, with **Domain Intelligence** (phase 1) leading.

## Changes
**1. Workflows tool picker — grouped by category**
- The create-workflow tool list was a flat set of checkboxes. Now grouped under category headers (`Domain Intelligence → Surface Enumeration → Port Discovery → Network Exposure → Web Exposure → Prioritization`), ordered by each group's earliest phase — matching scan execution order.
- Backend: `/api/workflows/tools/` now returns `phase_group` per tool (it previously exposed only `phase`).

**2. Dashboard — featured Domain Intelligence card**
- A prominent card at the top of the dashboard presents Domain Intelligence as the primary recon category: tool count, open-finding total, and a severity breakdown, linking through to findings.
- Backend: a new `domain_intelligence` block in `/api/dashboard/`. The category's tools are resolved from the registry (`get_tool_phase_groups`), so it stays correct as tools are added/removed.

## Verification
- Backend live: dashboard returns `domain_intelligence` (`tool_count: 6, total: 10, high: 2, medium: 5, low: 2, info: 1`); tools API includes `phase_group`.
- Frontend: verified in-browser — the Dashboard card renders with real data and the Workflows picker shows the 6 categories in phase order (Domain Intelligence first).
- `npm run build` clean; `npm run test:run` 35 pass; new pytest assertions for both API fields pass.

Design note: nothing in *execution* changed — Domain Intelligence already ran first (phase 1). This makes that primacy visible in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv