### PR TITLE
fix: trim the buyer report (Delete/hide bucket)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Trimmed the buyer-facing report (roadmap Delete/hide bucket).** These are
+  still stored and shown in the app — just removed from the exported PDF/CSV:
+  - **BIMI not configured** and **Domain update lock not enabled** findings are
+    suppressed from the report (marketing / lowest-value noise).
+  - **RDAP lookup failed** is no longer a finding in the report — it's surfaced
+    as a "Registration Data Unavailable" **coverage caveat** instead (the lookup
+    didn't fail *security*, it just couldn't be completed).
+  - **dns_history** and **github_secrets** are hidden from the report's Scope &
+    Methodology when unconfigured (no DNS-history URL / no GitHub token) — so the
+    report never implies a check that couldn't run. (Also keeps the "Did we leak
+    keys?" question honest when github_secrets is inert.)
+
 ### Added
 - **"The Five Questions" executive block in the PDF report.** The report now
   opens (in the Executive Summary) by answering the five questions a

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -295,7 +295,11 @@ def export_findings_csv(request, session_uuid):
     severities, err = _parse_min_severity(request)
     if err:
         return err
-    findings = Finding.objects.filter(session=session, severity__in=severities).order_by("severity", "source")
+    findings = (
+        Finding.objects.filter(session=session, severity__in=severities)
+        .exclude(title__in=_REPORT_HIDDEN_TITLES)
+        .order_by("severity", "source")
+    )
 
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = (
@@ -537,6 +541,25 @@ def _render_pdf(html: str) -> bytes:
     return HTML(string=html).write_pdf()
 
 
+# Findings hidden from the buyer-facing report (PDF + CSV) — still stored and
+# shown in the app, just noise in a report: BIMI (marketing, not security),
+# the update-lock (lowest-value registrar lock), and the RDAP-lookup-failed
+# notice (surfaced instead as a coverage caveat).
+_REPORT_HIDDEN_TITLES = frozenset({
+    "BIMI not configured",
+    "Domain update lock not enabled",
+    "RDAP lookup failed",
+})
+
+# Passive tools that no-op without a data source / key — hidden from the report's
+# scope & methodology when unconfigured so the report doesn't imply they assessed
+# anything. Keyed by the credential that activates each.
+_REPORT_TOOL_REQUIRES = {
+    "github_secrets": "GITHUB_TOKEN",
+    "dns_history": "DNS_HISTORY_API_URL",
+}
+
+
 # The five questions a decision-maker actually asks, mapped to the findings that
 # answer them. `tools` = the scanners that assess this question, so we can say
 # "not checked" (tool didn't run) instead of a misleading "no issues found".
@@ -593,6 +616,10 @@ def export_scan_pdf(request, session_uuid):
     findings = Finding.objects.filter(session=session, severity__in=severities).select_related("port", "url").order_by(
         "severity", "-discovered_at"
     )
+    # RDAP failure is surfaced as a coverage caveat, not a finding — capture it
+    # before suppressing the hidden titles from the buyer report.
+    rdap_unavailable = findings.filter(title="RDAP lookup failed").exists()
+    findings = findings.exclude(title__in=_REPORT_HIDDEN_TITLES)
 
     # Severity counts. Reset the queryset ordering with .order_by() first: the
     # `findings` queryset is ordered by (severity, -discovered_at), and that
@@ -674,6 +701,16 @@ def export_scan_pdf(request, session_uuid):
     core_tools = {n for n, i in registry.items() if i.get("core")}
     active_tools = workflow_tools | core_tools
 
+    # Drop passive tools that were in the workflow but couldn't do anything for
+    # lack of a key/data source — they didn't actually assess the target, so the
+    # buyer report shouldn't list them as coverage (also keeps the CEO "Did we
+    # leak keys?" honest).
+    from apps.core.console.credentials.resolver import get_credential
+    active_tools = {
+        t for t in active_tools
+        if t not in _REPORT_TOOL_REQUIRES or get_credential(_REPORT_TOOL_REQUIRES[t])
+    }
+
     # Executive framing: the five questions a decision-maker asks, answered from
     # the findings (rendered as the report's opening summary).
     ceo_questions = _ceo_questions(issue_groups, active_tools)
@@ -745,6 +782,7 @@ def export_scan_pdf(request, session_uuid):
         "top_risks": top_risks,
         "headline_risk": top_risks[0] if top_risks else None,
         "coverage": _coverage_context(session),
+        "rdap_unavailable": rdap_unavailable,
         "asset_counts": asset_counts,
         "technologies": technologies,
         "methodology": methodology,

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -224,6 +224,13 @@
 </div>
 {% endif %}
 
+{% if rdap_unavailable %}
+<div class="risk no-break" style="border-color:#868e96;">
+  <div class="l" style="color:#868e96;">Scan Coverage — Registration Data Unavailable</div>
+  <p style="margin:6px 0 0;font-size:10px;line-height:1.5;">RDAP registration data could not be retrieved for {{ session.domain }}, so registrar, domain-expiry, and transfer/delete/update-lock checks could not be completed. This is a coverage gap, not a finding — re-run once RDAP is reachable for the domain's TLD.</p>
+</div>
+{% endif %}
+
 {% if top_risks %}
 <div class="h2">Priority Actions — Fix These First</div>
 <p class="lead">The highest-impact issues, ranked. Actively-exploited (CISA KEV) and internet-facing critical issues come first. The full list is in Section 3.</p>

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -103,6 +103,22 @@ class TestExportFindingsCsv:
         assert "TLS expired" in content
         assert "No DMARC" in content
 
+    def test_hidden_titles_excluded_from_csv(self, authed_client, session):
+        from apps.core.data.findings.models import Finding
+        for t in ("BIMI not configured", "Domain update lock not enabled", "RDAP lookup failed"):
+            Finding.objects.create(session=session, source="domain_security",
+                                   target=session.domain, check_type="rdap",
+                                   severity="info", title=t, description="d", remediation="r")
+        Finding.objects.create(session=session, source="domain_security",
+                               target=session.domain, check_type="dnssec",
+                               severity="medium", title="DNSSEC not enabled",
+                               description="d", remediation="r")
+        content = authed_client.get(f"/reports/{session.uuid}/csv/").content.decode("utf-8")
+        assert "BIMI not configured" not in content
+        assert "Domain update lock not enabled" not in content
+        assert "RDAP lookup failed" not in content
+        assert "DNSSEC not enabled" in content   # a normal finding still exported
+
     def test_csv_empty_when_no_findings(self, authed_client, session):
         res = authed_client.get(f"/reports/{session.uuid}/csv/")
         content = res.content.decode("utf-8")
@@ -562,6 +578,39 @@ class TestTopRisksAndIntel:
             res = authed_client.get(f"/reports/{session.uuid}/pdf/")
         assert res.status_code == 200
         assert "Priority Actions" in captured["html"]
+
+    def test_hidden_findings_absent_from_pdf(self, authed_client, session):
+        self._mk(session, source="domain_security", check_type="email", severity="info",
+                 title="BIMI not configured", target="ex.com")
+        self._mk(session, title="Unencrypted POSTGRESQL")  # a normal finding
+        captured = {}
+        with patch("apps.core.console.reports.views._render_pdf",
+                   side_effect=lambda h: captured.update(html=h) or b"%PDF-1.7"):
+            authed_client.get(f"/reports/{session.uuid}/pdf/")
+        assert "BIMI not configured" not in captured["html"]
+        assert "Unencrypted POSTGRESQL" in captured["html"]
+
+    def test_rdap_failure_becomes_coverage_note(self, authed_client, session):
+        self._mk(session, source="domain_security", check_type="rdap", severity="info",
+                 title="RDAP lookup failed", target="ex.com")
+        captured = {}
+        with patch("apps.core.console.reports.views._render_pdf",
+                   side_effect=lambda h: captured.update(html=h) or b"%PDF-1.7"):
+            authed_client.get(f"/reports/{session.uuid}/pdf/")
+        assert "Registration Data Unavailable" in captured["html"]  # coverage caveat
+        assert "RDAP lookup failed" not in captured["html"]          # not a finding row
+
+    def test_unconfigured_tools_hidden_from_methodology(self, authed_client, session):
+        # github_secrets / dns_history no-op without a key/URL — the report must not
+        # list them as coverage (would imply an assessment that didn't happen).
+        self._mk(session, title="Unencrypted POSTGRESQL")
+        captured = {}
+        with patch("apps.core.console.credentials.resolver.get_credential", return_value=""), \
+             patch("apps.core.console.reports.views._render_pdf",
+                   side_effect=lambda h: captured.update(html=h) or b"%PDF-1.7"):
+            authed_client.get(f"/reports/{session.uuid}/pdf/")
+        assert "Historical DNS Records" not in captured["html"]   # dns_history hidden
+        assert "GitHub Secret Exposure" not in captured["html"]   # github_secrets hidden
         assert "KEV" in captured["html"]
 
 


### PR DESCRIPTION
Roadmap **Delete/hide** bucket — all five items. Everything here is **report-only**; the findings/tools are still stored and shown in the app, just cleaned out of the exported PDF/CSV.

## Changes
- **BIMI not configured** and **Domain update lock not enabled** — suppressed from PDF + CSV (marketing / lowest-value noise). Applied via `_REPORT_HIDDEN_TITLES` on the findings query, **before** counts/score/groups so they don't skew the report.
- **RDAP lookup failed** — no longer a finding in the report. Surfaced instead as a **"Registration Data Unavailable" coverage caveat** (the lookup didn't fail *security*, it just couldn't complete).
- **dns_history** + **github_secrets** — hidden from the report's **Scope & Methodology** when unconfigured (no DNS-history URL / no GitHub token), so the report never implies a check that couldn't run. Also keeps the CEO **"Did we leak keys?"** answer honest when github_secrets is inert.

## Verification
5 new tests: CSV suppression, PDF suppression, RDAP→coverage note, methodology tool-hiding. Full reports suite **69 passed**; check + ruff clean.

## Roadmap status
This completes the **Edit** and **Delete/hide** buckets. Remaining: the **Build** bucket (passive/active split, web-presence check, DKIM selector inference, "since last month" block, per-finding next-steps) + the dead `checks/` module cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv