### PR TITLE
chore: release v2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.11.0] — 2026-09-10
+
 ### Changed
 - **Trimmed the buyer-facing report (roadmap Delete/hide bucket).** These are
   still stored and shown in the app — just removed from the exported PDF/CSV:
@@ -1316,7 +1318,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.10.1...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.11.0...HEAD
+[v2.11.0]: https://github.com/cybersecify/OpenEASD/compare/v2.10.1...v2.11.0
 [v2.10.1]: https://github.com/cybersecify/OpenEASD/compare/v2.10.0...v2.10.1
 [v2.10.0]: https://github.com/cybersecify/OpenEASD/compare/v2.9.1...v2.10.0
 [v2.9.1]: https://github.com/cybersecify/OpenEASD/compare/v2.9.0...v2.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.10.1"
+version = "2.11.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.10.1"
+version = "2.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release — the Domain Intelligence report roadmap (Edit + Delete/hide buckets) + typosquat weaponization.

### Added
- **typosquat weaponization scoring** (#411) — login-form / brand-impersonation detection → HIGH for active phishing lookalikes.
- **"The Five Questions" executive block** in the PDF report (#413).

### Changed
- **DI finding tuning** (#412) — DNSSEC/MTA-STS high→medium; DKIM "could not be confirmed".
- **Buyer report trimmed** (#414) — BIMI/update-lock suppressed; RDAP-failed → coverage note; dns_history/github_secrets hidden when unconfigured.

### Fixed
- **Email report copy now renders** (#410 + #412) — per-control business-impact copy (was landing in dead code); DKIM/DMARC/SPF/MTA-STS.

Version `2.10.1 → 2.11.0`; CHANGELOG + compare links added. Tag pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv