### PR TITLE
chore: release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.10.0] — 2026-09-10
+
+### Changed
+- **The UI is now strictly scan-centric.** The scan is the single organizing
+  unit: the global Findings page and the persistent Assets inventory pages
+  (list + detail) were removed, along with their nav entries and routes.
+  Findings and assets are viewed only within a scan (Scan Detail's tabs).
+  Finding triage (status: open/acknowledged/in_progress/resolved/false_positive)
+  moved into the Scan Detail finding modal, so no capability was lost. The
+  Dashboard's cross-scan cards (Domain Intelligence, Asset inventory) were
+  dropped; the domain-status table (→ View Scans) and latest-scan KPIs remain.
+  **Why:** commit to the scan as the primary model rather than the prior
+  half scan / half attack-surface-posture UI. The `/api/assets/` endpoints and
+  `asset_inventory` data layer are left intact (valid REST surface, still tested).
+
+### Added
+- **Domain Intelligence surfaced as the primary scan category.** The category
+  taxonomy (phase_group) — previously an internal execution-ordering concept —
+  is now first-class in the UI: the Workflows tool picker is grouped by category
+  (Domain Intelligence first), and `/api/workflows/tools/` exposes `phase_group`
+  and `active` per tool.
+- **Scan-start presets with dynamic attestation.** The Start Scan form offers
+  three intent-based presets — Passive recon / Full scan / Custom. The
+  authorization attestation now appears only when the selection includes active
+  tools or is scheduled (matching the API's auth gate), so passive scans are
+  friction-free and Passive is the default. `/api/workflows/` exposes
+  `is_passive` per workflow.
+- **Category-scoped scans.** Under the Custom preset, a By category / By workflow
+  toggle lets you launch a scan restricted to selected categories' tools without
+  building a workflow. `/api/scans/start/` accepts an optional validated `tools`
+  subset, gated on `is_passive_tool_set` and run via `subscan_tools`.
+
 ## [v2.9.1] — 2026-09-10
 
 ### Changed
@@ -1215,7 +1247,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.9.1...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.10.0...HEAD
+[v2.10.0]: https://github.com/cybersecify/OpenEASD/compare/v2.9.1...v2.10.0
 [v2.9.1]: https://github.com/cybersecify/OpenEASD/compare/v2.9.0...v2.9.1
 [v2.9.0]: https://github.com/cybersecify/OpenEASD/compare/v2.8.0...v2.9.0
 [v2.8.0]: https://github.com/cybersecify/OpenEASD/compare/v2.7.0...v2.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.9.1"
+version = "2.10.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.9.1"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release — the scan-centric UI rework + the Domain-Intelligence-primary and scan-initiation UX work.

### Changed
- **UI is now strictly scan-centric** (#406) — removed the global Findings page and persistent Assets inventory pages; findings/assets live under a scan; finding triage moved into the Scan Detail modal.

### Added
- **Domain Intelligence as primary category** (#403) — Workflows picker grouped by category, DI first; tools API exposes `phase_group`/`active`.
- **Scan-start presets + dynamic attestation** (#404) — Passive recon / Full scan / Custom; attestation only when active/scheduled; `is_passive` per workflow.
- **Category-scoped scans** (#405) — Custom → By category; `/api/scans/start/` accepts a validated `tools` subset.

Version `2.9.1 → 2.10.0`; CHANGELOG + compare links added. Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv