### PR TITLE
feat: category selection on the scan start form (Custom → By category)

### DIFF
--- a/apps/core/engine/scans/api.py
+++ b/apps/core/engine/scans/api.py
@@ -216,21 +216,28 @@ def _get_vuln_counts(session) -> dict:
     return counts
 
 
-def _is_passive_only_scan(schedule_type: str, workflow) -> bool:
-    """True only for an immediate scan whose workflow contains solely passive tools.
+def _is_passive_only_scan(schedule_type: str, workflow, tools=None) -> bool:
+    """True only for an immediate scan whose tool set is solely passive.
 
     Passive tools use only public / third-party data and never touch the target,
     so such a scan needs no DomainAuthorization. Everything else — any active
     tool, or a scheduled (once/recurring) scan, which always runs the default
     active Full Scan workflow — is treated as active and stays behind the gate.
 
-    Resolving to the DEFAULT workflow when none was chosen means a bare "now"
-    scan (default = Full Scan) correctly reads as active and keeps the gate.
+    `tools`, when given (a category-scoped scan from the start form), is the
+    authoritative tool set and is gated directly — so selecting only passive
+    categories bypasses auth, while including an active tool (e.g. the Domain
+    Intelligence category's domain_security) keeps the gate. Otherwise the
+    workflow's tools are used; resolving to the DEFAULT workflow when none was
+    chosen means a bare "now" scan (default = Full Scan) correctly reads active.
     """
     if schedule_type != "now":
         return False
 
     from apps.core.engine.workflows.registry import is_passive_tool_set
+
+    if tools:
+        return is_passive_tool_set(tools)
 
     if workflow is None:
         from apps.core.engine.workflows.models import Workflow
@@ -269,6 +276,10 @@ class ScanStartRequest(Schema):
     domain: str
     schedule_type: str = "now"
     workflow_id: int | None = None
+    # Optional tool subset (immediate scans only) — e.g. the tools of the
+    # categories a user ticked on the start form. Restricts the run to these
+    # tools over the resolved workflow; the auth gate is applied to this set.
+    tools: list[str] | None = None
     scheduled_at: str | None = None
     recurrence: str = "daily"
     recurrence_time: str = "00:00"
@@ -293,10 +304,22 @@ def start_scan(request, data: ScanStartRequest):
         except Workflow.DoesNotExist:
             raise HttpError(404, "Workflow not found")
 
+    # Optional tool subset (immediate scans only) — validated against the registry.
+    tools = None
+    if data.tools:
+        if data.schedule_type != "now":
+            raise HttpError(400, "tools may only be given for an immediate (now) scan")
+        from apps.core.engine.workflows.registry import get_tool_choices
+        valid = {key for key, _ in get_tool_choices()}
+        unknown = [t for t in data.tools if t not in valid]
+        if unknown:
+            raise HttpError(400, f"Unknown tools: {', '.join(unknown)}")
+        tools = data.tools
+
     # Authorization gate — required unless this is an immediate passive-only scan.
-    # Scheduled scans (once/recurring) always run the default active Full Scan
-    # workflow and therefore always keep the gate.
-    if not _is_passive_only_scan(data.schedule_type, workflow):
+    # When a tool subset is given it is the authoritative set the gate checks;
+    # otherwise the workflow's tools are used. Scheduled scans always keep the gate.
+    if not _is_passive_only_scan(data.schedule_type, workflow, tools=tools):
         from apps.core.data.domains.models import DomainAuthorization
         if not DomainAuthorization.objects.filter(domain__name=domain).exists():
             raise HttpError(403, "Domain is not authorized for scanning")
@@ -305,7 +328,7 @@ def start_scan(request, data: ScanStartRequest):
         from apps.core.engine.scans.pipeline import create_scan_session
         from apps.core.engine.scans.tasks import run_scan_task
 
-        session = create_scan_session(domain, workflow=workflow)
+        session = create_scan_session(domain, workflow=workflow, tools=tools)
         if session is None:
             raise HttpError(409, "A scan is already running for this domain.")
         run_scan_task(session.id)

--- a/apps/core/engine/scans/pipeline.py
+++ b/apps/core/engine/scans/pipeline.py
@@ -276,13 +276,18 @@ def _is_scan_active(domain: str) -> bool:
     ).exists()
 
 
-def create_scan_session(domain: str, triggered_by: str = "manual", workflow=None) -> "ScanSession | None":
+def create_scan_session(domain: str, triggered_by: str = "manual", workflow=None, tools=None) -> "ScanSession | None":
     """
     Atomically create a scan session if no active scan exists for the domain.
     Returns the new ScanSession or None if a scan is already active.
 
     If no workflow is specified, the default workflow is auto-assigned so all
     scans run through the dynamic workflow runner.
+
+    `tools`, when given, restricts the run to that tool subset (stored as
+    `subscan_tools`, which the runner honors via `only_tools`) — this is how a
+    category-scoped scan from the start form runs just the selected tools over
+    the resolved workflow. None runs the full workflow.
     """
     if workflow is None:
         from apps.core.engine.workflows.models import Workflow
@@ -304,6 +309,7 @@ def create_scan_session(domain: str, triggered_by: str = "manual", workflow=None
             return ScanSession.objects.create(
                 domain=domain, scan_type="full", status="pending",
                 triggered_by=triggered_by, workflow=workflow,
+                subscan_tools=tools,
             )
     except DatabaseError:
         if _is_scan_active(domain):
@@ -323,6 +329,7 @@ def create_scan_session(domain: str, triggered_by: str = "manual", workflow=None
                 return ScanSession.objects.create(
                     domain=domain, scan_type="full", status="pending",
                     triggered_by=triggered_by, workflow=workflow,
+                    subscan_tools=tools,
                 )
         except DatabaseError:
             logger.error(f"[create_scan_session] Retry failed for {domain} — skipping scan")

--- a/apps/core/engine/workflows/api.py
+++ b/apps/core/engine/workflows/api.py
@@ -11,6 +11,7 @@ from apps.core.console.api.auth import JWTAuth
 from apps.core.engine.workflows.models import Workflow, WorkflowStep
 from apps.core.engine.workflows.registry import (
     get_registry,
+    get_tool_active,
     get_tool_choices,
     get_tool_phase_groups,
     get_tool_phases,
@@ -71,6 +72,7 @@ def list_tools(request):
     phases = get_tool_phases()
     produces = get_tool_produces_findings()
     groups = get_tool_phase_groups()
+    active = get_tool_active()
     tools = [
         {
             "key": key,
@@ -78,6 +80,10 @@ def list_tools(request):
             "phase": phases.get(key, 99),
             "phase_group": groups.get(key, ""),
             "produces_findings": produces.get(key, False),
+            # active = probes the target directly (needs authorization); passive
+            # tools use only public/third-party data. Drives the start form's
+            # dynamic attestation for a category selection.
+            "active": active.get(key, True),
         }
         for key, label in get_tool_choices()
     ]

--- a/frontend/src/pages/ScanStartPage.jsx
+++ b/frontend/src/pages/ScanStartPage.jsx
@@ -47,14 +47,32 @@ export default function ScanStartPage() {
     queryKey: ['/workflows/'],
     queryFn: () => apiGet('/workflows/'),
   });
+  const { data: toolsData } = useQuery({
+    queryKey: ['/workflows/tools/'],
+    queryFn: () => apiGet('/workflows/tools/'),
+  });
 
   const domains   = domainsData  || [];
   const workflows = workflowsData || [];
+  const allTools  = toolsData?.tools || [];
   const defaultWf = workflows.find(w => w.is_default);
   const passiveWf = workflows.find(w => w.name === 'Passive Scan')
                  || workflows.find(w => w.is_passive && !w.is_default);
 
+  // Categories (phase_group) ordered by earliest phase — Domain Intelligence first.
+  const categories = React.useMemo(() => {
+    const byGroup = new Map();
+    for (const t of allTools) {
+      const g = t.phase_group || 'Other';
+      if (!byGroup.has(g)) byGroup.set(g, { group: g, minPhase: t.phase ?? 99, tools: [] });
+      const e = byGroup.get(g); e.tools.push(t); e.minPhase = Math.min(e.minPhase, t.phase ?? 99);
+    }
+    return [...byGroup.values()].sort((a, b) => a.minPhase - b.minPhase);
+  }, [allTools]);
+
   const [scanType,   setScanType]  = useState('passive');   // 'passive' | 'full' | 'custom'
+  const [customMode, setCustomMode] = useState('category'); // 'category' | 'workflow'
+  const [selectedCats, setSelectedCats] = useState(['Domain Intelligence']);
   const [domain,     setDomain]    = useState(initDomain);
   const [workflowId, setWorkflow]  = useState('');
   const [scheduled,  setScheduled] = useState(false);
@@ -62,6 +80,12 @@ export default function ScanStartPage() {
   const [attested,   setAttested]  = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error,      setError]     = useState(null);
+
+  function toggleCat(g) {
+    setSelectedCats(prev => prev.includes(g) ? prev.filter(x => x !== g) : [...prev, g]);
+  }
+  // Tools of the ticked categories → the subset a category scan will run.
+  const selectedTools = allTools.filter(t => selectedCats.includes(t.phase_group));
 
   // If there's no passive workflow available, fall back to the full-scan preset.
   useEffect(() => {
@@ -73,21 +97,34 @@ export default function ScanStartPage() {
     if (scanType === 'custom' && defaultWf && !workflowId) setWorkflow(String(defaultWf.id));
   }, [scanType, defaultWf, workflowId]);
 
-  // Resolve the preset → the workflow that will actually run.
+  // Resolve the preset → the workflow that will actually run (workflow-based paths).
   const resolvedWf =
     scanType === 'passive' ? passiveWf
     : scanType === 'full'  ? defaultWf
     : (workflows.find(w => String(w.id) === workflowId) || defaultWf);
 
-  // Attestation is required unless the scan is passive-only AND runs now — the
-  // exact condition the API's scan-start gate uses to bypass DomainAuthorization.
-  const needsAttestation = !(resolvedWf?.is_passive && !scheduled);
+  // Is the selection passive-only? Passive preset → yes; full → no; custom by
+  // category → all selected tools passive; custom by workflow → the workflow's flag.
+  const isCategoryScan = scanType === 'custom' && customMode === 'category';
+  const selectionIsPassive =
+    scanType === 'passive' ? true
+    : scanType === 'full'  ? false
+    : isCategoryScan       ? (selectedTools.length > 0 && selectedTools.every(t => !t.active))
+    : !!resolvedWf?.is_passive;
+
+  // Attestation is required unless the selection is passive-only AND runs now —
+  // the exact condition the API's scan-start gate uses to bypass DomainAuthorization.
+  const needsAttestation = !(selectionIsPassive && !scheduled);
 
   async function handleSubmit(e) {
     e.preventDefault();
     const target = domain.trim().toLowerCase();
     if (!target) { setError('Enter a domain.'); return; }
     if (!HOSTNAME_RE.test(target)) { setError('Enter a valid domain name.'); return; }
+    if (isCategoryScan && selectedTools.length === 0) {
+      setError('Select at least one category.');
+      return;
+    }
     if (needsAttestation && !attested) {
       setError('Please confirm you have authority to scan this domain.');
       return;
@@ -109,7 +146,12 @@ export default function ScanStartPage() {
       }
 
       const body = { domain: target, schedule_type: scheduled ? 'once' : 'now' };
-      if (resolvedWf?.id) body.workflow_id = Number(resolvedWf.id);
+      if (isCategoryScan && !scheduled) {
+        // Category scan: run just the selected tools over the default workflow.
+        body.tools = selectedTools.map(t => t.key);
+      } else if (resolvedWf?.id) {
+        body.workflow_id = Number(resolvedWf.id);
+      }
       if (scheduled && schedTime) body.scheduled_at = schedTime;
       await apiPost('/scans/start/', body);
       navigate('/scans');
@@ -162,23 +204,52 @@ export default function ScanStartPage() {
                     <PresetCard
                       active={scanType === 'custom'} onClick={() => setScanType('custom')}
                       title="Custom"
-                      desc="Pick a saved workflow."
-                      scope={resolvedWf && scanType === 'custom' ? `${enabledToolCount(resolvedWf)} tools` : ' '}
+                      desc="Pick categories or a saved workflow."
+                      scope={scanType === 'custom'
+                        ? (isCategoryScan ? `${selectedTools.length} tools · ${selectedCats.length} categories`
+                                          : `${enabledToolCount(resolvedWf)} tools`)
+                        : ' '}
                       auth={{ needed: scanType === 'custom' ? needsAttestation : true }}
                     />
                   </div>
                 </div>
 
                 {scanType === 'custom' && (
-                  <div>
-                    <label className="block text-xs text-dim mb-1 font-medium">Workflow</label>
-                    <select value={workflowId} onChange={e => setWorkflow(e.target.value)} className="field">
-                      {workflows.map(w => (
-                        <option key={w.id} value={w.id}>
-                          {w.name}{w.is_default ? ' (default)' : ''}{w.is_passive ? ' · passive' : ''}
-                        </option>
+                  <div className="space-y-3 rounded-lg border border-rim p-3">
+                    <div className="inline-flex rounded-md border border-rim overflow-hidden text-xs">
+                      {['category', 'workflow'].map(m => (
+                        <button key={m} type="button" onClick={() => setCustomMode(m)}
+                          className={`px-3 py-1 ${customMode === m ? 'bg-brand/15 text-brand' : 'text-dim hover:text-body'}`}>
+                          {m === 'category' ? 'By category' : 'By workflow'}
+                        </button>
                       ))}
-                    </select>
+                    </div>
+
+                    {customMode === 'category' ? (
+                      <div className="space-y-1.5">
+                        {categories.map(({ group, tools }) => {
+                          const activeCount = tools.filter(t => t.active).length;
+                          return (
+                            <label key={group} className="flex items-center gap-2 text-sm text-body cursor-pointer">
+                              <input type="checkbox" checked={selectedCats.includes(group)}
+                                onChange={() => toggleCat(group)} className="accent-brand" />
+                              <span>{group}</span>
+                              <span className="text-dim text-xs">
+                                {tools.length} tools{activeCount === 0 ? ' · passive' : ''}
+                              </span>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <select value={workflowId} onChange={e => setWorkflow(e.target.value)} className="field">
+                        {workflows.map(w => (
+                          <option key={w.id} value={w.id}>
+                            {w.name}{w.is_default ? ' (default)' : ''}{w.is_passive ? ' · passive' : ''}
+                          </option>
+                        ))}
+                      </select>
+                    )}
                   </div>
                 )}
 

--- a/tests/unit/test_passive_scan.py
+++ b/tests/unit/test_passive_scan.py
@@ -194,6 +194,43 @@ class TestPassiveScanAuthorizationGate:
         })
         assert resp.status_code == 403
 
+    def test_passive_tools_subset_bypasses_authorization(self, auth_client, domain):
+        # A category-scoped scan of only passive tools on an unauthorized domain
+        # is accepted, and the run is restricted to those tools (subscan_tools).
+        captured = {}
+
+        def fake_create(domain, triggered_by="manual", workflow=None, tools=None):
+            captured["tools"] = tools
+            return type("S", (), {"uuid": "cat-uuid-1", "id": 7})()
+
+        with patch("apps.core.engine.scans.tasks.run_scan_task"), \
+             patch("apps.core.engine.scans.pipeline.create_scan_session", side_effect=fake_create):
+            resp = post_json(auth_client, "/api/scans/start/", {
+                "domain": "example.com",
+                "schedule_type": "now",
+                "tools": ["cve_intel"],  # passive
+            })
+        assert resp.status_code == 201, resp.content
+        assert captured["tools"] == ["cve_intel"]
+
+    def test_active_tools_subset_requires_authorization(self, auth_client, domain):
+        # Including an active tool (e.g. the Domain Intelligence category's
+        # domain_security) keeps the auth gate.
+        resp = post_json(auth_client, "/api/scans/start/", {
+            "domain": "example.com",
+            "schedule_type": "now",
+            "tools": ["typosquat", "domain_security"],
+        })
+        assert resp.status_code == 403
+
+    def test_unknown_tool_rejected(self, auth_client, domain):
+        resp = post_json(auth_client, "/api/scans/start/", {
+            "domain": "example.com",
+            "schedule_type": "now",
+            "tools": ["not_a_real_tool"],
+        })
+        assert resp.status_code == 400
+
 
 # ---------------------------------------------------------------------------
 # Subscan gate — active tools against a parent domain need authorization


### PR DESCRIPTION
Phase 2 of the scan-initiation UX (follows #404). Lets a user launch a scan scoped to specific **categories** without pre-building a workflow.

## What
Under the **Custom** preset, a segmented **By category / By workflow** toggle:
- **By category** (default) — the 6 categories (Domain Intelligence first), each with its tool count and a passive marker. The scan runs just the selected categories' tools.
- **By workflow** — the saved-workflow dropdown (phase 1 behavior, preserved).

## Backend
- `/api/scans/start/` accepts an optional **`tools`** subset (immediate scans only). It's validated against the registry and restricts the run to those tools via the existing `subscan_tools` → `only_tools` plumbing over the default workflow — the same mechanism subscans use, which the main run path already honors.
- The **auth gate applies to the tool subset** (`is_passive_tool_set`): a passive-only selection bypasses `DomainAuthorization`, while any active tool keeps the gate. Note the Domain Intelligence *category* includes the active `domain_security`, so selecting it correctly requires authorization.
- `/api/workflows/tools/` now exposes **`active`** per tool, so the form computes passive/active for a category selection and drives the dynamic attestation.
- `create_scan_session(..., tools=)` sets `subscan_tools`.

## Verification
- In-browser: Custom → By category shows the 6 categories (DI checked → attestation required because DI has `domain_security`); switching to a passive-only category (Prioritization) drops the attestation.
- Tests: passive tool subset bypasses the gate; active subset → 403; unknown tool → 400. Backend ruff + 24 passive-scan tests pass; frontend build clean, 35 vitest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv