### PR TITLE
feat: 'The Five Questions' executive block in the PDF report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **"The Five Questions" executive block in the PDF report.** The report now
+  opens (in the Executive Summary) by answering the five questions a
+  decision-maker actually asks — Can someone spoof our email? · Can we lose our
+  domain? · Are staff logins stolen? · Is anyone impersonating us? · Did we leak
+  keys? — each mapped to the relevant findings with a status: at risk (a
+  critical/high), needs attention (medium/low), no issues found, or **not
+  assessed** (the tool that answers it wasn't in this scan — an honest state, not
+  a false all-clear).
+
 ### Changed
 - **Domain Intelligence finding tuning (report roadmap, Edit bucket).**
   - **DNSSEC** ("not enabled" and "chain of trust broken") and **MTA-STS** ("not

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -537,6 +537,52 @@ def _render_pdf(html: str) -> bytes:
     return HTML(string=html).write_pdf()
 
 
+# The five questions a decision-maker actually asks, mapped to the findings that
+# answer them. `tools` = the scanners that assess this question, so we can say
+# "not checked" (tool didn't run) instead of a misleading "no issues found".
+_CEO_QUESTIONS = [
+    ("Can someone spoof our email?", {"domain_security"},
+     lambda g: g["source"] == "domain_security" and g["check_type"] == "email"),
+    ("Can we lose our domain?", {"domain_security"},
+     lambda g: g["source"] == "domain_security" and g["check_type"] in ("rdap", "dnssec")),
+    ("Are staff logins stolen?", {"hudson_rock", "breach_check"},
+     lambda g: g["source"] in ("hudson_rock", "breach_check")),
+    ("Is anyone impersonating us?", {"typosquat"},
+     lambda g: g["source"] == "typosquat"),
+    ("Did we leak keys?", {"js_secrets", "github_secrets"},
+     lambda g: g["source"] in ("js_secrets", "github_secrets") or g["check_type"] == "exposed_secret"),
+]
+
+
+def _ceo_questions(issue_groups, active_tools):
+    """Answer each executive question from the findings, so the report opens with
+    the business picture before the technical detail.
+
+    Status per question: at_risk (a critical/high finding), attention (only
+    medium/low/info), clear (the tool ran and found nothing), or not_checked
+    (the assessing tool wasn't in this scan) — the last avoids a false all-clear.
+    """
+    active = set(active_tools)
+    out = []
+    for question, tools, match in _CEO_QUESTIONS:
+        matched = [g for g in issue_groups if match(g)]
+        if matched:
+            has_high = any(g["severity"] in ("critical", "high") for g in matched)
+            status = "at_risk" if has_high else "attention"
+        elif tools & active:
+            status = "clear"
+        else:
+            status = "not_checked"
+        out.append({
+            "question": question,
+            "status": status,
+            "issue_count": len(matched),
+            "instance_count": sum(len(g["instances"]) for g in matched),
+            "issues": matched,
+        })
+    return out
+
+
 @_report_auth_required
 def export_scan_pdf(request, session_uuid):
     """Export a scan report as PDF, optionally filtered by ?min_severity=."""
@@ -627,6 +673,10 @@ def export_scan_pdf(request, session_uuid):
     )
     core_tools = {n for n, i in registry.items() if i.get("core")}
     active_tools = workflow_tools | core_tools
+
+    # Executive framing: the five questions a decision-maker asks, answered from
+    # the findings (rendered as the report's opening summary).
+    ceo_questions = _ceo_questions(issue_groups, active_tools)
     src_counts = {}
     for row in findings.order_by().values("source").annotate(n=Count("id")):
         src_counts[row["source"]] = row["n"]
@@ -688,6 +738,7 @@ def export_scan_pdf(request, session_uuid):
         "total_findings": len(issue_groups),   # headline = unique issue count
         "raw_total": raw_total,                # raw detections, shown only in the note
         "risk_rating": risk_rating,
+        "ceo_questions": ceo_questions,
         "exposure_score": exposure_score,
         "exposure_grade": exposure_grade,
         "exposure_trend": exposure_trend,

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -192,6 +192,29 @@
 </div>
 {% endif %}
 
+{% if ceo_questions %}
+<div class="h2">The Five Questions</div>
+<p class="lead">The questions a decision-maker actually asks, answered from this scan.</p>
+<table class="grid no-break">
+  <thead><tr><th style="width:58%;">Question</th><th style="width:42%;">Answer</th></tr></thead>
+  <tbody>
+    {% for q in ceo_questions %}
+    <tr>
+      <td><strong>{{ q.question }}</strong></td>
+      <td>
+        {% if q.status == "at_risk" %}<strong style="color:#e03131;">At risk</strong> — {{ q.issue_count }} finding{{ q.issue_count|pluralize }}
+        {% elif q.status == "attention" %}<strong style="color:#e8590c;">Needs attention</strong> — {{ q.issue_count }} finding{{ q.issue_count|pluralize }}
+        {% elif q.status == "clear" %}<strong style="color:#2f9e44;">No issues found</strong>
+        {% else %}<span style="color:#868e96;">Not assessed in this scan</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<p class="lead" style="font-size:9px;color:#666;">"Not assessed" means the check for that question was not part of this scan's workflow — not that it is clear.</p>
+{% endif %}
+
 <p class="lead" style="font-style:italic;font-size:9px;color:#666;">This is a point-in-time snapshot of the externally observable attack surface, taken from the public internet. It does not include authenticated, internal, or manual testing, and an attack surface changes over time — treat it as a baseline, not a certificate.</p>
 
 {% if coverage %}

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -747,6 +747,45 @@ def test_every_emitted_check_type_has_cwe_mapping():
 
 
 # ---------------------------------------------------------------------------
+# The Five Questions (CEO-question executive framing)
+# ---------------------------------------------------------------------------
+
+class TestCeoQuestions:
+    def _g(self, source, check_type, severity="high", n=1):
+        return {"source": source, "check_type": check_type,
+                "severity": severity, "instances": [object()] * n}
+
+    def _by_q(self, groups, active):
+        from apps.core.console.reports.views import _ceo_questions
+        return {q["question"]: q for q in _ceo_questions(groups, active)}
+
+    def test_email_finding_maps_to_spoof_question(self):
+        qs = self._by_q([self._g("domain_security", "email")], {"domain_security"})
+        assert qs["Can someone spoof our email?"]["status"] == "at_risk"
+
+    def test_dnssec_rdap_maps_to_lose_domain(self):
+        qs = self._by_q([self._g("domain_security", "dnssec", "medium")], {"domain_security"})
+        assert qs["Can we lose our domain?"]["status"] == "attention"
+
+    def test_typosquat_maps_to_impersonation(self):
+        qs = self._by_q([self._g("typosquat", "lookalike_domain", "medium")], {"typosquat"})
+        assert qs["Is anyone impersonating us?"]["status"] == "attention"
+
+    def test_tool_not_run_is_not_checked(self):
+        # No breach tools in the scan → honest "not checked", not a false all-clear.
+        qs = self._by_q([], set())
+        assert qs["Are staff logins stolen?"]["status"] == "not_checked"
+
+    def test_tool_ran_no_findings_is_clear(self):
+        qs = self._by_q([], {"breach_check"})
+        assert qs["Are staff logins stolen?"]["status"] == "clear"
+
+    def test_all_five_questions_present(self):
+        qs = self._by_q([], {"domain_security"})
+        assert len(qs) == 5
+
+
+# ---------------------------------------------------------------------------
 # AI Analyst Summary block (apps/core/console/ai integration)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Roadmap **Edit** item 5 — group the report under the five CEO questions.

## What
The PDF report's **Executive Summary** now opens with the questions a decision-maker actually asks, each answered from this scan's findings:

| Question | Answered from |
|---|---|
| Can someone spoof our email? | domain_security email controls (SPF/DMARC/DKIM/MTA-STS/…) |
| Can we lose our domain? | RDAP locks/expiry + DNSSEC |
| Are staff logins stolen? | hudson_rock (infostealer) + breach_check |
| Is anyone impersonating us? | typosquat (lookalike domains) |
| Did we leak keys? | js_secrets + github_secrets |

**Status per question:** *At risk* (a critical/high finding), *Needs attention* (medium/low), *No issues found* (the tool ran and found nothing), or ***Not assessed*** — the tool that answers it wasn't in this scan. That last state is deliberate: it avoids a **false all-clear** on a question the scan never actually checked (e.g. breach_check not in the workflow).

The detailed findings section below is unchanged — this is an executive framing on top, not a reorg of the technical detail.

## Verification
`_ceo_questions` helper + 6 unit tests (question mapping, severity→status, tool-not-run → not_checked, tool-ran-clean → clear, all five present). Full reports suite **65 passed** (renders the template, so the new block renders clean). check + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv