### PR TITLE
feat: per-finding Recommended Next Steps (hosted reports)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **Per-finding "Recommended Next Steps" on hosted reports.** The PDF report's
+  finding detail now carries a concrete, ordered remediation checklist per finding
+  type (e.g. HSTS → confirm HTTPS → add the header → submit to hstspreload.org),
+  on top of the existing Remediation prose. Covers the common web-header / cookie
+  / CORS / disclosure / security.txt / email-auth / TLS / SSH / takeover /
+  cloud-bucket / exposed-secret findings; unmapped types render nothing (no empty
+  block). **Gated on hosted reports only** — it renders when `REPORT_CTA_URL` is
+  configured (the same flag that marks a hosted deployment); self-hosters still
+  get the per-finding Remediation text. **Why:** turns "what's wrong" into "what
+  to do next," in copy-pasteable steps, for the reader who has to action the
+  report. Report-only — no scanning, model, or API change.
 - **security.txt (RFC 9116) responsible-disclosure check.** `web_checker` now
   checks whether the scan's **primary domain** publishes a `security.txt` at
   `/.well-known/security.txt` — the standard, machine-readable way a researcher

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,7 +832,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_qcluster_config.py` | 3 | Scan-timeout invariants (Q_CLUSTER removed; SCAN_TASK_TIMEOUT + watchdog bound) |
 | `tests/unit/test_durable_task.py` | 7 | `@durable_task` engine adapter (H6) — in-process call, `.delay()` enqueue, dedupe template + override, registry, real tasks are DurableTasks, enqueue_* wrappers delegate |
 | `tests/unit/test_credentials.py` | 13 | UI-managed BYOK credentials (C1+C3) — singleton, ciphertext-at-rest/plaintext-via-ORM, resolver DB-wins-over-env + env fallback + source + never-raises, write-only API (presence-only never values, set/none-unchanged/clear), and a DB key reaching `shodan.collect` (paid tier, no env key) |
-| `tests/unit/test_reports.py` | 63 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block, AI Analyst Summary block (absent without AI rows), "Since Your Last Scan" delta block (new/resolved/still-open, baseline + subscan + min_severity rules, CSV new-flag column) |
+| `tests/unit/test_reports.py` | 80 | CSV export content/structure, PDF export (WeasyPrint, mocked via _render_pdf), min_severity filter, per-severity count aggregation, issue grouping, scope/CWE/CVSS/risk enrichment, WAF coverage block, technology stack block, AI Analyst Summary block (absent without AI rows), "Since Your Last Scan" delta block (new/resolved/still-open, baseline + subscan + min_severity rules, CSV new-flag column), per-finding "Recommended Next Steps" checklist (hosted-only gating, effective-key mapping incl. email control, empty for unmapped) |
 | `tests/unit/test_waf_detection.py` | 16 | WAF/block/challenge classifier (spec C1) — vendor fingerprint, false-positive guards, analyzer wiring |
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
@@ -875,6 +875,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1808 tests** (1756 fast + 52 slow domain_security)
+**Total: 1813 tests** (1761 fast + 52 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -453,6 +453,8 @@ def _group_findings_by_issue(findings):
             grp["business_impact"] = _BUSINESS_IMPACT_BY_SEV.get(grp["severity"], "")
         else:
             grp["business_impact"] = ""
+        # Concrete remediation checklist (rendered on hosted reports only).
+        grp["next_steps"] = _NEXT_STEPS_BY_CHECK.get(effective_key, [])
         # Affected endpoints as a pill grid (3 per row). Capped at 50 per group
         # to prevent OOM when a single finding fires on thousands of URLs.
         endpoints = [(f.url.url if f.url else f.target) for f in grp["instances"]]
@@ -486,6 +488,140 @@ _BUSINESS_IMPACT_BY_SEV = {
     "high": "A serious weakness an external attacker can leverage.",
 }
 _SEV_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+
+
+# Concrete, ordered "do this" steps per finding type — a remediation checklist,
+# not a paragraph. Keyed by effective key (the email `control` where findings
+# share the coarse check_type="email", else the check_type). Rendered in the
+# report's finding detail ONLY on hosted reports (REPORT_CTA configured) —
+# self-hosters still get the per-finding Remediation prose. Unmapped types render
+# nothing, so the block never shows an empty list.
+_NEXT_STEPS_BY_CHECK = {
+    # --- Web security headers (web_checker) ---
+    "missing_csp": [
+        "Ship a report-only policy first: `Content-Security-Policy-Report-Only: default-src 'self'; report-uri /csp-report`.",
+        "Review the reported violations for a week and fold legitimate origins into the policy.",
+        "Switch the header to enforcing (`Content-Security-Policy`) once violations are clean.",
+    ],
+    "missing_xfo": [
+        "Add `X-Frame-Options: DENY` (or `SAMEORIGIN` if the page is framed by your own origin).",
+        "Add a matching CSP directive for modern browsers: `Content-Security-Policy: frame-ancestors 'none'`.",
+        "Re-scan to confirm both headers are present on every page.",
+    ],
+    "missing_xcto": [
+        "Add `X-Content-Type-Options: nosniff` to all responses.",
+        "Confirm every response sets a correct `Content-Type` so nosniff doesn't break assets.",
+    ],
+    "missing_hsts": [
+        "Confirm the site is fully reachable over HTTPS.",
+        "Add `Strict-Transport-Security: max-age=31536000; includeSubDomains`.",
+        "Once stable across all subdomains, add `preload` and submit at hstspreload.org.",
+    ],
+    "weak_hsts": [
+        "Raise the HSTS `max-age` to at least 31536000 (one year).",
+        "Add `includeSubDomains` if every subdomain is HTTPS-only.",
+    ],
+    # --- Cookies (web_checker) ---
+    "cookie_missing_secure": [
+        "Set the `Secure` attribute on every cookie served over HTTPS.",
+        "For session cookies, combine with `HttpOnly` and `SameSite`.",
+    ],
+    "cookie_missing_httponly": [
+        "Set `HttpOnly` on any cookie that JavaScript does not need to read (session/auth cookies first).",
+    ],
+    "cookie_missing_samesite": [
+        "Set `SameSite=Lax` on cookies by default, or `Strict` for sensitive session cookies.",
+        "If a cookie must cross sites, use `SameSite=None; Secure` deliberately.",
+    ],
+    # --- CORS (web_checker) ---
+    "cors_wildcard_credentials": [
+        "Stop returning `Access-Control-Allow-Origin: *` together with `Access-Control-Allow-Credentials: true` — this combination is exploitable.",
+        "Echo back only origins from a server-side allowlist of trusted sites.",
+        "Re-test with an untrusted `Origin` header to confirm it is rejected.",
+    ],
+    "cors_origin_reflection": [
+        "Validate the `Origin` header against an allowlist instead of reflecting it.",
+        "Return no CORS headers for untrusted origins.",
+        "Re-test with a spoofed `Origin` to confirm it is not reflected.",
+    ],
+    "cors_wildcard": [
+        "Replace `Access-Control-Allow-Origin: *` with an explicit allowlist of trusted origins.",
+        "Scope the wildcard to only genuinely public, non-credentialed endpoints if it must stay.",
+    ],
+    # --- Disclosure / listing (web_checker) ---
+    "server_version_disclosure": [
+        "Suppress the version in the `Server` header (nginx: `server_tokens off;`, Apache: `ServerTokens Prod`).",
+        "Reload the web server and re-scan to confirm the version is gone.",
+    ],
+    "server_poweredby_disclosure": [
+        "Remove the `X-Powered-By` header (e.g. PHP `expose_php = Off`, Express `app.disable('x-powered-by')`).",
+    ],
+    "directory_listing": [
+        "Disable auto-indexing (nginx: `autoindex off;`, Apache: `Options -Indexes`).",
+        "Add an index file or return 403 for the exposed directories.",
+        "Review the listed files for anything sensitive that should be removed.",
+    ],
+    # --- Responsible disclosure (web_checker) ---
+    "missing_security_txt": [
+        "Create `/.well-known/security.txt` with at least `Contact:` (a monitored security email or reporting URL) and `Expires:`.",
+        "Serve it as `text/plain` over HTTPS.",
+        "Set a calendar reminder to refresh `Expires:` before it lapses.",
+    ],
+    "expired_security_txt": [
+        "Update the `Expires:` field to a future date.",
+        "Confirm the `Contact:` address/URL is still monitored.",
+    ],
+    # --- Email authentication (domain_security; keyed by control) ---
+    "spf": [
+        "Publish a single SPF TXT record listing every legitimate sender, ending in `-all` (hard fail).",
+        "Keep it to ≤10 DNS lookups; flatten include chains if needed.",
+    ],
+    "dmarc": [
+        "Publish `_dmarc` TXT starting at `v=DMARC1; p=none` with an `rua=` aggregate-report address.",
+        "Review the reports, then raise the policy to `p=quarantine` and finally `p=reject`.",
+    ],
+    "dkim": [
+        "Enable DKIM signing at your mail provider and publish the selector's public key in DNS.",
+        "Send a test message and confirm the signature verifies (`dkim=pass`).",
+    ],
+    # --- TLS (tls_checker) ---
+    "weak_cipher": [
+        "Disable the weak cipher suites and prefer AEAD suites (AES-GCM, ChaCha20-Poly1305).",
+        "Re-test with an SSL/TLS scanner to confirm only strong suites remain.",
+    ],
+    "no_forward_secrecy": [
+        "Enable ECDHE key-exchange cipher suites and prefer them in server order.",
+        "Disable static-RSA key exchange.",
+    ],
+    "cert_expired": [
+        "Reissue and install a current certificate immediately.",
+        "Automate renewal (ACME/Let's Encrypt or your CA's API) so it can't lapse again.",
+    ],
+    # --- SSH (ssh_checker) ---
+    "ssh_password_auth": [
+        "Deploy SSH keys for all operators, then set `PasswordAuthentication no` in sshd_config.",
+        "Reload sshd and confirm password login is refused.",
+    ],
+    "ssh_root_login": [
+        "Set `PermitRootLogin no` and use a sudo-capable named account instead.",
+        "Reload sshd and verify direct root login is rejected.",
+    ],
+    # --- Attack surface ---
+    "subdomain_takeover": [
+        "Remove the dangling DNS record, or reclaim the referenced resource at the provider.",
+        "Re-scan to confirm the subdomain no longer resolves to an unclaimed endpoint.",
+    ],
+    "open_cloud_bucket": [
+        "Remove public/anonymous access on the bucket and enable the provider's public-access block.",
+        "Audit the objects that were exposed for anything sensitive.",
+        "Set an alert for future public-access changes.",
+    ],
+    "exposed_secret": [
+        "Treat the secret as compromised: rotate/revoke it now.",
+        "Remove it from the code and load it from a secret manager or environment variable.",
+        "Purge it from git history if it was committed.",
+    ],
+}
 
 
 def _priority_score(grp) -> float:
@@ -894,6 +1030,10 @@ def export_scan_pdf(request, session_uuid):
         # Optional CTA — template renders the block only when both are truthy.
         "report_cta_url": getattr(settings, "REPORT_CTA_URL", "") or "",
         "report_cta_text": getattr(settings, "REPORT_CTA_TEXT", "") or "",
+        # Per-finding remediation checklists are a hosted-report extra — gated on
+        # the same REPORT_CTA_URL flag that marks a hosted deployment (self-hosters
+        # still get the per-finding Remediation prose).
+        "show_next_steps": bool(getattr(settings, "REPORT_CTA_URL", "") or ""),
         # Optional AI analyst summary — {} when absent, so the block never renders.
         **_ai_context(session),
     })

--- a/templates/reports/scan_report.html
+++ b/templates/reports/scan_report.html
@@ -424,6 +424,13 @@
   <div class="sect-lbl">Remediation</div>
   <div class="prose">{{ g.remediation }}</div>
   {% endif %}
+
+  {% if show_next_steps and g.next_steps %}
+  <div class="sect-lbl">Recommended Next Steps</div>
+  <ol class="prose" style="margin:4px 0 0;padding-left:18px;">
+    {% for step in g.next_steps %}<li style="margin:0 0 3px;">{{ step }}</li>{% endfor %}
+  </ol>
+  {% endif %}
 </div>
 {% endfor %}
 {% endfor %}

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -1009,3 +1009,75 @@ class TestSinceLastScanBlock:
         rows = {r[0]: r[idx] for r in reader if r}
         assert rows["Fresh"] == "new"
         assert rows["Shared"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-finding "Recommended Next Steps" (hosted reports only)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestNextStepsBlock:
+    """Concrete remediation checklists render in the PDF finding detail ONLY on
+    hosted reports (REPORT_CTA_URL configured). Self-hosters keep the Remediation
+    prose but not the numbered checklist. The mapping is keyed by effective key."""
+
+    def _capture(self, authed_client, session):
+        captured = {}
+
+        def capture_html(html):
+            captured["html"] = html
+            return b"%PDF-1.7"
+
+        with patch("apps.core.console.reports.views._render_pdf", side_effect=capture_html):
+            res = authed_client.get(f"/reports/{session.uuid}/pdf/")
+        assert res.status_code == 200
+        return captured["html"]
+
+    def test_absent_when_not_hosted(self, authed_client, session, findings, settings):
+        settings.REPORT_CTA_URL = ""
+        html = self._capture(authed_client, session)
+        assert "Recommended Next Steps" not in html
+
+    def test_present_when_hosted(self, authed_client, session, findings, settings):
+        settings.REPORT_CTA_URL = "https://example.com/help"
+        settings.REPORT_CTA_TEXT = "Need help?"
+        html = self._capture(authed_client, session)
+        assert "Recommended Next Steps" in html
+        # The DMARC finding in the fixture maps to a concrete step.
+        assert "Publish" in html and "_dmarc" in html
+
+    def test_group_attaches_next_steps_for_mapped_check(self, db, session):
+        from apps.core.console.reports.views import _group_findings_by_issue
+        from apps.core.data.findings.models import Finding
+        f = Finding.objects.create(
+            session=session, source="web_checker", check_type="missing_hsts",
+            severity="medium", title="Missing Strict-Transport-Security on https://x",
+            description="d", remediation="r", target="https://x",
+        )
+        groups = _group_findings_by_issue([f])
+        assert groups[0]["next_steps"]  # non-empty
+        assert any("Strict-Transport-Security" in s for s in groups[0]["next_steps"])
+
+    def test_group_empty_next_steps_for_unmapped_check(self, db, session):
+        from apps.core.console.reports.views import _group_findings_by_issue
+        from apps.core.data.findings.models import Finding
+        f = Finding.objects.create(
+            session=session, source="some_tool", check_type="totally_unmapped_check",
+            severity="low", title="Odd thing", description="d", remediation="r",
+            target="x",
+        )
+        groups = _group_findings_by_issue([f])
+        assert groups[0]["next_steps"] == []
+
+    def test_email_control_keys_next_steps(self, db, session):
+        # Email findings share check_type="email"; next steps resolve via control.
+        from apps.core.console.reports.views import _group_findings_by_issue
+        from apps.core.data.findings.models import Finding
+        f = Finding.objects.create(
+            session=session, source="domain_security", check_type="email",
+            severity="medium", title="SPF record missing on example.com",
+            description="d", remediation="r", target="example.com",
+            extra={"control": "spf"},
+        )
+        groups = _group_findings_by_issue([f])
+        assert any("SPF" in s for s in groups[0]["next_steps"])


### PR DESCRIPTION
## What

The PDF report's finding detail now carries a concrete, **ordered remediation checklist** per finding type, on top of the existing Remediation prose.

> **Recommended Next Steps** (Missing HSTS)
> 1. Confirm the site is fully reachable over HTTPS.
> 2. Add \`Strict-Transport-Security: max-age=31536000; includeSubDomains\`.
> 3. Once stable across all subdomains, add \`preload\` and submit at hstspreload.org.

## Why

The report said *what's wrong*; it didn't say, step by step, *what to do next*. This turns each finding into copy-pasteable actions for the person who has to action it.

## Design

- **Keyed by effective key** — the email \`control\` where findings share \`check_type="email"\` (spf/dmarc/dkim), else the \`check_type\`. Same resolution the Business Impact copy already uses.
- **Covers the common types:** web security headers, cookies, CORS, server/version disclosure, directory listing, security.txt, email auth, TLS (weak cipher / no-FS / expired cert), SSH (password auth / root login), subdomain takeover, open cloud bucket, exposed secret.
- **Unmapped types render nothing** — no empty "Next Steps" block ever shows.
- **Hosted-only gating.** Renders when \`REPORT_CTA_URL\` is configured — the same flag that already marks a hosted deployment (\"self-hosters with no CTA get a clean report\"). Self-hosters keep the per-finding Remediation prose; the numbered checklist is the hosted-report extra, per the roadmap's \"hosted reports only\" scope.

## Scope

Report-only — no scanning, model, or API change.

## Tests

+5 in \`test_reports.py\`: absent when not hosted, present + correct step text when hosted, group attaches steps for a mapped check, empty list for an unmapped check, email-control keying. Full \`test_reports\` suite green (80 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv