### PR TITLE
feat: asn_cluster — cluster lookalikes by shared hosting ASN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **Lookalike ASN clustering — new `asn_cluster` tool.** Turns isolated
+  typosquat findings into a *campaign* signal: it reads the registered
+  `lookalike_domain` findings, resolves their IPs to autonomous systems via Team
+  Cymru's keyless DNS service, and groups lookalikes that share an ASN into a
+  single `lookalike_cluster` finding ("6 lookalikes all resolve into AS-NNNNN —
+  coordinated phishing infrastructure; take them down together"). A cluster with a
+  weaponized member (login form / brand impersonation, as flagged by typosquat) is
+  **high**, else **medium**; a lone lookalike per ASN raises nothing. **Passive**
+  (queries Team Cymru, never the target or the lookalikes), fail-graceful,
+  `requires: [typosquat]`, phase 12 (runs after typosquat's findings exist). Joins
+  Full Scan + Passive Scan (migration 0032); registry tool count 29 → 30. This is
+  the target-scoped slice of adversary-infrastructure correlation — it clusters
+  *your* lookalikes, not the whole internet.
 - **Deeper email-authentication checks in `domain_security`.** Beyond present/absent
   SPF/DMARC, the phase-1 passive check now catches the gaps that actually let mail
   be spoofed or silently unprotected:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 - **Released**: v2.12.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
   `:v2.12.0` / `:v2.12` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
-- **Scope**: 29 registered scan tools across 12 pipeline phases; single-user
+- **Scope**: 30 registered scan tools across 12 pipeline phases; single-user
   (one admin, no RBAC) by design.
 - **Engine**: DBOS durable workflows on PostgreSQL — one multi-step `run_scan`
   workflow per scan (checkpoint/resume) + `@durable_task` for one-step tasks
@@ -465,7 +465,7 @@ a terminal tree (`--format text`), or JSON (`--format json`). Because it reads
 `tool_meta` live, it can never drift; a test (`test_render_pipeline_diagram.py`)
 guards that every registered tool appears in the output.
 
-### Tool apps (29 registered tools)
+### Tool apps (30 registered tools)
 
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
@@ -498,6 +498,7 @@ guards that every registered tool appears in the output.
 | `apps/web_checker/` | 11 | Web Exposure | Yes | Security headers, cookies, CORS; + security.txt (RFC 9116) responsible-disclosure check on the apex |
 | `apps/js_secrets/` | 11 | Data Leak | Yes | Hardcoded-secret detection — fetches discovered `.js` assets and runs gitleaks over them; secret is redacted before storage |
 | `apps/cve_intel/` | 12 | Prioritization | No | Enriches CVE findings in place with EPSS scores + CISA KEV flags (no new findings) |
+| `apps/asn_cluster/` | 12 | Domain Intelligence | Yes | Lookalike ASN clustering — reads typosquat's `lookalike_domain` findings, resolves their IPs to ASNs via Team Cymru (keyless DNS), and groups lookalikes sharing an autonomous system into `lookalike_cluster` campaign findings (weaponized member → high). Passive, fail-graceful, `requires: [typosquat]` |
 
 ### Tool app structure
 ```
@@ -562,7 +563,7 @@ the registry via `get_tool_active()` and `is_passive_tool_set(tools)`.
   Passive tools: `domain_security`, `subfinder`, `alterx`, `dnsx`,
   `historical_urls`, `cloud_assets`, `cve_intel`, `asn_discovery`, `hudson_rock`,
   `shodan`, `typosquat`, `breach_check`, `github_secrets`, `github_recon`,
-  `dns_history`.
+  `dns_history`, `asn_cluster`.
 - **Active** (`active=True`): probes the target directly (port scans, HTTP/TLS/SSH
   connections, crawling, vuln templates, AXFR/SMTP/mta-sts probes). **Requires
   `DomainAuthorization`.**
@@ -865,6 +866,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_subfinder.py` | 10 | JSON parser, dedup, hostname normalization |
 | `tests/unit/test_subscan.py` | 12 | Targeted re-scan of a single tool / subset |
 | `tests/unit/test_typosquat.py` | 36 | candidate generation (all 8 techniques, uniqueness, no-original, www-strip, cap/truncation-logged), passive DNS registration check (A/MX/NS, NXDOMAIN + timeout never raise), weaponization homepage probe (login form + brand mention flagged, fetch failure graceful), analyzer severity (A/MX → medium, NS-only → low, login-form/brand → high), scanner (saves + never-raises), concurrent collect (order-preserving, all-registered-checked, fetch cap) |
+| `tests/unit/test_asn_cluster.py` | 13 | Lookalike ASN clustering — meta (passive/group), Team Cymru IP→ASN parse (asn/prefix/name, space-list ASN, non-IPv4 + DNS-failure → None), clustering (≥2 same-ASN → finding, single → none, weaponized → high, unresolved-IPs ignored), scanner (<2 lookalikes no-op, persists, skips IP-less, no lookup when nothing to cluster) |
 | `tests/unit/test_takeover_check.py` | 35 | collector (missing binary, bad JSON, happy path), analyzer (vulnerable/non-vulnerable, FK link, dedup), scanner |
 | `tests/unit/test_tls_checker.py` | 87 | Cert parsing, ciphers, protocols, HSTS, collector, scanner, cipher enumeration |
 | `tests/unit/test_tools_healthcheck.py` | 14 | Tool binary preflight / health checks |
@@ -898,6 +900,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1857 tests** (1811 fast + 46 slow domain_security)
+**Total: 1870 tests** (1824 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline**: 29-tool scan workflow from domain to findings
+- **Automated pipeline**: 30-tool scan workflow from domain to findings
 - **Network attack surface scanning**: CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **CVE prioritisation**: EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows**: Create custom scan configurations, enable/disable tools per workflow
@@ -195,6 +195,8 @@ Phase 1  Typosquat          - Lookalike / typosquat domain detection (passive;
                              registered lookalikes via public DNS — phishing/brand abuse)
 Phase 1  DNS History        - Historical A/AAAA/MX records via a passive-DNS
                              dataset (passive; BYO DNS_HISTORY_API_URL)
+Phase 12 ASN Clustering     - Groups registered lookalikes by shared hosting ASN
+                             (Team Cymru, passive) — coordinated phishing infra
 
 ── Data Leak ────────────────────────────────────────────────────────────────
 Phase 1  Hudson Rock        - Infostealer-log exposure via Hudson Rock's keyless

--- a/apps/asn_cluster/analyzer.py
+++ b/apps/asn_cluster/analyzer.py
@@ -1,0 +1,91 @@
+"""Cluster registered lookalikes by shared hosting ASN.
+
+Turns N isolated `lookalike_domain` findings into a campaign signal: when two or
+more lookalikes resolve into the same autonomous system, that shared
+infrastructure is a strong indicator of coordinated phishing — worth prioritising
+as one takedown rather than N separate ones.
+"""
+
+import logging
+from collections import defaultdict
+
+from apps.core.data.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+
+def cluster(session, lookalikes: list[dict], asn_by_ip: dict) -> list[Finding]:
+    """Build one Finding per ASN shared by ≥2 distinct lookalike candidates.
+
+    lookalikes: ``[{"candidate", "ips": [...], "weaponized": bool}]``
+    asn_by_ip:  ``{ip: {"asn", "as_name", "prefix"}}``
+
+    A cluster with any weaponized member (login form / brand impersonation, as
+    flagged by typosquat) is `high`; otherwise `medium`.
+    """
+    members: dict[str, set] = defaultdict(set)      # asn -> {candidate}
+    weaponized: dict[str, set] = defaultdict(set)    # asn -> {weaponized candidate}
+    as_names: dict[str, str] = {}                    # asn -> name
+    prefixes: dict[str, set] = defaultdict(set)      # asn -> {bgp prefix}
+
+    for la in lookalikes:
+        touched: set[str] = set()
+        for ip in la.get("ips", []):
+            info = asn_by_ip.get(ip)
+            if not info:
+                continue
+            asn = info["asn"]
+            touched.add(asn)
+            as_names.setdefault(asn, info.get("as_name", "") or "")
+            if info.get("prefix"):
+                prefixes[asn].add(info["prefix"])
+        for asn in touched:
+            members[asn].add(la["candidate"])
+            if la.get("weaponized"):
+                weaponized[asn].add(la["candidate"])
+
+    findings: list[Finding] = []
+    apex = getattr(session, "domain", "") or ""
+    for asn, candidates in members.items():
+        if len(candidates) < 2:
+            continue  # not a cluster — a single lookalike per ASN is unremarkable
+        cands = sorted(candidates)
+        weap = sorted(weaponized[asn])
+        name = as_names.get(asn) or "unknown network"
+        severity = "high" if weap else "medium"
+        weap_note = (
+            f" {len(weap)} of them show active phishing signals "
+            f"(login form / brand impersonation)."
+            if weap else ""
+        )
+        findings.append(Finding(
+            session=session,
+            source="asn_cluster",
+            check_type="lookalike_cluster",
+            severity=severity,
+            title=f"{len(cands)} lookalike domains share hosting (AS{asn} {name})",
+            description=(
+                f"{len(cands)} registered lookalikes of {apex} resolve into the same "
+                f"autonomous system — AS{asn} ({name}). Shared infrastructure across "
+                f"multiple lookalikes indicates coordinated phishing infrastructure "
+                f"rather than unrelated registrations.{weap_note} "
+                f"Domains: {', '.join(cands)}."
+            ),
+            remediation=(
+                "Treat these as one campaign: file takedowns together, report the "
+                f"shared network (AS{asn}) to its hosting provider / registrar, and "
+                "monitor the ASN for further lookalikes."
+            ),
+            target=f"AS{asn}",
+            extra={
+                "asn": asn,
+                "as_name": name,
+                "prefixes": sorted(prefixes[asn]),
+                "candidates": cands,
+                "member_count": len(cands),
+                "weaponized": weap,
+                "weaponized_count": len(weap),
+            },
+        ))
+
+    return findings

--- a/apps/asn_cluster/apps.py
+++ b/apps/asn_cluster/apps.py
@@ -1,0 +1,21 @@
+from django.apps import AppConfig
+
+
+class AsnClusterConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.asn_cluster"
+    label = "asn_cluster"
+    verbose_name = "Lookalike ASN Clustering"
+    tool_meta = {
+        "label": "Lookalike ASN Clustering",
+        "runner": "apps.asn_cluster.scanner.run_asn_cluster",
+        # Late phase: it correlates typosquat's already-written lookalike findings,
+        # so it must run after phase 1. Sits with cve_intel in Prioritization order.
+        "phase": 12,
+        "phase_group": "Domain Intelligence",
+        "requires": ["typosquat"],
+        "produces_findings": True,
+        # PASSIVE: IP→ASN via Team Cymru's keyless DNS service (a third party) —
+        # never contacts the target or the lookalike domains. No auth needed.
+        "active": False,
+    }

--- a/apps/asn_cluster/collector.py
+++ b/apps/asn_cluster/collector.py
@@ -1,0 +1,60 @@
+"""IP → ASN lookup via Team Cymru's keyless DNS service.
+
+Passive: queries Team Cymru (a third party), never the target or the lookalike
+domains. Fail-graceful — any DNS failure yields None, never raises.
+
+Team Cymru protocol (IPv4):
+  - origin: TXT `<d.c.b.a>.origin.asn.cymru.com`
+      → "ASN | BGP Prefix | CC | Registry | Allocated"  (ASN may be a space-list)
+  - name:   TXT `AS<n>.asn.cymru.com`
+      → "ASN | CC | Registry | Allocated | AS-NAME, CC"
+"""
+
+import logging
+
+import dns.resolver
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+_DNS_TIMEOUT = getattr(settings, "SCANNER_DNS_TIMEOUT", 5)
+
+
+def _txt(name: str) -> list[str]:
+    """Resolve a TXT record; [] on any failure. Never raises."""
+    try:
+        r = dns.resolver.Resolver()
+        r.timeout = _DNS_TIMEOUT
+        r.lifetime = _DNS_TIMEOUT
+        answers = r.resolve(name, "TXT")
+    except Exception:  # noqa: BLE001 — any resolver failure = "no data"
+        return []
+    return [b"".join(rd.strings).decode("utf-8", errors="ignore") for rd in answers]
+
+
+def lookup_asn(ip: str) -> "dict | None":
+    """Return ``{"asn", "as_name", "prefix"}`` for an IPv4 address, or None.
+
+    IPv4 only — Team Cymru's ``origin6`` zone would be needed for IPv6; lookalike
+    A-records are effectively always v4, so v6 is skipped rather than mis-parsed.
+    """
+    parts = (ip or "").strip().split(".")
+    if len(parts) != 4 or not all(p.isdigit() for p in parts):
+        return None
+
+    origin = _txt(f"{'.'.join(reversed(parts))}.origin.asn.cymru.com")
+    if not origin:
+        return None
+    fields = [f.strip() for f in origin[0].split("|")]
+    asn = fields[0].split()[0] if fields and fields[0] else ""
+    if not asn:
+        return None
+    prefix = fields[1] if len(fields) > 1 else ""
+
+    as_name = ""
+    name_txt = _txt(f"AS{asn}.asn.cymru.com")
+    if name_txt:
+        nf = [f.strip() for f in name_txt[0].split("|")]
+        as_name = nf[-1] if nf else ""
+
+    return {"asn": asn, "as_name": as_name, "prefix": prefix}

--- a/apps/asn_cluster/models.py
+++ b/apps/asn_cluster/models.py
@@ -1,0 +1,5 @@
+"""asn_cluster writes to apps.core.data.findings.Finding — no models of its own.
+
+Intentionally empty: findings land in the unified Finding model, like every
+tool app. No migrations needed.
+"""

--- a/apps/asn_cluster/scanner.py
+++ b/apps/asn_cluster/scanner.py
@@ -1,0 +1,63 @@
+"""asn_cluster scanner — orchestrator: read typosquat lookalikes → IP→ASN → cluster.
+
+Reads the `lookalike_domain` findings typosquat already wrote (shared DB data,
+not a cross-tool import), resolves their A-record IPs to ASNs via Team Cymru, and
+groups lookalikes that share an autonomous system into cluster findings. No-op
+(returns []) when there are fewer than two registered, IP-bearing lookalikes to
+correlate. Never raises — a lookup failure just drops that IP.
+"""
+
+import logging
+
+from apps.core.data.findings.models import Finding
+from .collector import lookup_asn
+from .analyzer import cluster
+
+logger = logging.getLogger(__name__)
+
+# Safety cap on distinct IPs looked up per scan (each = up to 2 DNS queries).
+_MAX_IPS = 256
+
+
+def run_asn_cluster(session) -> list[Finding]:
+    lookalikes: list[dict] = []
+    ips: set[str] = set()
+
+    qs = Finding.objects.filter(
+        session=session, source="typosquat", check_type="lookalike_domain"
+    )
+    for f in qs:
+        extra = f.extra if isinstance(f.extra, dict) else {}
+        cand_ips = extra.get("resolved_ips") or []
+        if not cand_ips:
+            continue  # only A-record-bearing lookalikes can be clustered by host
+        lookalikes.append({
+            "candidate": extra.get("candidate") or f.target,
+            "ips": cand_ips,
+            # typosquat marks weaponized lookalikes (login form / brand) as high.
+            "weaponized": f.severity == "high",
+        })
+        ips.update(cand_ips)
+
+    if len(lookalikes) < 2:
+        logger.info(
+            "[asn_cluster:%s] %d clusterable lookalike(s) — nothing to correlate",
+            session.id, len(lookalikes),
+        )
+        return []
+
+    asn_by_ip: dict = {}
+    for ip in list(ips)[:_MAX_IPS]:
+        info = lookup_asn(ip)
+        if info:
+            asn_by_ip[ip] = info
+
+    findings = cluster(session, lookalikes, asn_by_ip)
+    if findings:
+        Finding.objects.bulk_create(findings)
+
+    logger.info(
+        "[asn_cluster:%s] %d lookalike(s) over %d ASN-resolved IP(s) → %d cluster(s)",
+        session.id, len(lookalikes), len(asn_by_ip), len(findings),
+    )
+    return findings

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -44,7 +44,7 @@ _SCOPE_BY_SOURCE = {
 }
 _SCOPE_BY_CHECK = {
     "rdap": "Domain", "dns": "DNS", "caa": "DNS", "dnssec": "DNS",
-    "open_relay": "Email / DNS",
+    "open_relay": "Email / DNS", "lookalike_cluster": "Attack Surface",
 }
 
 # CWE mapping per check_type. Unmapped check types render "—".
@@ -121,6 +121,8 @@ _CWE_BY_CHECK = {
     # A registered lookalike domain is infrastructure built to be visually
     # confused with the org's real domain — the essence of CWE-451.
     "lookalike_domain": "CWE-451: User Interface (UI) Misrepresentation of Critical Information",
+    # asn_cluster — lookalikes sharing one ASN = coordinated impersonation infra.
+    "lookalike_cluster": "CWE-451: User Interface (UI) Misrepresentation of Critical Information",
     # github_recon — infra references (internal hostnames/subdomains, cloud-bucket
     # URLs, API endpoints) and the public-repo surface leaked in the org's PUBLIC
     # GitHub source. CWE-200 (Exposure of Sensitive Information to an Unauthorized
@@ -622,6 +624,11 @@ _NEXT_STEPS_BY_CHECK = {
         "Remove it from the code and load it from a secret manager or environment variable.",
         "Purge it from git history if it was committed.",
     ],
+    "lookalike_cluster": [
+        "Treat the clustered domains as one campaign — file takedowns together.",
+        "Report the shared network (the named ASN) to its hosting provider / registrar.",
+        "Add the ASN and domains to your monitoring/blocklists and watch for new lookalikes on it.",
+    ],
 }
 
 
@@ -734,8 +741,8 @@ _CEO_QUESTIONS = [
      lambda g: g["source"] == "domain_security" and g["check_type"] in ("rdap", "dnssec")),
     ("Are staff logins stolen?", {"hudson_rock", "breach_check"},
      lambda g: g["source"] in ("hudson_rock", "breach_check")),
-    ("Is anyone impersonating us?", {"typosquat"},
-     lambda g: g["source"] == "typosquat"),
+    ("Is anyone impersonating us?", {"typosquat", "asn_cluster"},
+     lambda g: g["source"] in ("typosquat", "asn_cluster")),
     ("Did we leak keys?", {"js_secrets", "github_secrets"},
      lambda g: g["source"] in ("js_secrets", "github_secrets") or g["check_type"] == "exposed_secret"),
 ]

--- a/apps/core/engine/workflows/migrations/0032_add_asn_cluster_to_workflows.py
+++ b/apps/core/engine/workflows/migrations/0032_add_asn_cluster_to_workflows.py
@@ -1,0 +1,55 @@
+"""Add asn_cluster (Lookalike ASN Clustering) to the default workflows.
+
+asn_cluster is a passive, phase-12 correlation tool: it reads typosquat's
+`lookalike_domain` findings, resolves their IPs to ASNs (Team Cymru, keyless),
+and groups lookalikes that share hosting infrastructure into campaign findings.
+It joins:
+
+  * Full Scan    — the invariant test_full_scan_covers_every_registered_tool
+                   requires every non-core registered tool to be in the default
+                   Full Scan.
+  * Passive Scan — it is passive (active=False) and depends on typosquat, which
+                   is already in Passive Scan, so it belongs in the no-auth
+                   passive recon workflow too.
+
+Additive and idempotent (skips if already present), matching 0029/0030/0031.
+Execution order is unaffected — the runner regroups steps by registry phase.
+"""
+
+from django.db import migrations
+
+_TOOL = "asn_cluster"
+_WORKFLOWS = ["Full Scan", "Passive Scan"]
+
+
+def add_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None or wf.steps.filter(tool=_TOOL).exists():
+            continue
+        next_order = (
+            wf.steps.order_by("-order").values_list("order", flat=True).first() or 0
+        ) + 1
+        WorkflowStep.objects.create(workflow=wf, tool=_TOOL, order=next_order, enabled=True)
+
+
+def remove_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None:
+            continue
+        WorkflowStep.objects.filter(workflow=wf, tool=_TOOL).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflow", "0031_split_domain_security_probe"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tool, remove_tool),
+    ]

--- a/openeasd/settings/base.py
+++ b/openeasd/settings/base.py
@@ -115,6 +115,7 @@ INSTALLED_APPS = [
     "ninja_jwt.token_blacklist",
     "apps.domain_security",
     "apps.domain_probe",
+    "apps.asn_cluster",
     "apps.hudson_rock",
     "apps.breach_check",
     "apps.dns_history",

--- a/tests/unit/test_asn_cluster.py
+++ b/tests/unit/test_asn_cluster.py
@@ -1,0 +1,187 @@
+"""Tests for apps/asn_cluster — IP→ASN lookup + lookalike clustering.
+
+Fully mocked at dns.resolver.Resolver.resolve — no real network.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _session():
+    from apps.core.engine.scans.models import ScanSession
+    return ScanSession.objects.create(domain="example.com", scan_type="full", status="pending")
+
+
+def _lookalike(session, candidate, ips, weaponized=False):
+    from apps.core.data.findings.models import Finding
+    return Finding.objects.create(
+        session=session, source="typosquat", check_type="lookalike_domain",
+        severity="high" if weaponized else "medium",
+        title=f"Registered lookalike domain {candidate}",
+        description="d", remediation="r", target=candidate,
+        extra={"candidate": candidate, "resolved_ips": ips, "has_a": True},
+    )
+
+
+# ---------------------------------------------------------------------------
+# tool_meta / registration
+# ---------------------------------------------------------------------------
+
+class TestMeta:
+    def test_passive(self):
+        from apps.core.engine.workflows.registry import get_tool_active
+        assert get_tool_active().get("asn_cluster") is False
+
+    def test_phase_group(self):
+        from apps.core.engine.workflows.registry import get_tool_phase_groups
+        assert get_tool_phase_groups().get("asn_cluster") == "Domain Intelligence"
+
+
+# ---------------------------------------------------------------------------
+# collector — Team Cymru parsing
+# ---------------------------------------------------------------------------
+
+class TestLookupAsn:
+    def _txt_mock(self, mapping):
+        """Return a fake resolve() that yields TXT rdata whose .strings match mapping."""
+        def fake(name, rdtype):
+            for key, val in mapping.items():
+                if name == key:
+                    rd = type("R", (), {"strings": [val.encode()]})()
+                    return [rd]
+            raise Exception("NXDOMAIN")
+        return fake
+
+    def test_parses_asn_prefix_and_name(self):
+        from apps.asn_cluster.collector import lookup_asn
+        m = {
+            "1.1.1.1.origin.asn.cymru.com": "13335 | 1.1.1.0/24 | US | arin | 2010-07-14",
+            "AS13335.asn.cymru.com": "13335 | US | arin | 2010-07-14 | CLOUDFLARENET, US",
+        }
+        with patch("dns.resolver.Resolver.resolve", side_effect=self._txt_mock(m)):
+            info = lookup_asn("1.1.1.1")
+        assert info == {"asn": "13335", "as_name": "CLOUDFLARENET, US", "prefix": "1.1.1.0/24"}
+
+    def test_first_asn_taken_from_space_list(self):
+        from apps.asn_cluster.collector import lookup_asn
+        m = {"4.3.2.1.origin.asn.cymru.com": "111 222 | 1.2.3.0/24 | US | arin |"}
+        with patch("dns.resolver.Resolver.resolve", side_effect=self._txt_mock(m)):
+            info = lookup_asn("1.2.3.4")
+        assert info["asn"] == "111"
+
+    def test_non_ipv4_returns_none(self):
+        from apps.asn_cluster.collector import lookup_asn
+        assert lookup_asn("2606:4700::1111") is None
+        assert lookup_asn("not-an-ip") is None
+
+    def test_dns_failure_returns_none(self):
+        from apps.asn_cluster.collector import lookup_asn
+        with patch("dns.resolver.Resolver.resolve", side_effect=Exception("timeout")):
+            assert lookup_asn("8.8.8.8") is None
+
+
+# ---------------------------------------------------------------------------
+# analyzer — clustering
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCluster:
+    def test_two_lookalikes_same_asn_makes_cluster(self):
+        from apps.asn_cluster.analyzer import cluster
+        sess = _session()
+        lookalikes = [
+            {"candidate": "examp1e.com", "ips": ["1.1.1.1"], "weaponized": False},
+            {"candidate": "exampl3.com", "ips": ["1.1.1.2"], "weaponized": False},
+        ]
+        asn_by_ip = {
+            "1.1.1.1": {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": "1.1.1.0/24"},
+            "1.1.1.2": {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": "1.1.1.0/24"},
+        }
+        out = cluster(sess, lookalikes, asn_by_ip)
+        assert len(out) == 1
+        assert out[0].check_type == "lookalike_cluster"
+        assert out[0].severity == "medium"
+        assert out[0].extra["member_count"] == 2
+        assert set(out[0].extra["candidates"]) == {"examp1e.com", "exampl3.com"}
+
+    def test_single_lookalike_per_asn_no_cluster(self):
+        from apps.asn_cluster.analyzer import cluster
+        sess = _session()
+        lookalikes = [
+            {"candidate": "a.com", "ips": ["1.1.1.1"], "weaponized": False},
+            {"candidate": "b.com", "ips": ["2.2.2.2"], "weaponized": False},
+        ]
+        asn_by_ip = {
+            "1.1.1.1": {"asn": "111", "as_name": "X", "prefix": ""},
+            "2.2.2.2": {"asn": "222", "as_name": "Y", "prefix": ""},
+        }
+        assert cluster(sess, lookalikes, asn_by_ip) == []
+
+    def test_weaponized_member_makes_cluster_high(self):
+        from apps.asn_cluster.analyzer import cluster
+        sess = _session()
+        lookalikes = [
+            {"candidate": "login-a.com", "ips": ["9.9.9.9"], "weaponized": True},
+            {"candidate": "a-secure.com", "ips": ["9.9.9.9"], "weaponized": False},
+        ]
+        asn_by_ip = {"9.9.9.9": {"asn": "666", "as_name": "BadHost", "prefix": "9.9.9.0/24"}}
+        out = cluster(sess, lookalikes, asn_by_ip)
+        assert len(out) == 1
+        assert out[0].severity == "high"
+        assert out[0].extra["weaponized_count"] == 1
+
+    def test_unresolved_ips_ignored(self):
+        from apps.asn_cluster.analyzer import cluster
+        sess = _session()
+        lookalikes = [
+            {"candidate": "a.com", "ips": ["1.1.1.1"], "weaponized": False},
+            {"candidate": "b.com", "ips": ["1.1.1.1"], "weaponized": False},
+        ]
+        assert cluster(sess, lookalikes, {}) == []  # no ASN data → no clusters
+
+
+# ---------------------------------------------------------------------------
+# scanner — orchestration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestScanner:
+    def test_fewer_than_two_lookalikes_noop(self):
+        from apps.asn_cluster.scanner import run_asn_cluster
+        sess = _session()
+        _lookalike(sess, "only-one.com", ["1.1.1.1"])
+        with patch("apps.asn_cluster.scanner.lookup_asn") as lk:
+            out = run_asn_cluster(sess)
+        assert out == []
+        lk.assert_not_called()  # short-circuits before any lookup
+
+    def test_clusters_and_persists(self):
+        from apps.asn_cluster.scanner import run_asn_cluster
+        from apps.core.data.findings.models import Finding
+        sess = _session()
+        _lookalike(sess, "examp1e.com", ["1.1.1.1"])
+        _lookalike(sess, "exampl3.com", ["1.1.1.2"])
+
+        def fake_lookup(ip):
+            return {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": "1.1.1.0/24"}
+
+        with patch("apps.asn_cluster.scanner.lookup_asn", side_effect=fake_lookup):
+            out = run_asn_cluster(sess)
+        assert len(out) == 1
+        assert Finding.objects.filter(session=sess, source="asn_cluster").count() == 1
+
+    def test_skips_lookalikes_without_ips(self):
+        from apps.asn_cluster.scanner import run_asn_cluster
+        sess = _session()
+        # Two lookalikes but neither has resolved_ips → nothing clusterable.
+        from apps.core.data.findings.models import Finding
+        for c in ("a.com", "b.com"):
+            Finding.objects.create(
+                session=sess, source="typosquat", check_type="lookalike_domain",
+                severity="low", title=f"lookalike {c}", description="d", remediation="r",
+                target=c, extra={"candidate": c, "resolved_ips": []},
+            )
+        with patch("apps.asn_cluster.scanner.lookup_asn") as lk:
+            assert run_asn_cluster(sess) == []
+        lk.assert_not_called()

--- a/tests/unit/test_default_workflow.py
+++ b/tests/unit/test_default_workflow.py
@@ -12,6 +12,8 @@ _EXPECTED_FULL_SCAN = {
     "asn_discovery", "js_secrets",
     # added in 0031 — the active probes split out of domain_security
     "domain_probe",
+    # added in 0032 — lookalike ASN clustering
+    "asn_cluster",
 }
 
 
@@ -77,7 +79,7 @@ def test_forward_is_idempotent_and_fills_gaps():
 
     tools = set(wf.steps.values_list("tool", flat=True))
     # 0021 restores its own canonical 18; asn_discovery/js_secrets are added by
-    # 0023 and domain_probe by 0031, so exclude those from this migration's check.
-    assert (_EXPECTED_FULL_SCAN - {"asn_discovery", "js_secrets", "domain_probe"}) <= tools
+    # 0023, domain_probe by 0031, asn_cluster by 0032 — exclude those here.
+    assert (_EXPECTED_FULL_SCAN - {"asn_discovery", "js_secrets", "domain_probe", "asn_cluster"}) <= tools
     # no duplicates introduced
     assert wf.steps.count() == len(set(wf.steps.values_list("tool", flat=True)))

--- a/tests/unit/test_passive_scan.py
+++ b/tests/unit/test_passive_scan.py
@@ -25,6 +25,8 @@ _PASSIVE = {
     # domain_security is passive now that its active probes (AXFR/open-relay/
     # MTA-STS fetch) were split out into domain_probe.
     "domain_security",
+    # asn_cluster does IP→ASN via Team Cymru (third party) — never the target.
+    "asn_cluster",
 }
 _ACTIVE = {
     "domain_probe", "amass", "takeover_check", "naabu", "service_detection",


### PR DESCRIPTION
## What

A new phase-12 passive tool that turns isolated typosquat findings into a **campaign** signal.

It reads the registered `lookalike_domain` findings `typosquat` already wrote, resolves their IPs to **autonomous systems** via **Team Cymru's keyless DNS service**, and groups lookalikes that share an ASN:

> **6 lookalike domains share hosting (AS-NNNNN BadHost LLC)** — `login-acme.com`, `acme-secure.net`, `acrne.com`, … all resolve into one AS. Coordinated infrastructure → take them down as one campaign.

- A cluster with a **weaponized** member (login form / brand impersonation, as flagged by typosquat) → **high**; otherwise **medium**.
- A lone lookalike per ASN raises nothing (not a cluster).

## Why

It's the target-scoped slice of adversary-infrastructure correlation — the one genuinely useful capability from DIBS-style systems, applied to **your** lookalikes rather than the whole internet. The data was already there (`extra["resolved_ips"]`), so it's pure correlation.

## Design / scope

- New tool app `apps/asn_cluster/` (standard collect→analyze→save shape). `check_type="lookalike_cluster"`.
- **Passive** (Team Cymru, never the target or the lookalikes), fail-graceful, `requires: [typosquat]`, **phase 12** so typosquat's findings already exist.
- Joins **Full Scan + Passive Scan** (migration 0032). Registry tool count **29 → 30**.
- Reports wired: CWE-451, scope "Attack Surface", hosted-report next-steps; the **"Is anyone impersonating us?"** CEO question now matches it too.

## Tests

+13 in `test_asn_cluster.py` (fully mocked at `dns.resolver`): Team Cymru parse (asn/prefix/name, space-list ASN, non-IPv4 + DNS-failure → None); clustering (≥2 same-ASN → finding, single → none, weaponized → high, unresolved IPs ignored); scanner (<2 lookalikes no-op, persists, skips IP-less). Invariant sets updated (`_EXPECTED_FULL_SCAN`, passive classification); CWE-completeness guard passes.

**Follow-up (separate repo):** website tool count → 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv