### PR TITLE
feat: DKIM selector inference from MX/SPF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **DKIM selector inference from MX/SPF.** DKIM selectors are per-provider and
+  not discoverable from the domain, so the old check tried only a fixed common
+  list. It now fingerprints the mail provider from MX and SPF records (Google
+  Workspace, Microsoft 365, Zoho, Amazon SES, SendGrid, Mailchimp, Fastmail,
+  Proofpoint) and checks that provider's known selectors first. This confirms
+  DKIM in more cases, and when it still can't, the "DKIM could not be confirmed"
+  finding names the detected provider and records the selectors checked — so a
+  missing record reads as more likely genuine.
+
 ### Removed
 - **Dead `apps/domain_security/checks/` package** (`email.py`, `dns.py`,
   `rdap.py`, `__init__.py`). Their `collect_and_analyze` functions were imported

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -450,28 +450,76 @@ def _check_dmarc(session, domain) -> list:
     return findings
 
 
+# Mail-provider fingerprints (in MX / SPF) → that provider's known DKIM
+# selectors. DKIM selectors are provider-specific and not otherwise discoverable
+# from the domain, so inferring the provider lets the check try the RIGHT
+# selector instead of only a generic guess list.
+_DKIM_PROVIDER_SELECTORS = [
+    ("Google Workspace", ("google.com", "googlemail.com", "_spf.google.com"), ["google"]),
+    ("Microsoft 365", ("mail.protection.outlook.com", "spf.protection.outlook.com"), ["selector1", "selector2"]),
+    ("Zoho", ("zoho.com", "zoho.eu", "zohomail"), ["zoho", "zmail"]),
+    ("Amazon SES", ("amazonses.com",), ["amazonses"]),
+    ("SendGrid", ("sendgrid.net",), ["s1", "s2"]),
+    ("Mailchimp/Mandrill", ("mcsv.net", "mandrillapp.com"), ["k1", "k2", "k3", "mandrill"]),
+    ("Fastmail", ("messagingengine.com",), ["fm1", "fm2", "fm3", "mesmtp"]),
+    ("Proofpoint", ("pphosted.com", "ppe-hosted.com"), ["selector1", "selector2"]),
+]
+
+
+def _infer_dkim_selectors(domain):
+    """Guess the mail provider from MX + SPF and return (provider, [selectors]).
+
+    Returns (None, []) when no known provider is matched. Never raises.
+    """
+    try:
+        mx = " ".join(_resolve(domain, "MX")).lower()
+        spf = " ".join(
+            r for r in _get_txt_record(domain) if r.lower().startswith("v=spf1")
+        ).lower()
+    except Exception:  # noqa: BLE001 — inference is best-effort
+        return None, []
+    haystack = f"{mx} {spf}"
+    for provider, fingerprints, selectors in _DKIM_PROVIDER_SELECTORS:
+        if any(fp in haystack for fp in fingerprints):
+            return provider, selectors
+    return None, []
+
+
 def _check_dkim(session, domain) -> list:
     findings = []
+    provider, inferred = _infer_dkim_selectors(domain)
+    # Try the inferred provider's selectors first, then the generic common list.
+    selectors = inferred + [s for s in DKIM_SELECTORS if s not in inferred]
     dkim_found = False
-    for selector in DKIM_SELECTORS:
+    for selector in selectors:
         records = _get_txt_record(f"{selector}._domainkey.{domain}")
         if any("v=DKIM1" in r for r in records):
             dkim_found = True
             break
 
     if not dkim_found:
+        if provider:
+            provider_line = (
+                f" Detected mail provider: {provider} — its known selectors were "
+                "checked along with common ones, so a missing record is more likely genuine."
+            )
+        else:
+            provider_line = (
+                " DKIM uses a per-provider selector that can't always be discovered "
+                "without knowing it, so this may be a lookup limitation rather than a "
+                "definitively missing record."
+            )
         findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
             severity="medium",
             title="DKIM could not be confirmed",
             description=(
                 f"DKIM could not be confirmed for {domain}: no DKIM record was found at "
-                "the common selectors checked. DKIM uses a per-provider selector that "
-                "can't always be discovered without knowing it, so this may be a lookup "
-                "limitation rather than a definitively missing record — verify against "
-                "your mail provider's published selector."
+                f"the selectors checked.{provider_line} Verify against your mail "
+                "provider's published selector."
             ),
             remediation="Configure DKIM signing with your email provider and publish the public key as a TXT record.",
+            extra={"mail_provider": provider, "selectors_checked": selectors},
         ))
 
     return findings

--- a/tests/unit/test_domain_security.py
+++ b/tests/unit/test_domain_security.py
@@ -153,6 +153,13 @@ class TestDNSChecks:
 
 @pytest.mark.django_db
 class TestEmailChecks:
+    @pytest.fixture(autouse=True)
+    def _no_real_dns(self):
+        # DKIM selector inference (and open-relay) resolve MX via _resolve; keep
+        # these mocked email tests off the network. Individual tests override it.
+        with patch("apps.domain_security.scanner._resolve", return_value=[]):
+            yield
+
     def _make_session(self, db):
         from apps.core.engine.scans.models import ScanSession
         return ScanSession.objects.create(domain="example.com", scan_type="full", status="pending")
@@ -262,6 +269,62 @@ class TestEmailChecks:
             findings = _check_email(session, "example.com")
         controls = {f.extra.get("control") for f in findings if isinstance(f.extra, dict)}
         assert {"spf", "dmarc", "dkim", "mta_sts"} <= controls
+
+
+# ---------------------------------------------------------------------------
+# DKIM selector inference (from MX / SPF)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestDkimInference:
+    def _make_session(self, db):
+        from apps.core.engine.scans.models import ScanSession
+        return ScanSession.objects.create(domain="example.com", scan_type="full", status="pending")
+
+    def test_infers_google_from_mx(self):
+        from apps.domain_security.scanner import _infer_dkim_selectors
+        with patch("apps.domain_security.scanner._resolve", return_value=["10 aspmx.l.google.com."]), \
+             patch("apps.domain_security.scanner._get_txt_record", return_value=[]):
+            provider, sels = _infer_dkim_selectors("example.com")
+        assert provider == "Google Workspace"
+        assert "google" in sels
+
+    def test_infers_m365_from_spf(self):
+        from apps.domain_security.scanner import _infer_dkim_selectors
+        with patch("apps.domain_security.scanner._resolve", return_value=[]), \
+             patch("apps.domain_security.scanner._get_txt_record",
+                   return_value=["v=spf1 include:spf.protection.outlook.com -all"]):
+            provider, sels = _infer_dkim_selectors("example.com")
+        assert provider == "Microsoft 365"
+        assert sels == ["selector1", "selector2"]
+
+    def test_no_provider_match(self):
+        from apps.domain_security.scanner import _infer_dkim_selectors
+        with patch("apps.domain_security.scanner._resolve", return_value=["10 mail.acme.example."]), \
+             patch("apps.domain_security.scanner._get_txt_record", return_value=[]):
+            assert _infer_dkim_selectors("example.com") == (None, [])
+
+    def test_dkim_found_at_inferred_selector_no_finding(self, db):
+        from apps.domain_security.scanner import _check_dkim
+        session = self._make_session(db)
+
+        def txt(name):
+            return ["v=DKIM1; k=rsa; p=x"] if name.startswith("google._domainkey") else []
+
+        with patch("apps.domain_security.scanner._resolve", return_value=["1 aspmx.l.google.com."]), \
+             patch("apps.domain_security.scanner._get_txt_record", side_effect=txt):
+            findings = _check_dkim(session, "example.com")
+        assert findings == []   # confirmed via the inferred google selector
+
+    def test_dkim_finding_records_provider_and_selectors(self, db):
+        from apps.domain_security.scanner import _check_dkim
+        session = self._make_session(db)
+        with patch("apps.domain_security.scanner._resolve", return_value=["1 aspmx.l.google.com."]), \
+             patch("apps.domain_security.scanner._get_txt_record", return_value=[]):
+            f = _check_dkim(session, "example.com")[0]
+        assert f.extra["mail_provider"] == "Google Workspace"
+        assert f.extra["selectors_checked"][0] == "google"   # inferred selector tried first
+        assert "Google Workspace" in f.description
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Build-bucket item — completes the DKIM story from v2.11.0's reword.

## Problem
DKIM selectors are **per-provider** and not discoverable from the domain, so the check only tried a fixed common list (`default`, `google`, `selector1`, …). For providers using other selectors (SendGrid `s1`, Zoho `zoho`, Fastmail `fm1`, …) it would report "DKIM could not be confirmed" even when DKIM was correctly configured.

## Change
Infer the mail provider from **MX + SPF** records and check that provider's known selectors first:

| Provider | Fingerprint (MX/SPF) | Selectors |
|---|---|---|
| Google Workspace | google.com / _spf.google.com | google |
| Microsoft 365 | mail.protection.outlook.com | selector1, selector2 |
| Zoho | zoho / zohomail | zoho, zmail |
| Amazon SES | amazonses.com | amazonses |
| SendGrid | sendgrid.net | s1, s2 |
| Mailchimp/Mandrill | mcsv.net / mandrillapp.com | k1–k3, mandrill |
| Fastmail | messagingengine.com | fm1–fm3, mesmtp |
| Proofpoint | pphosted.com | selector1, selector2 |

This confirms DKIM in more cases. When it still can't, the **"DKIM could not be confirmed"** finding now names the detected provider and records `selectors_checked` + `mail_provider` in `extra` — so a missing record reads as genuinely missing, not a lookup gap. Inference is fail-graceful (no provider match → falls back to the common list).

## Verification
New `TestDkimInference` (provider inference for Google/M365/none, confirmation via inferred selector, finding metadata) + a class-autouse `_resolve` mock so the mocked email tests stay off the network. 18 email/DKIM/DNS tests pass; check + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv