### PR TITLE
feat: scan-type presets with dynamic attestation on the start form

### DIFF
--- a/apps/core/engine/workflows/api.py
+++ b/apps/core/engine/workflows/api.py
@@ -16,6 +16,7 @@ from apps.core.engine.workflows.registry import (
     get_tool_phases,
     get_tool_produces_findings,
     get_tool_requires,
+    is_passive_tool_set,
 )
 
 logger = logging.getLogger(__name__)
@@ -43,6 +44,10 @@ def _serialize_workflow(workflow) -> dict:
         "name": workflow.name,
         "description": workflow.description,
         "is_default": workflow.is_default,
+        # Passive-only workflows send no packets to the target and need no
+        # DomainAuthorization for an immediate scan — drives the start form's
+        # dynamic attestation. Matches the scan-start gate's is_passive_tool_set.
+        "is_passive": is_passive_tool_set(workflow.enabled_tools()),
         "created_at": workflow.created_at.isoformat(),
         "updated_at": workflow.updated_at.isoformat(),
         "steps": steps,

--- a/frontend/src/pages/ScanStartPage.jsx
+++ b/frontend/src/pages/ScanStartPage.jsx
@@ -7,8 +7,32 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { apiPost, apiGet } from '../api/client.js';
 
-// Mirrors the API's RFC 1123 hostname check (apps/core/domains/api.py)
+// Mirrors the API's RFC 1123 hostname check (apps/core/data/domains/api.py)
 const HOSTNAME_RE = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+
+function enabledToolCount(wf) {
+  if (!wf?.steps) return null;
+  return wf.steps.filter(s => s.enabled).length;
+}
+
+function PresetCard({ active, onClick, title, desc, scope, auth }) {
+  return (
+    <button type="button" onClick={onClick}
+      className={`flex-1 text-left rounded-xl border p-3.5 transition-colors
+        ${active ? 'border-brand/50 bg-brand/10' : 'border-rim bg-canvas hover:border-dim'}`}>
+      <div className="flex items-center gap-2">
+        <span className={`h-3.5 w-3.5 rounded-full border-2 shrink-0
+          ${active ? 'border-brand bg-brand' : 'border-dim'}`} />
+        <span className={`text-sm font-semibold ${active ? 'text-brand' : 'text-body'}`}>{title}</span>
+      </div>
+      <div className="text-dim text-xs mt-1.5 leading-snug">{desc}</div>
+      {scope && <div className="text-dim text-xs mt-1.5">{scope}</div>}
+      <div className={`text-xs mt-1 font-medium ${auth.needed ? 'text-orange-400' : 'text-green-400'}`}>
+        {auth.needed ? '⚠ Authorization required' : '✓ No authorization needed'}
+      </div>
+    </button>
+  );
+}
 
 export default function ScanStartPage() {
   const navigate = useNavigate();
@@ -27,7 +51,10 @@ export default function ScanStartPage() {
   const domains   = domainsData  || [];
   const workflows = workflowsData || [];
   const defaultWf = workflows.find(w => w.is_default);
+  const passiveWf = workflows.find(w => w.name === 'Passive Scan')
+                 || workflows.find(w => w.is_passive && !w.is_default);
 
+  const [scanType,   setScanType]  = useState('passive');   // 'passive' | 'full' | 'custom'
   const [domain,     setDomain]    = useState(initDomain);
   const [workflowId, setWorkflow]  = useState('');
   const [scheduled,  setScheduled] = useState(false);
@@ -36,34 +63,53 @@ export default function ScanStartPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error,      setError]     = useState(null);
 
+  // If there's no passive workflow available, fall back to the full-scan preset.
   useEffect(() => {
-    if (defaultWf && !workflowId) setWorkflow(String(defaultWf.id));
-  }, [defaultWf, workflowId]);
+    if (!lw && !passiveWf && scanType === 'passive') setScanType('full');
+  }, [lw, passiveWf, scanType]);
+
+  // Custom defaults its dropdown to the default workflow.
+  useEffect(() => {
+    if (scanType === 'custom' && defaultWf && !workflowId) setWorkflow(String(defaultWf.id));
+  }, [scanType, defaultWf, workflowId]);
+
+  // Resolve the preset → the workflow that will actually run.
+  const resolvedWf =
+    scanType === 'passive' ? passiveWf
+    : scanType === 'full'  ? defaultWf
+    : (workflows.find(w => String(w.id) === workflowId) || defaultWf);
+
+  // Attestation is required unless the scan is passive-only AND runs now — the
+  // exact condition the API's scan-start gate uses to bypass DomainAuthorization.
+  const needsAttestation = !(resolvedWf?.is_passive && !scheduled);
 
   async function handleSubmit(e) {
     e.preventDefault();
     const target = domain.trim().toLowerCase();
     if (!target) { setError('Enter a domain.'); return; }
     if (!HOSTNAME_RE.test(target)) { setError('Enter a valid domain name.'); return; }
-    if (!attested) {
+    if (needsAttestation && !attested) {
       setError('Please confirm you have authority to scan this domain.');
       return;
     }
     setError(null); setSubmitting(true);
     try {
-      // One flow for new and existing domains: create if missing, then authorize.
+      // One flow for new and existing domains: create if missing.
       let record;
       try {
         record = await apiPost('/domains/', { name: target });
       } catch (err) {
-        // Already exists — reuse the one from the loaded list.
         if (err.status === 400) record = domains.find(d => d.name === target);
         if (!record) throw err;
       }
-      await apiPost(`/domains/${record.id}/authorize/`, { attestation: true });
+      // Only authorize when the scan actually needs it (active, or scheduled).
+      // A passive-now scan is exempt from the gate, so we don't ask the user to attest.
+      if (needsAttestation) {
+        await apiPost(`/domains/${record.id}/authorize/`, { attestation: true });
+      }
 
       const body = { domain: target, schedule_type: scheduled ? 'once' : 'now' };
-      if (workflowId) body.workflow_id = Number(workflowId);
+      if (resolvedWf?.id) body.workflow_id = Number(resolvedWf.id);
       if (scheduled && schedTime) body.scheduled_at = schedTime;
       await apiPost('/scans/start/', body);
       navigate('/scans');
@@ -73,10 +119,12 @@ export default function ScanStartPage() {
   }
 
   const loading = ld || lw;
+  const passiveScope = passiveWf ? `${enabledToolCount(passiveWf)} passive checks` : 'passive checks';
+  const fullScope    = defaultWf ? `${enabledToolCount(defaultWf)} tools, all phases` : 'all tools';
 
   return (
     <Layout>
-      <div className="max-w-lg space-y-5">
+      <div className="max-w-2xl space-y-5">
         <div>
           <h1 className="text-lit text-xl font-bold">Start Scan</h1>
           <p className="text-dim text-sm mt-0.5">Launch a new scan against a domain</p>
@@ -84,40 +132,56 @@ export default function ScanStartPage() {
         {loading ? <div className="flex justify-center p-8"><Spinner /></div> : (
           <Card>
             <CardContent className="p-6">
-              <form onSubmit={handleSubmit} className="space-y-4">
+              <form onSubmit={handleSubmit} className="space-y-5">
                 <div>
                   <label className="block text-xs text-dim mb-1 font-medium">Domain *</label>
                   <input
-                    type="text"
-                    value={domain}
-                    onChange={e => setDomain(e.target.value)}
-                    placeholder="example.com"
-                    list="known-domains"
-                    className="field"
-                    autoFocus
+                    type="text" value={domain} onChange={e => setDomain(e.target.value)}
+                    placeholder="example.com" list="known-domains" className="field" autoFocus
                   />
                   <datalist id="known-domains">
                     {domains.map(d => <option key={d.id} value={d.name} />)}
                   </datalist>
-                  <label className="mt-2 flex items-start gap-2 text-sm text-body cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={attested}
-                      onChange={e => setAttested(e.target.checked)}
-                      className="accent-brand mt-0.5"
-                    />
-                    <span>I confirm I have authority to scan this domain (I own it or have written permission).</span>
-                  </label>
                 </div>
+
                 <div>
-                  <label className="block text-xs text-dim mb-1 font-medium">Workflow</label>
-                  <select value={workflowId} onChange={e => setWorkflow(e.target.value)} className="field">
-                    <option value="">— use default —</option>
-                    {workflows.map(w => (
-                      <option key={w.id} value={w.id}>{w.name}{w.is_default ? ' (default)' : ''}</option>
-                    ))}
-                  </select>
+                  <label className="block text-xs text-dim mb-2 font-medium">Scan type</label>
+                  <div className="flex flex-col sm:flex-row gap-2.5">
+                    <PresetCard
+                      active={scanType === 'passive'} onClick={() => setScanType('passive')}
+                      title="Passive recon"
+                      desc="Public &amp; third-party data only — no packets to the target."
+                      scope={passiveScope} auth={{ needed: false }}
+                    />
+                    <PresetCard
+                      active={scanType === 'full'} onClick={() => setScanType('full')}
+                      title="Full scan"
+                      desc="Complete assessment — probes the target directly."
+                      scope={fullScope} auth={{ needed: true }}
+                    />
+                    <PresetCard
+                      active={scanType === 'custom'} onClick={() => setScanType('custom')}
+                      title="Custom"
+                      desc="Pick a saved workflow."
+                      scope={resolvedWf && scanType === 'custom' ? `${enabledToolCount(resolvedWf)} tools` : ' '}
+                      auth={{ needed: scanType === 'custom' ? needsAttestation : true }}
+                    />
+                  </div>
                 </div>
+
+                {scanType === 'custom' && (
+                  <div>
+                    <label className="block text-xs text-dim mb-1 font-medium">Workflow</label>
+                    <select value={workflowId} onChange={e => setWorkflow(e.target.value)} className="field">
+                      {workflows.map(w => (
+                        <option key={w.id} value={w.id}>
+                          {w.name}{w.is_default ? ' (default)' : ''}{w.is_passive ? ' · passive' : ''}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+
                 <label className="inline-flex items-center gap-2 text-sm text-body cursor-pointer">
                   <input type="checkbox" checked={scheduled} onChange={e => setScheduled(e.target.checked)} className="accent-brand" />
                   Schedule for later
@@ -126,14 +190,24 @@ export default function ScanStartPage() {
                   <div>
                     <label className="block text-xs text-dim mb-1 font-medium">Scheduled time</label>
                     <input type="datetime-local" value={schedTime} onChange={e => setSchedTime(e.target.value)} className="field" />
+                    <p className="text-dim text-xs mt-1">Scheduled scans always require authorization.</p>
                   </div>
                 )}
+
+                {needsAttestation ? (
+                  <label className="flex items-start gap-2 text-sm text-body cursor-pointer rounded-lg border border-orange-800/50 bg-orange-900/10 p-3">
+                    <input type="checkbox" checked={attested} onChange={e => setAttested(e.target.checked)} className="accent-brand mt-0.5" />
+                    <span>I confirm I have authority to scan this domain (I own it or have written permission).</span>
+                  </label>
+                ) : (
+                  <p className="text-green-400 text-sm rounded-lg border border-green-800/50 bg-green-900/10 p-3">
+                    ✓ Passive scan — uses only public data, sends nothing to the target, and needs no authorization.
+                  </p>
+                )}
+
                 {error && <p className="text-red-400 text-sm">{error}</p>}
                 <div className="flex gap-3 pt-1">
-                  <Button
-                    type="submit"
-                    disabled={submitting || !domain.trim() || !attested}
-                  >
+                  <Button type="submit" disabled={submitting || !domain.trim() || (needsAttestation && !attested)}>
                     {submitting ? 'Starting…' : scheduled ? 'Schedule Scan' : 'Start Scan Now'}
                   </Button>
                   <Button type="button" variant="outline" onClick={() => navigate('/scans')}>Cancel</Button>

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -736,6 +736,15 @@ class TestWorkflowsList:
         assert isinstance(workflows, list)
         assert any(w["name"] == "Smoke Workflow" for w in workflows)
 
+    def test_exposes_is_passive_for_dynamic_attestation(self, auth_client, workflow):
+        """Each workflow reports is_passive so the start form can drop the
+        attestation requirement for passive-only scans."""
+        workflows = auth_client.get("/api/workflows/").json()
+        assert all("is_passive" in w for w in workflows)
+        passive = next((w for w in workflows if w["name"] == "Passive Scan"), None)
+        if passive is not None:
+            assert passive["is_passive"] is True
+
     def test_requires_auth(self, client):
         assert client.get("/api/workflows/").status_code == 401
 


### PR DESCRIPTION
Reworks the **Start Scan** form around intent-based presets, and makes the authorization attestation dynamic. Phase 1 of the scan-initiation UX improvements.

## Changes
**Three scan-type presets** replace the bare Workflow dropdown:
- **Passive recon** (default) — public/third-party data only, no packets to the target
- **Full scan** — complete assessment, probes the target directly
- **Custom** — reveals the saved-workflow dropdown

Each preset shows its **scope** (tool count) and **authorization status** up front.

**Dynamic attestation** — the "I have authority to scan" checkbox now appears (and is required) **only** when the scan includes active tools or is scheduled — the exact condition the API's scan-start gate uses to require `DomainAuthorization`. A passive-now scan shows a green "no authorization needed" note instead. This:
- removes friction from the safe path (no attestation for passive recon),
- makes the passive/active boundary legible (it was previously invisible),
- and defaults to Passive, so the form can't accidentally launch an unauthorized active scan.

## Backend
`/api/workflows/` now returns `is_passive` per workflow (via `is_passive_tool_set(enabled_tools())`) — the authoritative signal that drives the form.

## Verification
- Backend: `is_passive` correct (Passive Scan=true, Full/Infra=false); check + ruff clean.
- Frontend (in-browser DOM): default=Passive → no attestation checkbox, "no authorization needed" shown; selecting **Full scan** → attestation checkbox appears and gates the Start button. Build clean.
- New pytest for `is_passive`; existing suites pass.

Phase 2 (category checkboxes under Custom) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv