### PR TITLE
chore: release v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.12.0] — 2026-09-10
+
 ### Changed
 - **Faster phase-1 (Domain Intelligence) — concurrency where it was serial.** Two
   changes cut the phase from up-to-minutes toward seconds:
@@ -1435,7 +1437,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.11.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.12.0...HEAD
+[v2.12.0]: https://github.com/cybersecify/OpenEASD/compare/v2.11.0...v2.12.0
 [v2.11.0]: https://github.com/cybersecify/OpenEASD/compare/v2.10.1...v2.11.0
 [v2.10.1]: https://github.com/cybersecify/OpenEASD/compare/v2.10.0...v2.10.1
 [v2.10.0]: https://github.com/cybersecify/OpenEASD/compare/v2.9.1...v2.10.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.9.1 — 2026-09-10)
+## Status (v2.12.0 — 2026-09-10)
 
-- **Released**: v2.9.1 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.9.1` / `:v2.9` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.12.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.12.0` / `:v2.12` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 29 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.11.0"
+version = "2.12.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Release **v2.12.0**. Finalizes the CHANGELOG (`Unreleased` → `v2.12.0` + compare link), bumps the version in `pyproject.toml` / `uv.lock`, and refreshes the CLAUDE.md status header.

## Highlights since v2.11.0
- **Data Leak** tool category (hudson_rock/breach_check/github_secrets/js_secrets)
- **"Since Your Last Scan"** report delta + alert line
- **security.txt (RFC 9116)** responsible-disclosure check
- **Per-finding "Recommended Next Steps"** on hosted reports
- **`domain_security` split** into a passive tool + active `domain_probe` (passive scans now get DNS/email/RDAP intel)
- **`render_pipeline_diagram`** management command (generated, drift-proof diagram)
- **Faster phase-1** — typosquat + light-phase concurrency

Merging this, then tagging `main` as `v2.12.0` to trigger the GHCR publish (`:v2.12.0` / `:v2.12` / `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv