### PR TITLE
feat: deeper SPF/DMARC email-auth checks in domain_security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **Deeper email-authentication checks in `domain_security`.** Beyond present/absent
+  SPF/DMARC, the phase-1 passive check now catches the gaps that actually let mail
+  be spoofed or silently unprotected:
+  - **SPF:** neutral `?all` and *no* `all` mechanism (both = no protection); and the
+    **RFC 7208 ten-DNS-lookup limit** — over 10 lookups SPF returns permerror and is
+    silently ignored (**high**), with a **near-limit** warning at 8–10 (nested
+    includes can tip it over).
+  - **DMARC:** subdomain policy `sp=none` under an enforcing `p=` (subdomains left
+    spoofable), partial enforcement `pct<100`, and missing `rua=` (no reporting
+    visibility).
+  - **Bug fix:** the old DMARC check used `"p=none" in record`, which substring-matches
+    `sp=none` — a `p=reject; sp=none` record was mis-reported as `p=none`. Now parsed
+    by tag. Passive, no new tool. Fast mocked tests in `test_domain_security_email.py`.
+
 ## [v2.12.0] — 2026-09-10
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -828,6 +828,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_dnsx.py` | 21 | Public IP filter, analyzer, scanner |
 | `tests/unit/test_domain_authorization.py` | 10 | DomainAuthorization model + scan-entry gating |
 | `tests/unit/test_domain_security.py` | 46 | Passive DNS/DNSSEC/email-auth/RDAP — **slow, real network** (active AXFR/open-relay/MTA-STS tests moved to test_domain_probe) |
+| `tests/unit/test_domain_security_email.py` | 15 | Email-auth DEPTH (fast, mocked): SPF neutral/no-all/soft-fail/+all, RFC-7208 lookup-limit (>10 permerror / near-limit) + counter; DMARC p/quarantine, sp=none-not-misread-as-p=none regression, pct<100, missing rua, malformed pct |
 | `tests/unit/test_domain_probe.py` | 17 | Active domain probes — tool_meta (active/runner/group), AXFR zone transfer, MTA-STS policy fetch, SMTP open-relay (all mocked, source="domain_probe"), orchestrator stamps controls |
 | `tests/unit/test_domains.py` | 13 | Domain CRUD |
 | `tests/unit/test_historical_urls.py` | 37 | collector (missing binary, timeout, happy path), analyzer (noise filter, FK links, dedup), scanner |
@@ -897,6 +898,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1842 tests** (1796 fast + 46 slow domain_security)
+**Total: 1857 tests** (1811 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -333,6 +333,27 @@ def _get_txt_record(domain) -> list:
         return []
 
 
+_SPF_LOOKUP_LIMIT = 10  # RFC 7208 §4.6.4 — over this, receivers return permerror.
+
+
+def _spf_lookup_count(spf: str) -> int:
+    """Count the DNS-lookup-causing mechanisms in an SPF record (include / a / mx /
+    ptr / exists / redirect). Top-level only — nested includes can push the real
+    total higher, so a count near the limit is still a risk."""
+    count = 0
+    for term in spf.split()[1:]:  # skip the "v=spf1" version token
+        t = term.lstrip("+-~?").lower()
+        if t.startswith(("include:", "exists:", "redirect=")):
+            count += 1
+        elif t == "a" or t.startswith(("a:", "a/")):
+            count += 1
+        elif t == "mx" or t.startswith(("mx:", "mx/")):
+            count += 1
+        elif t == "ptr" or t.startswith("ptr:"):
+            count += 1
+    return count
+
+
 def _check_spf(session, domain) -> list:
     findings = []
     txt_records = _get_txt_record(domain)
@@ -346,26 +367,84 @@ def _check_spf(session, domain) -> list:
             description=f"{domain} has no SPF record. Anyone can spoof email from this domain.",
             remediation="Add a TXT record: v=spf1 include:<your-mail-provider> -all",
         ))
-    else:
-        spf = spf_records[0]
-        if "~all" in spf:
-            findings.append(Finding(
+        return findings
+
+    spf = spf_records[0]
+
+    # Policy strength — the trailing `all` qualifier decides what happens to mail
+    # that isn't from an authorised sender.
+    if "+all" in spf:
+        findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
-                severity="medium",
-                title="SPF policy is soft fail (~all)",
-                description="SPF is set to ~all (soft fail). Spoofed emails may still be delivered.",
-                remediation="Change ~all to -all for strict enforcement.",
-                extra={"spf_record": spf},
-            ))
-        elif "+all" in spf:
-            findings.append(Finding(
+            severity="critical",
+            title="SPF policy allows all senders (+all)",
+            description="SPF +all means any server can send email as this domain.",
+            remediation="Change +all to -all immediately.",
+            extra={"spf_record": spf},
+        ))
+    elif "~all" in spf:
+        findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
-                severity="critical",
-                title="SPF policy allows all senders (+all)",
-                description="SPF +all means any server can send email as this domain.",
-                remediation="Change +all to -all immediately.",
-                extra={"spf_record": spf},
-            ))
+            severity="medium",
+            title="SPF policy is soft fail (~all)",
+            description="SPF is set to ~all (soft fail). Spoofed emails may still be delivered.",
+            remediation="Change ~all to -all for strict enforcement.",
+            extra={"spf_record": spf},
+        ))
+    elif "?all" in spf:
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="medium",
+            title="SPF policy is neutral (?all)",
+            description=(
+                "SPF ?all provides no protection — receivers treat an unauthorised "
+                "sender's result as neutral, so spoofed mail is not rejected."
+            ),
+            remediation="Change ?all to -all for strict enforcement.",
+            extra={"spf_record": spf},
+        ))
+    elif not any(q in spf for q in ("-all", "~all", "+all", "?all")):
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="medium",
+            title="SPF record has no 'all' mechanism",
+            description=(
+                "The SPF record has no trailing all mechanism, so it defaults to "
+                "neutral (?all) — unauthorised senders are not rejected."
+            ),
+            remediation="Append -all to the SPF record for strict enforcement.",
+            extra={"spf_record": spf},
+        ))
+
+    # RFC 7208 DNS-lookup limit — over 10 lookups, receivers return permerror and
+    # SPF is silently NOT applied (protection fails without any visible error).
+    lookups = _spf_lookup_count(spf)
+    if lookups > _SPF_LOOKUP_LIMIT:
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="high",
+            title="SPF exceeds the 10 DNS-lookup limit",
+            description=(
+                f"The SPF record uses {lookups} DNS-lookup mechanisms; RFC 7208 caps "
+                "this at 10. Over the limit, receivers return permerror and SPF is not "
+                "applied — spoofing protection silently fails."
+            ),
+            remediation="Reduce include/a/mx/redirect mechanisms, or flatten includes.",
+            extra={"spf_record": spf, "lookups": lookups},
+        ))
+    elif lookups >= _SPF_LOOKUP_LIMIT - 2:
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="medium",
+            title="SPF is near the 10 DNS-lookup limit",
+            description=(
+                f"The SPF record uses {lookups} top-level DNS-lookup mechanisms. Nested "
+                "includes can push the real total over the RFC 7208 limit of 10, at "
+                "which point SPF fails with permerror."
+            ),
+            remediation="Trim or flatten includes to stay well under 10 lookups.",
+            extra={"spf_record": spf, "lookups": lookups},
+        ))
 
     return findings
 
@@ -383,25 +462,87 @@ def _check_dmarc(session, domain) -> list:
             description=f"{domain} has no DMARC record. Email spoofing is not prevented.",
             remediation=f"Add a TXT record at _dmarc.{domain}: v=DMARC1; p=reject; rua=mailto:dmarc@{domain}",
         ))
-    else:
-        if "p=none" in dmarc:
-            findings.append(Finding(
+        return findings
+
+    # Parse the record into tags — substring checks ("p=none" in dmarc) are
+    # wrong: "p=none" is a substring of "sp=none", so p=reject; sp=none would be
+    # mis-read as p=none.
+    tags: dict[str, str] = {}
+    for part in dmarc.split(";"):
+        if "=" in part:
+            key, _, val = part.partition("=")
+            tags[key.strip().lower()] = val.strip()
+    policy = tags.get("p", "").lower()
+    subpolicy = tags.get("sp", "").lower()
+    rua = tags.get("rua", "")
+
+    # Policy strength.
+    if policy == "none":
+        findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
-                severity="medium",
-                title="DMARC policy is none (monitoring only)",
-                description="DMARC p=none means no action is taken on failing emails.",
-                remediation="Change DMARC policy to p=quarantine or p=reject.",
-                extra={"dmarc_record": dmarc},
-            ))
-        elif "p=quarantine" in dmarc:
-            findings.append(Finding(
+            severity="medium",
+            title="DMARC policy is none (monitoring only)",
+            description="DMARC p=none means no action is taken on failing emails.",
+            remediation="Change DMARC policy to p=quarantine or p=reject.",
+            extra={"dmarc_record": dmarc},
+        ))
+    elif policy == "quarantine":
+        findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="email",
-                severity="low",
-                title="DMARC policy is quarantine (not reject)",
-                description="DMARC p=quarantine sends failing emails to spam. p=reject is stronger.",
-                remediation="Consider upgrading DMARC policy to p=reject.",
-                extra={"dmarc_record": dmarc},
-            ))
+            severity="low",
+            title="DMARC policy is quarantine (not reject)",
+            description="DMARC p=quarantine sends failing emails to spam. p=reject is stronger.",
+            remediation="Consider upgrading DMARC policy to p=reject.",
+            extra={"dmarc_record": dmarc},
+        ))
+
+    # Subdomain policy weaker than the domain policy — subdomains left spoofable.
+    if subpolicy == "none" and policy in ("quarantine", "reject"):
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="medium",
+            title="DMARC subdomain policy is none (sp=none)",
+            description=(
+                f"{domain} enforces DMARC (p={policy}) but sets sp=none, so its "
+                "SUBDOMAINS are unprotected — an attacker can spoof mail from any "
+                "subdomain."
+            ),
+            remediation="Remove sp=none (subdomains inherit p) or set sp=reject.",
+            extra={"dmarc_record": dmarc},
+        ))
+
+    # Partial enforcement — pct<100 applies the policy to only some failing mail.
+    pct_raw = tags.get("pct", "")
+    try:
+        pct = int(pct_raw) if pct_raw else 100
+    except ValueError:
+        pct = 100
+    if pct < 100:
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="low",
+            title="DMARC is only partially enforced (pct<100)",
+            description=(
+                f"DMARC pct={pct} applies the policy to only {pct}% of failing mail; "
+                "the rest is delivered, diluting protection."
+            ),
+            remediation="Set pct=100 (or omit pct, which defaults to 100).",
+            extra={"dmarc_record": dmarc, "pct": pct},
+        ))
+
+    # No aggregate reporting — no visibility into who is sending as the domain.
+    if not rua:
+        findings.append(Finding(
+            session=session, source="domain_security", target=domain, check_type="email",
+            severity="low",
+            title="DMARC has no aggregate reporting (rua)",
+            description=(
+                f"{domain}'s DMARC record has no rua= address, so there is no visibility "
+                "into who is sending — or spoofing — mail as this domain."
+            ),
+            remediation=f"Add rua=mailto:dmarc@{domain} to receive aggregate reports.",
+            extra={"dmarc_record": dmarc},
+        ))
 
     return findings
 

--- a/tests/unit/test_domain_security_email.py
+++ b/tests/unit/test_domain_security_email.py
@@ -1,0 +1,113 @@
+"""Fast, fully-mocked tests for domain_security's email-auth DEPTH checks
+(SPF lookup limit / neutral / no-all, DMARC sp / pct / rua).
+
+These live in their own file — separate from the network-touching
+test_domain_security.py that fast CI excludes — because the spoofing/permerror
+logic they cover is important enough to run on every CI run. Everything here is
+mocked at _get_txt_record, so there is no real DNS.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _session():
+    from apps.core.engine.scans.models import ScanSession
+    return ScanSession.objects.create(domain="example.com", scan_type="full", status="pending")
+
+
+def _spf(record):
+    from apps.domain_security.scanner import _check_spf
+    with patch("apps.domain_security.scanner._get_txt_record", return_value=[record]):
+        return _check_spf(_session(), "example.com")
+
+
+def _dmarc(record):
+    from apps.domain_security.scanner import _check_dmarc
+    with patch("apps.domain_security.scanner._get_txt_record", return_value=[record]):
+        return _check_dmarc(_session(), "example.com")
+
+
+# ---------------------------------------------------------------------------
+# SPF
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestSPFDepth:
+    def test_neutral_all_medium(self):
+        titles = {(f.title, f.severity) for f in _spf("v=spf1 include:x.com ?all")}
+        assert ("SPF policy is neutral (?all)", "medium") in titles
+
+    def test_no_all_mechanism_medium(self):
+        titles = {(f.title, f.severity) for f in _spf("v=spf1 include:x.com")}
+        assert ("SPF record has no 'all' mechanism", "medium") in titles
+
+    def test_hard_fail_single_lookup_clean(self):
+        assert _spf("v=spf1 include:x.com -all") == []
+
+    def test_soft_fail_still_medium(self):
+        # Existing behaviour preserved.
+        titles = {f.title for f in _spf("v=spf1 include:x.com ~all")}
+        assert "SPF policy is soft fail (~all)" in titles
+
+    def test_plus_all_critical(self):
+        titles = {(f.title, f.severity) for f in _spf("v=spf1 +all")}
+        assert ("SPF policy allows all senders (+all)", "critical") in titles
+
+    def test_too_many_lookups_high(self):
+        rec = "v=spf1 " + " ".join(f"include:s{i}.com" for i in range(11)) + " -all"
+        hi = next(f for f in _spf(rec) if f.title == "SPF exceeds the 10 DNS-lookup limit")
+        assert hi.severity == "high"
+        assert hi.extra["lookups"] == 11
+
+    def test_near_lookup_limit_medium(self):
+        rec = "v=spf1 " + " ".join(f"include:s{i}.com" for i in range(8)) + " -all"
+        titles = {f.title for f in _spf(rec)}
+        assert "SPF is near the 10 DNS-lookup limit" in titles
+
+    def test_lookup_counter_counts_a_mx_redirect(self):
+        from apps.domain_security.scanner import _spf_lookup_count
+        # include(1) + a(1) + mx(1) + a:host(1) + redirect(1) = 5; ip4 / -all cost 0.
+        rec = "v=spf1 include:x.com a mx a:mail.x.com ip4:1.2.3.4 redirect=y.com"
+        assert _spf_lookup_count(rec) == 5
+
+
+# ---------------------------------------------------------------------------
+# DMARC
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestDMARCDepth:
+    def test_none_policy_medium(self):
+        titles = {(f.title, f.severity)
+                  for f in _dmarc("v=DMARC1; p=none; rua=mailto:d@example.com")}
+        assert ("DMARC policy is none (monitoring only)", "medium") in titles
+
+    def test_quarantine_policy_low(self):
+        titles = {f.title for f in _dmarc("v=DMARC1; p=quarantine; rua=mailto:d@example.com")}
+        assert "DMARC policy is quarantine (not reject)" in titles
+
+    def test_pct_partial_low(self):
+        f = next(f for f in _dmarc("v=DMARC1; p=reject; rua=mailto:d@example.com; pct=50")
+                 if f.title == "DMARC is only partially enforced (pct<100)")
+        assert f.severity == "low" and f.extra["pct"] == 50
+
+    def test_sp_none_not_misread_as_p_none(self):
+        # Regression: "p=none" is a substring of "sp=none".
+        found = _dmarc("v=DMARC1; p=reject; sp=none; rua=mailto:d@example.com")
+        titles = {f.title for f in found}
+        assert "DMARC policy is none (monitoring only)" not in titles
+        assert "DMARC subdomain policy is none (sp=none)" in titles
+
+    def test_missing_rua_low(self):
+        titles = {(f.title, f.severity) for f in _dmarc("v=DMARC1; p=reject")}
+        assert ("DMARC has no aggregate reporting (rua)", "low") in titles
+
+    def test_reject_with_rua_and_pct100_clean(self):
+        assert _dmarc("v=DMARC1; p=reject; rua=mailto:d@example.com") == []
+
+    def test_malformed_pct_ignored(self):
+        # pct=abc must not crash and must not flag partial enforcement.
+        titles = {f.title for f in _dmarc("v=DMARC1; p=reject; rua=mailto:d@x; pct=abc")}
+        assert "DMARC is only partially enforced (pct<100)" not in titles


### PR DESCRIPTION
## What

`domain_security` (phase-1, passive) now checks email-auth **depth**, not just present/absent — the gaps that actually let mail be spoofed or leave protection silently broken.

**SPF**
- Neutral `?all` and *no* `all` mechanism → both provide no protection (medium)
- **RFC 7208 ten-DNS-lookup limit** — over 10 lookups SPF returns `permerror` and is silently ignored (**high**); a **near-limit** warning at 8–10 (nested includes can tip the real total over)

**DMARC**
- `sp=none` under an enforcing `p=` → subdomains left spoofable (medium)
- `pct<100` → partial enforcement dilutes the policy (low)
- Missing `rua=` → no reporting visibility (low)

## Bug fix

The old DMARC check used `"p=none" in record` — and `"p=none"` is a **substring of `"sp=none"`**, so a `p=reject; sp=none` record was mis-reported as `p=none`. Now parsed properly by tag. (Regression test included.)

## Scope

Passive, no new tool, no registry/Full-Scan change — `check_type="email"` is reused, so all report CWE/scope/next-steps mappings already apply.

## Tests

+15 in a **new fast file** `test_domain_security_email.py` — deliberately separate from the network-touching `test_domain_security.py` (which fast CI excludes) so this spoofing/permerror logic runs on every CI run. Fully mocked at `_get_txt_record`. Covers each new SPF/DMARC finding, the lookup counter, the `sp=none` regression, and malformed `pct`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv