### PR TITLE
feat: group leak-detection tools into a Data Leak category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **New "Data Leak" tool category.** The four tools that surface *leaked
+  credentials/secrets* rather than *domain posture* — `hudson_rock` (infostealer
+  logs), `breach_check` (breach exposure), `github_secrets` (secrets in public
+  GitHub), and `js_secrets` (secrets in fetched JS) — now group under a dedicated
+  `phase_group: "Data Leak"` instead of being mixed into "Domain Intelligence"
+  (the first three) and "Web Exposure" (`js_secrets`). **Why:** Domain
+  Intelligence had drifted into a catch-all; splitting leak-detection into its own
+  category makes the scan-start category picker, the report groupings, and the
+  "Did we leak keys / were staff logins stolen?" CEO questions line up with a
+  single, clearly-named bucket. Display-only regrouping — execution order
+  (`phase`), runners, and findings are unchanged.
+
 ### Added
 - **DKIM selector inference from MX/SPF.** DKIM selectors are per-provider and
   not discoverable from the domain, so the old check tried only a fixed common

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,11 +456,11 @@ The registry (`apps/core/engine/workflows/registry.py`) auto-discovers all `tool
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
 | `apps/domain_security/` | 1 | Domain Intelligence | Yes | DNS, email, RDAP checks |
-| `apps/hudson_rock/` | 1 | Domain Intelligence | Yes | Infostealer-log exposure via Hudson Rock's keyless Cavalier API (aggregate counts only, no plaintext); passive, fail-graceful |
+| `apps/hudson_rock/` | 1 | Data Leak | Yes | Infostealer-log exposure via Hudson Rock's keyless Cavalier API (aggregate counts only, no plaintext); passive, fail-graceful |
 | `apps/dns_history/` | 1 | Domain Intelligence | Yes | Historical A/AAAA/MX records via a passive-DNS dataset — surfaces past hosting / stale records (info findings). Passive, BYO `DNS_HISTORY_API_URL` (no-op if unset), fail-graceful |
-| `apps/github_secrets/` | 1 | Domain Intelligence | Yes | Leaked secrets in PUBLIC GitHub — searches GitHub's code-search API (org-scoped by default) for the target org's committed credentials, fetches the hits, runs gitleaks over them (same engine as `js_secrets`), REDACTS before storage (`check_type="exposed_secret"`, shared with js_secrets). Passive (queries GitHub, not the target); BYOK MANDATORY (`GITHUB_TOKEN` — code-search needs auth; no token → logged no-op); fail-graceful |
+| `apps/github_secrets/` | 1 | Data Leak | Yes | Leaked secrets in PUBLIC GitHub — searches GitHub's code-search API (org-scoped by default) for the target org's committed credentials, fetches the hits, runs gitleaks over them (same engine as `js_secrets`), REDACTS before storage (`check_type="exposed_secret"`, shared with js_secrets). Passive (queries GitHub, not the target); BYOK MANDATORY (`GITHUB_TOKEN` — code-search needs auth; no token → logged no-op); fail-graceful |
 | `apps/typosquat/` | 1 | Domain Intelligence | Yes | Lookalike / typosquat domain detection — generates lookalike candidates algorithmically (homoglyph/typo/omission/insertion/repetition/transposition/hyphenation/TLD-swap), checks which are registered via public DNS, then scores **weaponization**: registered web-serving lookalikes get a capped, fail-graceful homepage fetch for a login form (credential phishing) or brand mention (impersonation) → **high** (active impersonation, prioritise takedown); A/MX-only → medium; NS-only → low. Passive w.r.t. the target (contacts only the lookalike domains, never yours), no key, fail-graceful. Weaponization model ported from the standalone `tldsquatting` project |
-| `apps/breach_check/` | 1 | Domain Intelligence | Yes | Data-breach exposure for the domain. BYOK: free keyless XposedOrNot catalog by default, authoritative Have I Been Pwned `breacheddomain` when `HIBP_API_KEY` set. Aggregate COUNTS + public breach metadata only — never email aliases/credentials. Passive, fail-graceful |
+| `apps/breach_check/` | 1 | Data Leak | Yes | Data-breach exposure for the domain. BYOK: free keyless XposedOrNot catalog by default, authoritative Have I Been Pwned `breacheddomain` when `HIBP_API_KEY` set. Aggregate COUNTS + public breach metadata only — never email aliases/credentials. Passive, fail-graceful |
 | `apps/subfinder/` | 2 | Surface Enumeration | No | Passive subdomain enumeration |
 | `apps/amass/` | 2 | Surface Enumeration | No | Active subdomain enumeration |
 | `apps/asn_discovery/` | 2 | Surface Enumeration | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
@@ -481,7 +481,7 @@ The registry (`apps/core/engine/workflows/registry.py`) auto-discovers all `tool
 | `apps/katana/` | 10 | Web Exposure | No | Web crawling, endpoint discovery |
 | `apps/nuclei/` | 11 | Web Exposure | Yes | Web vuln scan (community templates) |
 | `apps/web_checker/` | 11 | Web Exposure | Yes | Security headers, cookies, CORS |
-| `apps/js_secrets/` | 11 | Web Exposure | Yes | Hardcoded-secret detection — fetches discovered `.js` assets and runs gitleaks over them; secret is redacted before storage |
+| `apps/js_secrets/` | 11 | Data Leak | Yes | Hardcoded-secret detection — fetches discovered `.js` assets and runs gitleaks over them; secret is redacted before storage |
 | `apps/cve_intel/` | 12 | Prioritization | No | Enriches CVE findings in place with EPSS scores + CISA KEV flags (no new findings) |
 
 ### Tool app structure

--- a/README.md
+++ b/README.md
@@ -188,16 +188,20 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 ── Domain Intelligence ──────────────────────────────────────────────────────
 Phase 1  Domain Security   - DNS, DNSSEC chain-of-trust, email
                              (SPF/DMARC/DKIM/MTA-STS/open-relay), RDAP checks
+Phase 1  Typosquat          - Lookalike / typosquat domain detection (passive;
+                             registered lookalikes via public DNS — phishing/brand abuse)
+Phase 1  DNS History        - Historical A/AAAA/MX records via a passive-DNS
+                             dataset (passive; BYO DNS_HISTORY_API_URL)
+
+── Data Leak ────────────────────────────────────────────────────────────────
 Phase 1  Hudson Rock        - Infostealer-log exposure via Hudson Rock's keyless
                              Cavalier API (aggregate counts only, no plaintext)
 Phase 1  GitHub Secrets      - Leaked secrets in public GitHub via gitleaks
                              (passive; BYO GITHUB_TOKEN, redacted before storage)
-Phase 1  Typosquat          - Lookalike / typosquat domain detection (passive;
-                             registered lookalikes via public DNS — phishing/brand abuse)
 Phase 1  Breach Check       - Data-breach exposure via XposedOrNot (free/keyless)
                              or Have I Been Pwned (BYO key); counts only, no PII
-Phase 1  DNS History        - Historical A/AAAA/MX records via a passive-DNS
-                             dataset (passive; BYO DNS_HISTORY_API_URL)
+Phase 11 JS Secrets         - Hardcoded secrets in fetched JavaScript via gitleaks
+                             (redacted before storage; runs after web crawl)
 
 ── Surface Enumeration ─────────────────────────────────────────────────────
 Phase 2  Subfinder         - Passive subdomain enumeration
@@ -227,7 +231,6 @@ Phase 9  Historical URLs   - Archived URL discovery via gau
 Phase 10 Katana            - Deep URL crawl on top of httpx
 Phase 11 Nuclei            - Web vulnerability scanning (community templates)
 Phase 11 Web Checker       - Security headers, cookies, CORS analysis
-Phase 11 JS Secrets        - Hardcoded secrets in JavaScript via gitleaks
 
 ── Prioritization ───────────────────────────────────────────────────────────
 Phase 12 CVE Intel         - Enrich CVE findings with EPSS + CISA KEV

--- a/apps/breach_check/apps.py
+++ b/apps/breach_check/apps.py
@@ -10,7 +10,7 @@ class BreachCheckConfig(AppConfig):
         "label": "Breach Exposure (HIBP / XposedOrNot)",
         "runner": "apps.breach_check.scanner.run_breach_check",
         "phase": 1,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Data Leak",
         "requires": [],
         "produces_findings": True,
         # Passive: queries third-party breach datasets (XposedOrNot's public

--- a/apps/github_secrets/apps.py
+++ b/apps/github_secrets/apps.py
@@ -10,7 +10,7 @@ class GithubSecretsConfig(AppConfig):
         "label": "GitHub Secret Exposure (gitleaks)",
         "runner": "apps.github_secrets.scanner.run_github_secrets",
         "phase": 1,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Data Leak",
         "requires": ["gitleaks"],
         "produces_findings": True,
         # Passive: queries GitHub's OWN public code-search API (a third party),

--- a/apps/hudson_rock/apps.py
+++ b/apps/hudson_rock/apps.py
@@ -10,7 +10,7 @@ class HudsonRockConfig(AppConfig):
         "label": "Infostealer Exposure (Hudson Rock)",
         "runner": "apps.hudson_rock.scanner.run_hudson_rock",
         "phase": 1,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Data Leak",
         "requires": [],
         "produces_findings": True,
         # Passive: queries Hudson Rock's Cavalier API (third-party threat

--- a/apps/js_secrets/apps.py
+++ b/apps/js_secrets/apps.py
@@ -10,7 +10,7 @@ class JsSecretsConfig(AppConfig):
         "label": "JS Secrets (gitleaks)",
         "runner": "apps.js_secrets.scanner.run_js_secrets",
         "phase": 11,
-        "phase_group": "Web Exposure",
+        "phase_group": "Data Leak",
         "requires": ["gitleaks"],
         "produces_findings": True,
         "active": True,  # fetches JS from the target — active

--- a/tests/unit/test_passive_scan.py
+++ b/tests/unit/test_passive_scan.py
@@ -63,6 +63,32 @@ class TestRegistryActiveFlag:
 
 
 # ---------------------------------------------------------------------------
+# phase_group categories (UI grouping)
+# ---------------------------------------------------------------------------
+
+class TestPhaseGroupCategories:
+    # The leak-detection tools live in their own "Data Leak" category rather than
+    # being mixed into Domain Intelligence / Web Exposure.
+    _DATA_LEAK = {"hudson_rock", "breach_check", "github_secrets", "js_secrets"}
+
+    def test_data_leak_tools_grouped_together(self):
+        from apps.core.engine.workflows.registry import get_tool_phase_groups
+        groups = get_tool_phase_groups()
+        for tool in self._DATA_LEAK:
+            assert groups.get(tool) == "Data Leak", (
+                f"{tool} should be in the Data Leak phase_group, got {groups.get(tool)!r}"
+            )
+
+    def test_domain_intelligence_excludes_leak_tools(self):
+        # Domain Intelligence keeps domain-posture tools only; leak tools moved out.
+        from apps.core.engine.workflows.registry import get_tool_phase_groups
+        groups = get_tool_phase_groups()
+        di = {t for t, g in groups.items() if g == "Domain Intelligence"}
+        assert di.isdisjoint(self._DATA_LEAK)
+        assert "domain_security" in di
+
+
+# ---------------------------------------------------------------------------
 # is_passive_tool_set helper
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Introduces a new \`phase_group: \"Data Leak\"\` and moves the four leak-detection tools into it:

| Tool | Was | Now |
|---|---|---|
| \`hudson_rock\` | Domain Intelligence | **Data Leak** |
| \`breach_check\` | Domain Intelligence | **Data Leak** |
| \`github_secrets\` | Domain Intelligence | **Data Leak** |
| \`js_secrets\` | Web Exposure | **Data Leak** |

## Why

"Domain Intelligence" had drifted into a catch-all mixing domain *posture* (DNS/email/RDAP, typosquat, DNS history) with leaked *credentials/secrets*. Splitting leak-detection into its own clearly-named bucket makes three UI surfaces line up with one category:

- the scan-start **By-category** picker,
- the report groupings,
- the "Did we leak keys? / Were staff logins stolen?" CEO questions.

## Scope

**Display-only regrouping.** \`phase\` (execution order), runners, \`requires\`, and findings are all unchanged — only the \`phase_group\` label moves. Domain Intelligence now holds domain-posture tools only (\`domain_security\`, \`typosquat\`, \`dns_history\`).

## Tests

- New \`TestPhaseGroupCategories\` in \`test_passive_scan.py\` asserts the four tools group under "Data Leak" and that Domain Intelligence excludes them.
- Existing \`test_default_workflow\` (full-scan coverage) + API \`phase_group\` test still pass.

Docs updated: CLAUDE.md tool table, README pipeline diagram, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv