### PR TITLE
feat: "Since Your Last Scan" delta in report + alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **"Since Your Last Scan" report block + alert line.** The PDF report now opens
+  (right under the Exposure Score) with what changed versus the domain's previous
+  scan — **N new / N resolved / N still-open** findings, plus a list of the new
+  issues (investigate first) and the resolved ones. The findings CSV gains a
+  **"New This Scan"** column flagging the same new issues, and Slack/Teams alerts
+  carry a **"N new since the last scan"** line/fact. **Why:** a point-in-time
+  snapshot doesn't answer the first question a returning reader asks — *"what's
+  different since last time?"*. The diff reuses the existing `ScanDelta` identity
+  key (`source:check_type:title`), picks the same non-subscan baseline as delta
+  detection, and respects the report's `min_severity` filter + hidden-title
+  suppression. Absent on a domain's first scan (no baseline), and the alert
+  line/fact is omitted when nothing is new, so those payloads stay byte-identical.
+
 ### Changed
 - **New "Data Leak" tool category.** The four tools that surface *leaked
   credentials/secrets* rather than *domain posture* — `hudson_rock` (infostealer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -825,14 +825,14 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_naabu.py` | 10 | JSON parser, FK to IPAddress |
 | `tests/unit/test_nmap.py` | 26 |
 | `tests/unit/test_nmap_backports.py` | 16 | Backport-aware CVE demotion engine — Debian/Ubuntu version compare, check_backport, `protocol 2.0` false-positive guard | Severity mapping, vulners XML parser, web/non-web exclusion, backport matching |
-| `tests/unit/test_notifications.py` | 35 | NotificationConfig, Slack/Teams alerts, alert-history API, AI summary block/fact (absent = payload byte-identical), alert idempotency on finalize replay (skip when already sent, retry when only failed) |
+| `tests/unit/test_notifications.py` | 41 | NotificationConfig, Slack/Teams alerts, alert-history API, AI summary block/fact (absent = payload byte-identical), alert idempotency on finalize replay (skip when already sent, retry when only failed), "N new since last scan" line/fact (counts only alerted new findings, absent = byte-identical) |
 | `tests/unit/test_nuclei.py` | 33 | CVE parsing, severity, dedup, URL linking, collector, honest UA |
 | `tests/unit/test_nuclei_network.py` | 28 | Network-template parsing, non-web targeting, collector |
 | `tests/unit/test_pipeline_phases.py` | 1 | Phase ordering sanity |
 | `tests/unit/test_qcluster_config.py` | 3 | Scan-timeout invariants (Q_CLUSTER removed; SCAN_TASK_TIMEOUT + watchdog bound) |
 | `tests/unit/test_durable_task.py` | 7 | `@durable_task` engine adapter (H6) — in-process call, `.delay()` enqueue, dedupe template + override, registry, real tasks are DurableTasks, enqueue_* wrappers delegate |
 | `tests/unit/test_credentials.py` | 13 | UI-managed BYOK credentials (C1+C3) — singleton, ciphertext-at-rest/plaintext-via-ORM, resolver DB-wins-over-env + env fallback + source + never-raises, write-only API (presence-only never values, set/none-unchanged/clear), and a DB key reaching `shodan.collect` (paid tier, no env key) |
-| `tests/unit/test_reports.py` | 57 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block, AI Analyst Summary block (absent without AI rows) |
+| `tests/unit/test_reports.py` | 63 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block, AI Analyst Summary block (absent without AI rows), "Since Your Last Scan" delta block (new/resolved/still-open, baseline + subscan + min_severity rules, CSV new-flag column) |
 | `tests/unit/test_waf_detection.py` | 16 | WAF/block/challenge classifier (spec C1) — vendor fingerprint, false-positive guards, analyzer wiring |
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
@@ -875,6 +875,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1778 tests** (1726 fast + 52 slow domain_security)
+**Total: 1790 tests** (1738 fast + 52 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/console/notifications/dispatcher.py
+++ b/apps/core/console/notifications/dispatcher.py
@@ -42,6 +42,7 @@ def _get_qualifying_findings(session, threshold_level: int) -> list:
                     "title": f.title,
                     "host": f.target,
                     "check_type": f.check_type,
+                    "source": f.source,
                 })
     except Exception as e:
         logger.warning(f"[alerts] Could not read findings: {e}")
@@ -77,6 +78,34 @@ def _get_triage_summary(session) -> "str | None":
         return None
 
 
+def _new_since_last_scan(session, findings) -> int:
+    """How many of the alerted findings are new since the previous scan.
+
+    Reads the ScanDelta rows already computed at finalize (``_detect_deltas``
+    runs before alerts dispatch) and counts the qualifying findings whose
+    identity key (``source:check_type:title``) was flagged new. Returns 0 when
+    there's no prior scan or nothing new — so the "new since last scan" line /
+    fact is omitted and the payload stays byte-identical to the no-delta case.
+    Never raises: a delta lookup can't fail an alert."""
+    try:
+        from apps.core.engine.scans.models import ScanDelta
+
+        new_keys = set(
+            ScanDelta.objects.filter(
+                session=session, change_type="new", change_category="finding"
+            ).values_list("item_identifier", flat=True)
+        )
+        if not new_keys:
+            return 0
+        return sum(
+            1 for f in findings
+            if f"{f['source']}:{f['check_type']}:{f['title']}" in new_keys
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("[alerts] new-finding delta lookup failed — omitting")
+        return 0
+
+
 # ---------------------------------------------------------------------------
 # Slack
 # ---------------------------------------------------------------------------
@@ -87,9 +116,16 @@ def _build_slack_payload(session, grouped: dict, threshold: str) -> dict:
     header = f":shield: *OpenEASD Alert* — `{session.domain}`"
     meta = f"Scan #{session.id} | {django_tz.now().strftime('%Y-%m-%d %H:%M')} UTC | threshold: {threshold}"
 
+    # "N new since the last scan" — appended only when there's a prior scan with
+    # new findings, so a baseline-less scan's payload is unchanged.
+    meta_text = f"{header}\n{meta}\n*{total} finding(s) found*"
+    new_count = _new_since_last_scan(session, [f for v in grouped.values() for f in v])
+    if new_count:
+        meta_text += f"\n:new: *{new_count} new since the last scan*"
+
     blocks = [
         {"type": "header", "text": {"type": "plain_text", "text": f"Security Alert — {session.domain}"}},
-        {"type": "section", "text": {"type": "mrkdwn", "text": f"{header}\n{meta}\n*{total} finding(s) found*"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": meta_text}},
         {"type": "divider"},
     ]
 
@@ -159,6 +195,9 @@ def _build_teams_payload(session, grouped: dict, threshold: str) -> dict:
     summary = _get_triage_summary(session)
     if summary:
         facts.append({"name": "Summary", "value": summary})
+    new_count = _new_since_last_scan(session, [f for v in grouped.values() for f in v])
+    if new_count:
+        facts.append({"name": "New since last scan", "value": str(new_count)})
     for sev in ["critical", "high", "medium", "low"]:
         items = grouped.get(sev, [])
         if not items:

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -301,6 +301,24 @@ def export_findings_csv(request, session_uuid):
         .order_by("severity", "source")
     )
 
+    # Keys (source:check_type:title) that weren't present in the previous scan,
+    # so each row can be flagged "new" — the CSV counterpart of the PDF's
+    # "Since Your Last Scan" block.
+    new_keys = set()
+    previous = _previous_baseline(session)
+    if previous is not None:
+        prev_keys = {
+            f"{r['source']}:{r['check_type']}:{r['title']}"
+            for r in Finding.objects.filter(session=previous, severity__in=severities)
+            .exclude(title__in=_REPORT_HIDDEN_TITLES)
+            .values("source", "check_type", "title")
+        }
+        cur_keys = {
+            f"{r['source']}:{r['check_type']}:{r['title']}"
+            for r in findings.values("source", "check_type", "title")
+        }
+        new_keys = cur_keys - prev_keys
+
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = (
         f'attachment; filename="findings_{session.domain}_{session.id}.csv"'
@@ -310,12 +328,15 @@ def export_findings_csv(request, session_uuid):
     writer.writerow([
         "Title", "Severity", "Source", "Check Type", "Status",
         "Target", "Description", "Remediation", "Assigned To", "Discovered At",
+        "New This Scan",
     ])
     for f in findings:
+        key = f"{f.source}:{f.check_type}:{f.title}"
         writer.writerow([
             f.title, f.severity, f.source, f.check_type, f.status,
             f.target, f.description, f.remediation, f.assigned_to,
             f.discovered_at.isoformat(),
+            "new" if key in new_keys else "",
         ])
 
     # Optional CTA — appended as a final row when both settings are configured.
@@ -606,6 +627,78 @@ def _ceo_questions(issue_groups, active_tools):
     return out
 
 
+def _previous_baseline(session):
+    """The scan to diff this one against: the most recent completed/partial scan
+    of the same domain that isn't a subscan (a subscan runs only a subset of
+    tools, so it would manufacture spurious deltas). Matches ScanDelta's choice.
+    Returns ``None`` when this is the domain's first scan.
+    """
+    return (
+        ScanSession.objects.filter(
+            domain=session.domain, status__in=["completed", "partial"]
+        )
+        .exclude(id=session.id)
+        .exclude(scan_type="subscan")
+        .order_by("-start_time")
+        .first()
+    )
+
+
+def _since_last_scan(session, severities):
+    """What changed vs the previous scan of this domain — new / resolved findings.
+
+    Diffs findings against the previous baseline by the same identity key as
+    ScanDelta (``source:check_type:title``). Carries severity + title so the
+    report can list what appeared and what cleared, and counts what persisted.
+    Scoped to the report's own ``min_severity`` filter and hidden-title
+    suppression so it never references findings the rest of the report hides.
+
+    Returns ``None`` on the first scan (no baseline) so the template block is
+    skipped entirely.
+    """
+    previous = _previous_baseline(session)
+    if previous is None:
+        return None
+
+    def _rows(s):
+        rows = {}
+        qs = (
+            Finding.objects.filter(session=s, severity__in=severities)
+            .exclude(title__in=_REPORT_HIDDEN_TITLES)
+            .values("source", "check_type", "title", "severity")
+        )
+        for f in qs:
+            key = f"{f['source']}:{f['check_type']}:{f['title']}"
+            rank = _SEVERITY_ORDER.index(f["severity"]) if f["severity"] in _SEVERITY_ORDER else 99
+            cur = rows.get(key)
+            # Keep the highest-severity representative when a key recurs.
+            if cur is None or rank < cur["_rank"]:
+                rows[key] = {"title": f["title"], "severity": f["severity"],
+                             "source": f["source"], "_rank": rank}
+        return rows
+
+    cur = _rows(session)
+    prev = _rows(previous)
+    cur_keys, prev_keys = set(cur), set(prev)
+
+    def _ranked(items):
+        rows = sorted(items, key=lambda d: d["_rank"])
+        for r in rows:
+            r.pop("_rank", None)
+        return rows
+
+    new = _ranked([cur[k] for k in cur_keys - prev_keys])
+    resolved = _ranked([prev[k] for k in prev_keys - cur_keys])
+    return {
+        "previous_date": previous.end_time or previous.start_time,
+        "new": new,
+        "resolved": resolved,
+        "new_count": len(new),
+        "resolved_count": len(resolved),
+        "still_open": len(cur_keys & prev_keys),
+    }
+
+
 @_report_auth_required
 def export_scan_pdf(request, session_uuid):
     """Export a scan report as PDF, optionally filtered by ?min_severity=."""
@@ -779,6 +872,7 @@ def export_scan_pdf(request, session_uuid):
         "exposure_score": exposure_score,
         "exposure_grade": exposure_grade,
         "exposure_trend": exposure_trend,
+        "since_last_scan": _since_last_scan(session, severities),
         "top_risks": top_risks,
         "headline_risk": top_risks[0] if top_risks else None,
         "coverage": _coverage_context(session),

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -178,6 +178,30 @@
   </p>
 </div>
 
+{% if since_last_scan %}
+<div class="risk no-break" style="border-color:#5c7cfa;">
+  <div class="l" style="color:#5c7cfa;">Since Your Last Scan</div>
+  <p style="margin:8px 0 0;font-size:10px;line-height:1.5;color:#333;">Compared with the previous scan of {{ session.domain }} on {{ since_last_scan.previous_date|date:"Y-m-d" }}:
+    <strong style="color:#e03131;">{{ since_last_scan.new_count }} new</strong>,
+    <strong style="color:#2f9e44;">{{ since_last_scan.resolved_count }} resolved</strong>,
+    <strong style="color:#333;">{{ since_last_scan.still_open }} still open</strong>.
+  </p>
+  {% if since_last_scan.new %}
+  <p style="margin:8px 0 2px;font-size:9px;font-weight:bold;color:#e03131;">New this scan — investigate first:</p>
+  <ul style="margin:0;padding-left:14px;font-size:9px;line-height:1.45;color:#333;">
+    {% for f in since_last_scan.new %}<li><strong>{{ f.title }}</strong> ({{ f.severity|upper }})</li>{% endfor %}
+  </ul>
+  {% endif %}
+  {% if since_last_scan.resolved %}
+  <p style="margin:8px 0 2px;font-size:9px;font-weight:bold;color:#2f9e44;">Resolved since last scan:</p>
+  <ul style="margin:0;padding-left:14px;font-size:9px;line-height:1.45;color:#333;">
+    {% for f in since_last_scan.resolved %}<li>{{ f.title }} ({{ f.severity|upper }})</li>{% endfor %}
+  </ul>
+  {% endif %}
+  <p style="margin:8px 0 0;font-size:8px;color:#888;">Changes are compared by issue type (tool, check, and title); a finding counts as "still open" when the same issue type appeared in both scans.</p>
+</div>
+{% endif %}
+
 {% if ai_summary %}
 <div class="risk no-break" style="border-color:#2f9e44;">
   <div class="l" style="color:#2f9e44;">Analyst Summary</div>

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -369,6 +369,69 @@ class TestAlertAiSummary:
 
 
 # ---------------------------------------------------------------------------
+# "New since last scan" delta in alert payloads
+# ---------------------------------------------------------------------------
+
+_GROUPED_SRC = {"high": [
+    {"title": "TLS expired", "check_type": "tls_expiry", "target": "example.com", "source": "tls_checker"},
+    {"title": "Open SSH", "check_type": "ssh", "target": "example.com", "source": "ssh_checker"},
+]}
+
+
+@pytest.mark.django_db
+class TestAlertNewSinceLastScan:
+    def _delta(self, session, source, check_type, title):
+        from apps.core.engine.scans.models import ScanDelta
+        ScanDelta.objects.create(
+            session=session, change_type="new", change_category="finding",
+            item_identifier=f"{source}:{check_type}:{title}",
+        )
+
+    def test_zero_when_no_deltas(self):
+        from apps.core.console.notifications.dispatcher import _new_since_last_scan
+        sess = _alert_session()
+        flat = [f for v in _GROUPED_SRC.values() for f in v]
+        assert _new_since_last_scan(sess, flat) == 0
+
+    def test_counts_only_alerted_new_findings(self):
+        from apps.core.console.notifications.dispatcher import _new_since_last_scan
+        sess = _alert_session()
+        self._delta(sess, "tls_checker", "tls_expiry", "TLS expired")   # in alert set
+        self._delta(sess, "nuclei", "cve", "Some CVE")                  # new but below threshold / not alerted
+        flat = [f for v in _GROUPED_SRC.values() for f in v]
+        assert _new_since_last_scan(sess, flat) == 1
+
+    def test_slack_payload_identical_when_no_new(self):
+        from apps.core.console.notifications.dispatcher import _build_slack_payload
+        sess = _alert_session()
+        payload = _build_slack_payload(sess, _GROUPED_SRC, "high")
+        assert all("new since the last scan" not in str(b) for b in payload["blocks"])
+
+    def test_slack_meta_gains_new_line(self):
+        from apps.core.console.notifications.dispatcher import _build_slack_payload
+        sess = _alert_session()
+        self._delta(sess, "tls_checker", "tls_expiry", "TLS expired")
+        payload = _build_slack_payload(sess, _GROUPED_SRC, "high")
+        # No extra block — it rides on the existing meta section.
+        assert len(payload["blocks"]) == 4
+        assert "1 new since the last scan" in payload["blocks"][1]["text"]["text"]
+
+    def test_teams_gains_new_fact(self):
+        from apps.core.console.notifications.dispatcher import _build_teams_payload
+        sess = _alert_session()
+        self._delta(sess, "tls_checker", "tls_expiry", "TLS expired")
+        payload = _build_teams_payload(sess, _GROUPED_SRC, "high")
+        facts = payload["sections"][0]["facts"]
+        assert {"name": "New since last scan", "value": "1"} in facts
+
+    def test_teams_identical_when_no_new(self):
+        from apps.core.console.notifications.dispatcher import _build_teams_payload
+        sess = _alert_session()
+        payload = _build_teams_payload(sess, _GROUPED_SRC, "high")
+        assert all(f["name"] != "New since last scan" for f in payload["sections"][0]["facts"])
+
+
+# ---------------------------------------------------------------------------
 # H1 — alert idempotency on finalize replay (apps/core/engine/scans/pipeline)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -899,3 +899,113 @@ class TestAnalystSummaryBlock:
         with patch("apps.core.console.ai.models.AITriage.objects") as broken:
             broken.filter.side_effect = RuntimeError("db broke")
             assert _ai_context(session) == {}
+
+
+# ---------------------------------------------------------------------------
+# "Since Your Last Scan" delta block
+# ---------------------------------------------------------------------------
+
+class TestSinceLastScanBlock:
+    """The report shows what changed versus the previous scan of the same domain:
+    new / resolved / still-open findings. Absent on the first scan (no baseline),
+    and the diff ignores subscans (they run only a subset of tools) and respects
+    the report's min_severity filter + hidden-title suppression."""
+
+    def _capture_pdf_html(self, authed_client, session, qs=""):
+        captured = {}
+
+        def capture_html(html):
+            captured["html"] = html
+            return b"%PDF-1.7"
+
+        with patch("apps.core.console.reports.views._render_pdf", side_effect=capture_html):
+            res = authed_client.get(f"/reports/{session.uuid}/pdf/{qs}")
+        assert res.status_code == 200
+        return captured["html"]
+
+    def _finding(self, session, title, severity, source, check_type, **kw):
+        from apps.core.data.findings.models import Finding
+        return Finding.objects.create(
+            session=session, source=source, check_type=check_type,
+            severity=severity, title=title, target="report.example.com",
+            description="desc", remediation="fix", status="open", **kw,
+        )
+
+    def _prev_session(self, domain="report.example.com", scan_type="full"):
+        from apps.core.engine.scans.models import ScanSession
+        return ScanSession.objects.create(
+            domain=domain, scan_type=scan_type, status="completed",
+            start_time=timezone.now() - timezone.timedelta(days=7),
+            end_time=timezone.now() - timezone.timedelta(days=7),
+        )
+
+    def test_absent_on_first_scan(self, authed_client, session, findings):
+        html = self._capture_pdf_html(authed_client, session)
+        assert "Since Your Last Scan" not in html
+
+    def test_new_and_resolved_and_still_open(self, authed_client, session):
+        prev = self._prev_session()
+        # previous: A (shared) + B (will be resolved)
+        self._finding(prev, "Shared issue", "high", "tls_checker", "tls_expiry")
+        self._finding(prev, "Resolved issue", "medium", "domain_security", "dmarc")
+        # current: A (shared, still open) + C (new)
+        self._finding(session, "Shared issue", "high", "tls_checker", "tls_expiry")
+        self._finding(session, "New issue", "critical", "nuclei", "cve")
+
+        html = self._capture_pdf_html(authed_client, session)
+        assert "Since Your Last Scan" in html
+        assert "1 new" in html
+        assert "1 resolved" in html
+        assert "1 still open" in html
+        assert "New issue" in html       # listed under "New this scan"
+        assert "Resolved issue" in html  # listed under "Resolved"
+
+    def test_from_helper_directly(self, db, session):
+        from apps.core.console.reports.views import _since_last_scan
+        prev = self._prev_session()
+        self._finding(prev, "Old one", "low", "web_checker", "cors")
+        self._finding(session, "Old one", "low", "web_checker", "cors")
+        self._finding(session, "Brand new", "high", "nmap", "cve")
+        result = _since_last_scan(session, ["critical", "high", "medium", "low", "info"])
+        assert result["new_count"] == 1
+        assert result["resolved_count"] == 0
+        assert result["still_open"] == 1
+        assert result["new"][0]["title"] == "Brand new"
+
+    def test_subscan_is_not_a_baseline(self, authed_client, session):
+        # A subscan of the same domain must not be chosen as the baseline, even if
+        # it's the most recent — it runs only a subset of tools.
+        sub = self._prev_session()
+        sub.scan_type = "subscan"
+        sub.start_time = timezone.now() - timezone.timedelta(hours=1)
+        sub.save()
+        self._finding(sub, "Subscan-only", "high", "nuclei", "cve")
+        self._finding(session, "Current", "high", "tls_checker", "tls_expiry")
+        html = self._capture_pdf_html(authed_client, session)
+        # No non-subscan prior scan exists → treated as the baseline (block absent).
+        assert "Since Your Last Scan" not in html
+
+    def test_respects_min_severity_filter(self, authed_client, session):
+        prev = self._prev_session()
+        self._finding(prev, "Shared high", "high", "tls_checker", "tls_expiry")
+        self._finding(session, "Shared high", "high", "tls_checker", "tls_expiry")
+        # A new LOW finding should be invisible when min_severity=high.
+        self._finding(session, "New low", "low", "web_checker", "cors")
+        html = self._capture_pdf_html(authed_client, session, qs="?min_severity=high")
+        assert "Since Your Last Scan" in html
+        assert "New low" not in html
+        assert "0 new" in html
+
+    def test_csv_flags_new_findings(self, authed_client, session):
+        prev = self._prev_session()
+        self._finding(prev, "Shared", "high", "tls_checker", "tls_expiry")
+        self._finding(session, "Shared", "high", "tls_checker", "tls_expiry")
+        self._finding(session, "Fresh", "critical", "nuclei", "cve")
+        content = authed_client.get(f"/reports/{session.uuid}/csv/").content.decode("utf-8")
+        reader = csv.reader(io.StringIO(content))
+        header = next(reader)
+        assert "New This Scan" in header
+        idx = header.index("New This Scan")
+        rows = {r[0]: r[idx] for r in reader if r}
+        assert rows["Fresh"] == "new"
+        assert rows["Shared"] == ""


### PR DESCRIPTION
## What

Answers the first question a returning reader asks — *what changed since last time?* — across the three places scan results surface:

- **PDF report:** a **"Since Your Last Scan"** block directly under the Exposure Score — **N new / N resolved / N still-open** findings, with the new issues listed (investigate first) and the resolved ones listed.
- **Findings CSV:** a **"New This Scan"** column (\`new\` / blank) on each row.
- **Slack / Teams alerts:** a **"N new since the last scan"** line (Slack meta) / fact (Teams).

## How

- Diffs findings by the same identity key as \`ScanDelta\` — \`source:check_type:title\`.
- Picks the **same baseline** as delta detection: the most recent completed/partial scan of the domain that **isn't a subscan** (a subscan runs a subset of tools and would manufacture spurious deltas).
- Respects the report's \`min_severity\` filter and hidden-title suppression, so it never references findings the rest of the report hides.
- Alerts read the \`ScanDelta\` "new" rows already computed at finalize (\`_detect_deltas\` runs before \`_dispatch_alerts\`), counting only the findings actually being alerted.

## Safety / no-regression

- **First scan:** no baseline → the report block is absent.
- **Nothing new:** the alert line/fact is omitted, so Slack/Teams payloads stay **byte-identical** to before (same guarantee the AI-summary block already honors — asserted by tests).

## Tests

+12: 6 in \`test_reports.py\` (new/resolved/still-open, helper, subscan-not-baseline, min_severity scope, CSV new-flag) and 6 in \`test_notifications.py\` (count only alerted new findings, Slack meta line, Teams fact, byte-identical when none). Full \`test_reports\` + \`test_notifications\` + \`test_alerts\` suites green (123 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv