### PR TITLE
fix: DI finding edits — DNSSEC/MTA-STS severity, DKIM wording, live email control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Domain Intelligence finding tuning (report roadmap, Edit bucket).**
+  - **DNSSEC** ("not enabled" and "chain of trust broken") and **MTA-STS** ("not
+    configured") dropped from **high → medium** — real hygiene gaps, but not
+    directly exploitable at high. (The DNSSEC "DS published but DNSKEY missing"
+    case stays high — it causes actual resolution failure.)
+  - **DKIM** finding reworded "DKIM record not found" → **"DKIM could not be
+    confirmed"** — DKIM uses a per-provider selector that can't always be
+    discovered, so absence at common selectors is a lookup limitation, not proof.
+
+### Fixed
+- **Email report copy now actually renders (completes the v2.10.x fix).** The
+  earlier per-control business-impact fix stamped `extra["control"]` in a
+  **dead** module (`checks/email.py`), while the live email checks live in
+  `scanner.py::_check_email` — so real email findings carried no `control` and
+  the copy still didn't render. Stamped the live path (spf/dmarc/dkim/mta_sts/
+  tls_rpt/bimi), with a regression test. (`checks/{email,dns,rdap}.py`
+  `collect_and_analyze` are dead code — flagged for a follow-up removal.)
+
 ### Added
 - **typosquat now scores weaponization, not just registration.** For registered
   lookalikes that serve web (have an A record), it fetches the homepage

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -249,7 +249,7 @@ def _check_dnssec(session, domain) -> list:
     if not has_dnskey and not has_ds:
         return [Finding(
             session=session, source="domain_security", target=domain,
-            check_type="dnssec", severity="high",
+            check_type="dnssec", severity="medium",
             title="DNSSEC not enabled",
             description=(
                 f"{domain} has no DNSSEC configured. DNS responses can be forged — "
@@ -269,7 +269,7 @@ def _check_dnssec(session, domain) -> list:
     if has_dnskey and not has_ds:
         return [Finding(
             session=session, source="domain_security", target=domain,
-            check_type="dnssec", severity="high",
+            check_type="dnssec", severity="medium",
             title="DNSSEC chain of trust broken — DS record not published",
             description=(
                 f"{domain} has DNSKEY records but the DS record is not published at the "
@@ -463,8 +463,14 @@ def _check_dkim(session, domain) -> list:
         findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
             severity="medium",
-            title="DKIM record not found",
-            description=f"No DKIM record found for common selectors on {domain}.",
+            title="DKIM could not be confirmed",
+            description=(
+                f"DKIM could not be confirmed for {domain}: no DKIM record was found at "
+                "the common selectors checked. DKIM uses a per-provider selector that "
+                "can't always be discovered without knowing it, so this may be a lookup "
+                "limitation rather than a definitively missing record — verify against "
+                "your mail provider's published selector."
+            ),
             remediation="Configure DKIM signing with your email provider and publish the public key as a TXT record.",
         ))
 
@@ -486,7 +492,7 @@ def _check_mta_sts(session, domain) -> list:
     if not mta_sts_dns:
         findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
-            severity="high",
+            severity="medium",
             title="MTA-STS not configured",
             description=(
                 f"{domain} has no MTA-STS policy. Email delivery to your mail server is not "
@@ -663,16 +669,28 @@ def _check_bimi(session, domain) -> list:
     return findings
 
 
+def _stamp_control(findings, control):
+    """Tag email findings with the control they concern (spf/dmarc/dkim/…).
+
+    All email findings share check_type="email", so the report keys its
+    per-control business-impact copy on extra["control"] instead. Without this
+    the copy silently doesn't render (the report resolves it via this key).
+    """
+    for f in findings:
+        f.extra = {**(f.extra or {}), "control": control}
+    return findings
+
+
 def _check_email(session, domain) -> list:
-    """Run all email security checks and return list of DomainFinding objects (not yet saved)."""
+    """Run all email security checks and return list of Finding objects (not yet saved)."""
     findings = []
-    findings += _check_spf(session, domain)
-    findings += _check_dmarc(session, domain)
-    findings += _check_dkim(session, domain)
-    findings += _check_mta_sts(session, domain)
-    findings += _check_open_relay(session, domain)
-    findings += _check_tls_rpt(session, domain)
-    findings += _check_bimi(session, domain)
+    findings += _stamp_control(_check_spf(session, domain), "spf")
+    findings += _stamp_control(_check_dmarc(session, domain), "dmarc")
+    findings += _stamp_control(_check_dkim(session, domain), "dkim")
+    findings += _stamp_control(_check_mta_sts(session, domain), "mta_sts")
+    findings += _stamp_control(_check_open_relay(session, domain), "open_relay")
+    findings += _stamp_control(_check_tls_rpt(session, domain), "tls_rpt")
+    findings += _stamp_control(_check_bimi(session, domain), "bimi")
     return findings
 
 

--- a/tests/integration/test_scan_flow.py
+++ b/tests/integration/test_scan_flow.py
@@ -91,7 +91,7 @@ class TestDomainSecurityScanFlow:
         titles = [f.title for f in findings]
         assert "SPF record missing" in titles
         assert "DMARC record missing" in titles
-        assert "DKIM record not found" in titles
+        assert "DKIM could not be confirmed" in titles
 
         high_findings = [f for f in findings if f.severity == "high"]
         assert len(high_findings) >= 2

--- a/tests/unit/test_domain_security.py
+++ b/tests/unit/test_domain_security.py
@@ -84,7 +84,7 @@ class TestDNSChecks:
         titles = [f.title for f in findings]
         assert "No NS records found" in titles
 
-    def test_dnssec_not_enabled_creates_high_finding(self, db):
+    def test_dnssec_not_enabled_creates_medium_finding(self, db):
         from apps.domain_security.scanner import _check_dnssec
         session = self._make_session(db)
 
@@ -95,7 +95,7 @@ class TestDNSChecks:
         assert len(findings) == 1
         f = findings[0]
         assert f.title == "DNSSEC not enabled"
-        assert f.severity == "high"
+        assert f.severity == "medium"
         assert f.check_type == "dnssec"
 
     def test_dnssec_broken_chain_dnskey_no_ds(self, db):
@@ -114,7 +114,7 @@ class TestDNSChecks:
         assert len(findings) == 1
         f = findings[0]
         assert "chain of trust broken" in f.title
-        assert f.severity == "high"
+        assert f.severity == "medium"
         assert f.extra == {"has_dnskey": True, "has_ds": False}
 
     def test_dnssec_broken_ds_no_dnskey(self, db):
@@ -250,7 +250,18 @@ class TestEmailChecks:
             findings = _check_email(session, "example.com")
 
         titles = [f.title for f in findings]
-        assert "DKIM record not found" in titles
+        assert "DKIM could not be confirmed" in titles
+
+    def test_email_findings_are_stamped_with_control(self, db):
+        # The LIVE email path must tag each finding with extra["control"], or the
+        # report's per-control business-impact copy silently won't render.
+        from apps.domain_security.scanner import _check_email
+        session = self._make_session(db)
+        with patch("apps.domain_security.scanner._get_txt_record", return_value=[]), \
+             patch("apps.domain_security.scanner._check_open_relay", return_value=[]):
+            findings = _check_email(session, "example.com")
+        controls = {f.extra.get("control") for f in findings if isinstance(f.extra, dict)}
+        assert {"spf", "dmarc", "dkim", "mta_sts"} <= controls
 
 
 # ---------------------------------------------------------------------------
@@ -636,7 +647,7 @@ class TestMTASTSChecks:
             findings = _check_mta_sts(session, "example.com")
 
         assert len(findings) == 1
-        assert findings[0].severity == "high"
+        assert findings[0].severity == "medium"
         assert "MTA-STS not configured" in findings[0].title
 
     def test_dns_record_present_but_policy_file_unreachable_creates_high_finding(self, db):


### PR DESCRIPTION
Roadmap **Edit** bucket (items 1–3).

### 1. Severity — DNSSEC & MTA-STS from HIGH → MEDIUM
- `DNSSEC not enabled` and `DNSSEC chain of trust broken` → **medium** (real hygiene gaps, not directly exploitable at high). The `DS published but DNSKEY missing` case **stays high** — it causes actual resolution failure/outage on DNSSEC-enforcing networks.
- `MTA-STS not configured` → **medium**.

### 2. DKIM wording
`DKIM record not found` → **`DKIM could not be confirmed`**. DKIM uses a per-provider selector that can't always be discovered without knowing it, so absence at common selectors is a lookup limitation, not proof.

### 3. Action line on infostealer/breach findings
Already present — both `hudson_rock` and `breach_check` remediation already lead with credential reset + MFA. **No change needed** (flagging so it's not lost).

## Also fixes an inert earlier change (important)
While doing this I found the earlier per-control business-impact fix (#410) stamped `extra["control"]` in **`checks/email.py` — which is dead code**. The live email checks are `scanner.py::_check_email`. So real email findings carried **no** `control`, and the report's per-control copy **still wasn't rendering in production**. This PR stamps the **live** path (spf/dmarc/dkim/mta_sts/tls_rpt/bimi) with a regression test, completing the fix.

`checks/{email,dns,rdap}.py::collect_and_analyze` are dead (imported nowhere) — flagged for a follow-up removal PR.

## Verification
Mocked DNSSEC/email unit tests + full reports suite — **72 passed**. New test asserts the live email path stamps `control`. check + ruff clean. (`test_domain_security.py` severity/title assertions updated to match.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv