### PR TITLE
fix: render per-control email report copy; drop misapplied expiry line

### DIFF
--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -360,6 +360,10 @@ def _group_findings_by_issue(findings):
                 "severity": f.severity,
                 "source": f.source,
                 "check_type": f.check_type,
+                # Sub-type for findings that share a coarse check_type (email
+                # controls all use check_type="email"); lets the report attach
+                # the right per-control copy.
+                "control": (f.extra or {}).get("control") if isinstance(f.extra, dict) else None,
                 "title": title,
                 "description": f.description,
                 "remediation": f.remediation,
@@ -407,11 +411,19 @@ def _group_findings_by_issue(findings):
         grp["cisa_kev"] = any(e.get("cisa_kev") for e in dict_extras)
         pctls = [e.get("epss_percentile") for e in dict_extras if e.get("epss_percentile") is not None]
         grp["epss_percentile"] = max(pctls) if pctls else None
-        # Plain-language business impact, shown on critical/high finding cards so
-        # a decision-maker (not just an engineer) understands what's at stake.
-        grp["business_impact"] = (
-            _BUSINESS_IMPACT.get(grp["check_type"]) or _BUSINESS_IMPACT_BY_SEV.get(grp["severity"], "")
-        ) if grp["severity"] in ("critical", "high") else ""
+        # Plain-language business impact for a decision-maker. Resolve via the
+        # effective key — the control for findings that share a coarse check_type
+        # (email), else the check_type. Specific per-control/check copy renders at
+        # ANY severity (many email-auth gaps are medium but still worth explaining);
+        # the generic severity fallback stays limited to critical/high.
+        effective_key = grp.get("control") or grp["check_type"]
+        specific = _BUSINESS_IMPACT.get(effective_key)
+        if specific:
+            grp["business_impact"] = specific
+        elif grp["severity"] in ("critical", "high"):
+            grp["business_impact"] = _BUSINESS_IMPACT_BY_SEV.get(grp["severity"], "")
+        else:
+            grp["business_impact"] = ""
         # Affected endpoints as a pill grid (3 per row). Capped at 50 per group
         # to prevent OOM when a single finding fires on thousands of URLs.
         endpoints = [(f.url.url if f.url else f.target) for f in grp["instances"]]
@@ -430,9 +442,15 @@ _BUSINESS_IMPACT = {
     "missing_csp": "A single injected script would run in your users' browsers (cross-site scripting).",
     "cve": "A publicly known vulnerability with a documented exploit is reachable from the internet.",
     "dnssec": "DNS answers for your domain can be forged, silently redirecting users to attacker servers.",
+    # Email controls — keyed by extra["control"] (all email findings share
+    # check_type="email"), resolved via the effective key below.
+    "spf": "Without a strict SPF policy, anyone can send email that appears to come from your domain.",
     "dmarc": "Anyone can send email that appears to come from your domain — brand and phishing risk.",
+    "dkim": "Recipients can't cryptographically verify your mail, so spoofed email is harder to reject.",
     "mta_sts": "Email to your mail servers can be forced down to plaintext and intercepted in transit.",
-    "rdap": "Your domain registration lapses soon — expiry means outage and a hijack window.",
+    # NOTE: no "rdap" entry — that check_type is shared by expiry AND the
+    # transfer/delete/update lock findings, so an expiry line here mis-renders on
+    # lock findings. Expiry findings carry their own dated description.
 }
 _BUSINESS_IMPACT_BY_SEV = {
     "critical": "Directly exploitable from the internet and high-impact — treat as urgent.",

--- a/apps/domain_security/checks/email.py
+++ b/apps/domain_security/checks/email.py
@@ -208,13 +208,26 @@ def _check_bimi(session, domain) -> list:
     return findings
 
 
+def _stamp(findings, control):
+    """Tag each finding with the email control it concerns (spf/dmarc/dkim/…).
+
+    All email findings share check_type="email", so the report can't tell them
+    apart by check_type. This stable `extra["control"]` key lets the report
+    attach the right per-control copy (business impact, and future CEO-question
+    grouping / next-step guidance) instead of the copy silently not rendering.
+    """
+    for f in findings:
+        f.extra = {**(f.extra or {}), "control": control}
+    return findings
+
+
 def collect_and_analyze(session, domain) -> list:
     """Run all email security checks and return list of DomainFinding objects (not yet saved)."""
     findings = []
-    findings += _check_spf(session, domain)
-    findings += _check_dmarc(session, domain)
-    findings += _check_dkim(session, domain)
-    findings += _check_mta_sts(session, domain)
-    findings += _check_tls_rpt(session, domain)
-    findings += _check_bimi(session, domain)
+    findings += _stamp(_check_spf(session, domain), "spf")
+    findings += _stamp(_check_dmarc(session, domain), "dmarc")
+    findings += _stamp(_check_dkim(session, domain), "dkim")
+    findings += _stamp(_check_mta_sts(session, domain), "mta_sts")
+    findings += _stamp(_check_tls_rpt(session, domain), "tls_rpt")
+    findings += _stamp(_check_bimi(session, domain), "bimi")
     return findings

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -515,6 +515,25 @@ class TestTopRisksAndIntel:
         assert by_sev["critical"]["business_impact"]        # populated
         assert by_sev["low"]["business_impact"] == ""       # not on low
 
+    def test_email_control_business_impact_renders(self, db, session):
+        # Email findings all share check_type="email"; the per-control impact copy
+        # is keyed on extra["control"] and must render even at medium severity.
+        self._mk(session, source="domain_security", check_type="email", severity="medium",
+                 title="DMARC policy is none (monitoring only)", target="ex.com",
+                 extra={"control": "dmarc"})
+        grp = self._groups(session)[0]
+        assert "email that appears to come from your domain" in grp["business_impact"]
+
+    def test_rdap_lock_finding_has_no_expiry_line(self, db, session):
+        # The transfer/delete/update lock findings share check_type="rdap" with
+        # expiry findings — the expiry business-impact line must not render on them.
+        self._mk(session, source="domain_security", check_type="rdap", severity="medium",
+                 title="Domain transfer lock not enabled", target="ex.com",
+                 extra={"statuses": []})
+        grp = self._groups(session)[0]
+        assert "expiry" not in grp["business_impact"].lower()
+        assert grp["business_impact"] == ""   # medium + no specific copy → empty
+
     def test_report_renders_headline_and_snapshot(self, authed_client, session):
         self._mk(session, title="Unencrypted POSTGRESQL")
         captured = {}


### PR DESCRIPTION
First PR of the Domain Intelligence report cleanup. Fixes two report-copy bugs, both rooted in `check_type` being too coarse.

## 1. DMARC / MTA-STS / SPF / DKIM business-impact copy never rendered
All email findings share `check_type="email"`, but `_BUSINESS_IMPACT` was keyed by control names (`dmarc`, `mta_sts`, …) — so the lookup **never matched** and these findings silently fell back to generic severity text (or nothing at medium).

- Stamp each email finding with `extra["control"]` (spf/dmarc/dkim/mta_sts/bimi/tls_rpt).
- Report resolves copy via an **effective key** (control for email findings, else check_type).
- Added SPF + DKIM impact copy (DMARC/MTA-STS existed but were unreachable).
- Per-control copy now renders at **any severity** (many email-auth gaps are medium but still worth explaining); the generic severity fallback stays limited to critical/high.

## 2. Expiry line mis-rendered on registrar-lock findings
`check_type="rdap"` is shared by the expiry findings **and** the transfer/delete/update **lock** findings, so `_BUSINESS_IMPACT["rdap"]` (*"…registration lapses soon — expiry…"*) attached to lock findings. Removed that entry — expiry findings carry their own dated description.

## Verification
New tests: email-control impact renders (medium DMARC), rdap lock finding shows no expiry line. Full reports suite **59 passed**, ruff + check clean.

## Roadmap context
This is item "Fix report copy that never renders (DMARC, MTA STS, SPF, DKIM) + remove the expiry line from registrar lock findings." The `extra["control"]` key also sets up later items (CEO-question grouping, per-finding next-step guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv