### PR TITLE
fix: never cache the SPA entry point (stale UI after deploy)

### DIFF
--- a/openeasd/urls.py
+++ b/openeasd/urls.py
@@ -4,8 +4,8 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import JsonResponse
+from django.shortcuts import render
 from django.urls import path, include, re_path
-from django.views.generic import TemplateView
 
 from apps.core.console.api.ninja import api
 
@@ -23,14 +23,25 @@ def health(request):
     return resp
 
 
+def spa(request):
+    """Serve the SPA entry point with no caching.
+
+    index.html references content-hashed JS/CSS bundles, so a CDN/browser that
+    caches it keeps serving the OLD bundle (stale UI) after a deploy even though
+    the backend is new — exactly what happened when Cloudflare cached index.html
+    with max-age=3600 and showed the pre-release UI post-v2.10.0. The hashed
+    assets under /static/ stay long-cached (WhiteNoise); only this mutable entry
+    point must always revalidate. Same class of fix as /health above.
+    """
+    resp = render(request, "index.html")
+    resp["Cache-Control"] = "no-store"
+    return resp
+
+
 urlpatterns = [
     path("health/", health),
     path("admin/", admin.site.urls),
     path("api/", api.urls),
     path("reports/", include("apps.core.console.reports.urls")),
-    re_path(
-        r'^(?!api/|admin|static/|media/).*$',
-        TemplateView.as_view(template_name='index.html'),
-        name='spa',
-    ),
+    re_path(r'^(?!api/|admin|static/|media/).*$', spa, name='spa'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -100,6 +100,15 @@ class TestHealthEndpoint:
         assert res.status_code == 200
 
 
+class TestSpaCaching:
+    def test_spa_entry_point_is_not_cached(self, client):
+        # index.html references content-hashed bundles; a CDN caching it serves a
+        # stale UI after a deploy (Cloudflare did this post-v2.10.0). Must be no-store.
+        res = client.get("/dashboard")
+        assert res.status_code == 200
+        assert "no-store" in res.headers.get("Cache-Control", "")
+
+
 # ---------------------------------------------------------------------------
 # Auth endpoints
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom
Production (`openeasd.cybersecify.com`) showed the **pre-v2.10.0 UI** — the removed **Assets** and **Findings** nav items were still present — even though `/health` and `/api/version` reported **v2.10.0** (git_sha `c725b79e`).

## Root cause — Cloudflare cached the SPA entry point
- Served `index.html` referenced the **old** JS bundle (`index-De6lyQlC.js`), `cf-cache-status: HIT`, `age ~6h`, `last-modified 04:34 UTC` — but the v2.10.0 image built at **10:19 UTC**. Cloudflare cached the pre-release `index.html` (`max-age=3600`).
- The version footer read "2.10.0" only because it comes from `/api/version` (fresh backend), not the cached bundle — which is why version and UI disagreed.
- Not a v2.10.0 bug; a CDN caching problem. `index.html` is mutable (it points at content-hashed bundles) and must never be cached.

## Fix
Serve the SPA catch-all through a small view that sets `Cache-Control: no-store`, so the entry point always revalidates. Content-hashed assets under `/static/` keep their long cache (WhiteNoise). This mirrors the existing `/health` fix, which already sets `no-store` after Cloudflare previously cached `/api/version`.

## Also needed operationally (not code)
Prod needs a **one-time Cloudflare cache purge** (or purge `/` + `/index.html`) for the current stale copy to clear; the origin header prevents recurrence. Worth also confirming the Cloudflare cache rule caches `/static/assets/*` but bypasses the HTML document.

## Verification
`GET /dashboard` (SPA route) now returns `Cache-Control: no-store`; new regression test `TestSpaCaching`. check + ruff clean; health tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv