### PR TITLE
feat: renumber pipeline — Data Leak is a dedicated phase 2 (13 phases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Pipeline renumbered to 13 phases — Data Leak is now a dedicated phase 2.**
+  The three domain-only Data Leak tools (`hudson_rock`, `breach_check`,
+  `github_secrets`) moved from phase 1 into their own **phase 2**, and every phase
+  at or after the old phase 2 shifted **+1** (Surface Enumeration 2→3 … cve_intel
+  12→13). `js_secrets` stays in the web-exposure phase (now 12) — it needs
+  discovered `.js` assets, so it can't run early; the Data Leak *category* still
+  spans phases 2 and 12. Execution order and all data dependencies are unchanged
+  (the shift preserves relative ordering); only phase numbers changed. Phase
+  numbers live in each tool's `tool_meta` (no migration). Docs + the generated
+  `render_pipeline_diagram` reflect the new numbering.
+
 ## [v2.13.0] — 2026-09-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 - **Released**: v2.13.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
   `:v2.13.0` / `:v2.13` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
-- **Scope**: 30 registered scan tools across 12 pipeline phases; single-user
+- **Scope**: 30 registered scan tools across 13 pipeline phases; single-user
   (one admin, no RBAC) by design.
 - **Engine**: DBOS durable workflows on PostgreSQL — one multi-step `run_scan`
   workflow per scan (checkpoint/resume) + `@durable_task` for one-step tasks
@@ -471,34 +471,34 @@ guards that every registered tool appears in the output.
 |---|---|---|---|---|
 | `apps/domain_security/` | 1 | Domain Intelligence | Yes | **Passive** DNS/DNSSEC/CAA/wildcard/lame-delegation, email-auth (SPF/DMARC/DKIM/TLS-RPT/BIMI) via public resolvers, and RDAP (expiry/locks/status). No packets to the target — needs no authorization |
 | `apps/domain_probe/` | 1 | Domain Intelligence | Yes | **Active** domain probes split out of domain_security: AXFR zone transfer (nameservers), SMTP open-relay (MX:25), and MTA-STS policy fetch (`mta-sts.<domain>`). Touches the target directly → requires `DomainAuthorization` |
-| `apps/hudson_rock/` | 1 | Data Leak | Yes | Infostealer-log exposure via Hudson Rock's keyless Cavalier API (aggregate counts only, no plaintext); passive, fail-graceful |
+| `apps/hudson_rock/` | 2 | Data Leak | Yes | Infostealer-log exposure via Hudson Rock's keyless Cavalier API (aggregate counts only, no plaintext); passive, fail-graceful |
 | `apps/dns_history/` | 1 | Domain Intelligence | Yes | Historical A/AAAA/MX records via a passive-DNS dataset — surfaces past hosting / stale records (info findings). Passive, BYO `DNS_HISTORY_API_URL` (no-op if unset), fail-graceful |
-| `apps/github_secrets/` | 1 | Data Leak | Yes | Leaked secrets in PUBLIC GitHub — searches GitHub's code-search API (org-scoped by default) for the target org's committed credentials, fetches the hits, runs gitleaks over them (same engine as `js_secrets`), REDACTS before storage (`check_type="exposed_secret"`, shared with js_secrets). Passive (queries GitHub, not the target); BYOK MANDATORY (`GITHUB_TOKEN` — code-search needs auth; no token → logged no-op); fail-graceful |
+| `apps/github_secrets/` | 2 | Data Leak | Yes | Leaked secrets in PUBLIC GitHub — searches GitHub's code-search API (org-scoped by default) for the target org's committed credentials, fetches the hits, runs gitleaks over them (same engine as `js_secrets`), REDACTS before storage (`check_type="exposed_secret"`, shared with js_secrets). Passive (queries GitHub, not the target); BYOK MANDATORY (`GITHUB_TOKEN` — code-search needs auth; no token → logged no-op); fail-graceful |
 | `apps/typosquat/` | 1 | Domain Intelligence | Yes | Lookalike / typosquat domain detection — generates lookalike candidates algorithmically (homoglyph/typo/omission/insertion/repetition/transposition/hyphenation/TLD-swap), checks which are registered via public DNS, then scores **weaponization**: registered web-serving lookalikes get a capped, fail-graceful homepage fetch for a login form (credential phishing) or brand mention (impersonation) → **high** (active impersonation, prioritise takedown); A/MX-only → medium; NS-only → low. Passive w.r.t. the target (contacts only the lookalike domains, never yours), no key, fail-graceful. Weaponization model ported from the standalone `tldsquatting` project |
-| `apps/breach_check/` | 1 | Data Leak | Yes | Data-breach exposure for the domain. BYOK: free keyless XposedOrNot catalog by default, authoritative Have I Been Pwned `breacheddomain` when `HIBP_API_KEY` set. Aggregate COUNTS + public breach metadata only — never email aliases/credentials. Passive, fail-graceful |
-| `apps/subfinder/` | 2 | Surface Enumeration | No | Passive subdomain enumeration |
-| `apps/amass/` | 2 | Surface Enumeration | No | Active subdomain enumeration |
-| `apps/asn_discovery/` | 2 | Surface Enumeration | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
-| `apps/alterx/` | 2 | Surface Enumeration | No | Subdomain permutation via alterx (generates candidates from discovered subdomains) |
-| `apps/github_recon/` | 2 | Surface Enumeration | Yes | GitHub Org Recon — enumerates the target org's PUBLIC GitHub repos via GitHub's official REST API and surfaces exposed infra references (internal hostnames/subdomains, cloud-bucket URLs, API endpoints) in that public code/config. Two-tier BYO-token: keyless unauthenticated API (60 req/hr, request-capped) works out of the box, `GITHUB_TOKEN` raises to 5000 req/hr. Complements `js_secrets`/`github_secrets` (secrets) — this finds infra exposure. Passive (queries GitHub, never the target), fail-graceful |
-| `apps/dnsx/` | 3 | Surface Enumeration | No | DNS resolution, public IP filtering |
-| `apps/takeover_check/` | 4 | Surface Enumeration | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
-| `apps/cloud_assets/` | 4 | Surface Enumeration | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
-| `apps/naabu/` | 5 | Port Discovery | No | Port scanning (top 100 TCP) |
-| `apps/shodan/` | 5 | Port Discovery | Yes | Passive exposure intel from Shodan's own scan data — ports/services/CVEs per resolved IP. BYOK: free InternetDB tier (no key, no credits), full host API when `SHODAN_API_KEY` set (`SHODAN_MAX_IPS` caps the paid path). CVEs land in `extra["cve_ids"]` so `cve_intel` enriches them. Passive, fail-graceful |
-| `apps/core/engine/service_detection/` | 6 | Port Discovery | No | nmap -sV enriches Port.service + is_web |
-| `apps/nmap/` | 7 | Network Exposure | Yes | NSE vulners CVE scan (non-web ports); backport-aware CVE matching (`backports.json` registry) |
-| `apps/tls_checker/` | 7 | Network Exposure | Yes | TLS/cert analysis + cipher suite enumeration via `nmap --script ssl-enum-ciphers` (all ports) |
-| `apps/ssh_checker/` | 7 | Network Exposure | Yes | SSH config analysis |
-| `apps/nuclei_network/` | 7 | Network Exposure | Yes | Network protocol vuln scan (319 templates, non-web) |
-| `apps/httpx/` | 8 | Web Exposure | No | Web probing, URL discovery, technology fingerprinting (`-tech-detect` → `URL.technologies`) |
-| `apps/historical_urls/` | 9 | Web Exposure | No | Historical URL discovery via gau (Wayback Machine, OTX, Common Crawl, URLScan) |
-| `apps/katana/` | 10 | Web Exposure | No | Web crawling, endpoint discovery |
-| `apps/nuclei/` | 11 | Web Exposure | Yes | Web vuln scan (community templates) |
-| `apps/web_checker/` | 11 | Web Exposure | Yes | Security headers, cookies, CORS; + security.txt (RFC 9116) responsible-disclosure check on the apex |
-| `apps/js_secrets/` | 11 | Data Leak | Yes | Hardcoded-secret detection — fetches discovered `.js` assets and runs gitleaks over them; secret is redacted before storage |
-| `apps/cve_intel/` | 12 | Prioritization | No | Enriches CVE findings in place with EPSS scores + CISA KEV flags (no new findings) |
-| `apps/asn_cluster/` | 12 | Domain Intelligence | Yes | Lookalike ASN clustering — reads typosquat's `lookalike_domain` findings, resolves their IPs to ASNs via Team Cymru (keyless DNS), and groups lookalikes sharing an autonomous system into `lookalike_cluster` campaign findings (weaponized member → high). Passive, fail-graceful, `requires: [typosquat]` |
+| `apps/breach_check/` | 2 | Data Leak | Yes | Data-breach exposure for the domain. BYOK: free keyless XposedOrNot catalog by default, authoritative Have I Been Pwned `breacheddomain` when `HIBP_API_KEY` set. Aggregate COUNTS + public breach metadata only — never email aliases/credentials. Passive, fail-graceful |
+| `apps/subfinder/` | 3 | Surface Enumeration | No | Passive subdomain enumeration |
+| `apps/amass/` | 3 | Surface Enumeration | No | Active subdomain enumeration |
+| `apps/asn_discovery/` | 3 | Surface Enumeration | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
+| `apps/alterx/` | 3 | Surface Enumeration | No | Subdomain permutation via alterx (generates candidates from discovered subdomains) |
+| `apps/github_recon/` | 3 | Surface Enumeration | Yes | GitHub Org Recon — enumerates the target org's PUBLIC GitHub repos via GitHub's official REST API and surfaces exposed infra references (internal hostnames/subdomains, cloud-bucket URLs, API endpoints) in that public code/config. Two-tier BYO-token: keyless unauthenticated API (60 req/hr, request-capped) works out of the box, `GITHUB_TOKEN` raises to 5000 req/hr. Complements `js_secrets`/`github_secrets` (secrets) — this finds infra exposure. Passive (queries GitHub, never the target), fail-graceful |
+| `apps/dnsx/` | 4 | Surface Enumeration | No | DNS resolution, public IP filtering |
+| `apps/takeover_check/` | 5 | Surface Enumeration | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
+| `apps/cloud_assets/` | 5 | Surface Enumeration | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
+| `apps/naabu/` | 6 | Port Discovery | No | Port scanning (top 100 TCP) |
+| `apps/shodan/` | 6 | Port Discovery | Yes | Passive exposure intel from Shodan's own scan data — ports/services/CVEs per resolved IP. BYOK: free InternetDB tier (no key, no credits), full host API when `SHODAN_API_KEY` set (`SHODAN_MAX_IPS` caps the paid path). CVEs land in `extra["cve_ids"]` so `cve_intel` enriches them. Passive, fail-graceful |
+| `apps/core/engine/service_detection/` | 7 | Port Discovery | No | nmap -sV enriches Port.service + is_web |
+| `apps/nmap/` | 8 | Network Exposure | Yes | NSE vulners CVE scan (non-web ports); backport-aware CVE matching (`backports.json` registry) |
+| `apps/tls_checker/` | 8 | Network Exposure | Yes | TLS/cert analysis + cipher suite enumeration via `nmap --script ssl-enum-ciphers` (all ports) |
+| `apps/ssh_checker/` | 8 | Network Exposure | Yes | SSH config analysis |
+| `apps/nuclei_network/` | 8 | Network Exposure | Yes | Network protocol vuln scan (319 templates, non-web) |
+| `apps/httpx/` | 9 | Web Exposure | No | Web probing, URL discovery, technology fingerprinting (`-tech-detect` → `URL.technologies`) |
+| `apps/historical_urls/` | 10 | Web Exposure | No | Historical URL discovery via gau (Wayback Machine, OTX, Common Crawl, URLScan) |
+| `apps/katana/` | 11 | Web Exposure | No | Web crawling, endpoint discovery |
+| `apps/nuclei/` | 12 | Web Exposure | Yes | Web vuln scan (community templates) |
+| `apps/web_checker/` | 12 | Web Exposure | Yes | Security headers, cookies, CORS; + security.txt (RFC 9116) responsible-disclosure check on the apex |
+| `apps/js_secrets/` | 12 | Data Leak | Yes | Hardcoded-secret detection — fetches discovered `.js` assets and runs gitleaks over them; secret is redacted before storage |
+| `apps/cve_intel/` | 13 | Prioritization | No | Enriches CVE findings in place with EPSS scores + CISA KEV flags (no new findings) |
+| `apps/asn_cluster/` | 13 | Domain Intelligence | Yes | Lookalike ASN clustering — reads typosquat's `lookalike_domain` findings, resolves their IPs to ASNs via Team Cymru (keyless DNS), and groups lookalikes sharing an autonomous system into `lookalike_cluster` campaign findings (weaponized member → high). Passive, fail-graceful, `requires: [typosquat]` |
 
 ### Tool app structure
 ```
@@ -522,32 +522,34 @@ but not yet in the default set.)
 ```
 Phase 1  domain_security    → Finding (DNS/DNSSEC/email-auth/RDAP — passive)
 Phase 1  domain_probe        → Finding (AXFR / open-relay / MTA-STS fetch — active)
-Phase 1  hudson_rock         → Finding (infostealer exposure via Hudson Rock — passive)
-Phase 1  dns_history         → Finding (historical A/AAAA/MX records via passive DNS — passive)
-Phase 1  github_secrets      → Finding (leaked secrets in public GitHub via gitleaks — passive, BYO token)
 Phase 1  typosquat           → Finding (registered lookalike/typosquat domains via public DNS — passive)
-Phase 1  breach_check        → Finding (data-breach exposure: XposedOrNot free / HIBP BYO-key — passive, counts only)
-Phase 2  subfinder          → Subdomain (passive enumeration)
-Phase 2  amass              → Subdomain (active enumeration)
-Phase 2  asn_discovery      → Finding (owned ASN/CIDR ranges via amass intel — informational)
-Phase 2  alterx             → Subdomain (permutation candidates from existing subdomains)
-Phase 2  github_recon       → Finding (infra refs in the org's PUBLIC GitHub repos — passive)
-Phase 3  dnsx               → IPAddress (public-only filter)
-Phase 4  takeover_check     → Finding (subzy — dangling DNS → unclaimed cloud)
-Phase 4  cloud_assets       → Finding (open S3/Azure/GCP buckets — cloud_enum)
-Phase 5  naabu              → Port (top 100 TCP scan)
-Phase 5  shodan             → Finding (passive exposure: ports/services/CVEs from Shodan's data)
-Phase 6  service_detection  → enriches Port.service + Port.is_web
-Phase 7  nmap               → Finding (CVEs on non-web ports, is_web=False)  ┐
-Phase 7  tls_checker        → Finding (cipher/cert/protocol on all ports)    │ parallel
-Phase 7  ssh_checker        → Finding (SSH config on service="ssh" ports)    │
-Phase 7  nuclei_network     → Finding (network protocol vulns, non-web ports)┘
-Phase 8  httpx              → URL (web probing, CDN-aware via SNI)
-Phase 9  historical_urls    → URL (gau — archived endpoints)
-Phase 10 katana             → URL (web crawling, endpoint discovery)
-Phase 11 nuclei             → Finding (web vulns via templates on URLs)
-Phase 11 web_checker        → Finding (headers, cookies, CORS on URLs; + security.txt RFC 9116 on apex)
-Phase 11 js_secrets         → Finding (gitleaks over fetched .js assets — secret redacted)
+Phase 1  dns_history         → Finding (historical A/AAAA/MX records via passive DNS — passive)
+Phase 2  hudson_rock         → Finding (infostealer exposure via Hudson Rock — passive)      ┐ Data Leak
+Phase 2  github_secrets      → Finding (leaked secrets in public GitHub via gitleaks — passive)│
+Phase 2  breach_check        → Finding (data-breach exposure: XposedOrNot / HIBP — passive)   ┘
+Phase 3  subfinder          → Subdomain (passive enumeration)
+Phase 3  amass              → Subdomain (active enumeration)
+Phase 3  asn_discovery      → Finding (owned ASN/CIDR ranges via amass intel — informational)
+Phase 3  alterx             → Subdomain (permutation candidates from existing subdomains)
+Phase 3  github_recon       → Finding (infra refs in the org's PUBLIC GitHub repos — passive)
+Phase 4  dnsx               → IPAddress (public-only filter)
+Phase 5  takeover_check     → Finding (subzy — dangling DNS → unclaimed cloud)
+Phase 5  cloud_assets       → Finding (open S3/Azure/GCP buckets — cloud_enum)
+Phase 6  naabu              → Port (top 100 TCP scan)
+Phase 6  shodan             → Finding (passive exposure: ports/services/CVEs from Shodan's data)
+Phase 7  service_detection  → enriches Port.service + Port.is_web
+Phase 8  nmap               → Finding (CVEs on non-web ports, is_web=False)  ┐
+Phase 8  tls_checker        → Finding (cipher/cert/protocol on all ports)    │ parallel
+Phase 8  ssh_checker        → Finding (SSH config on service="ssh" ports)    │
+Phase 8  nuclei_network     → Finding (network protocol vulns, non-web ports)┘
+Phase 9  httpx              → URL (web probing, CDN-aware via SNI)
+Phase 10 historical_urls    → URL (gau — archived endpoints)
+Phase 11 katana             → URL (web crawling, endpoint discovery)
+Phase 12 nuclei             → Finding (web vulns via templates on URLs)
+Phase 12 web_checker        → Finding (headers, cookies, CORS on URLs; + security.txt RFC 9116 on apex)
+Phase 12 js_secrets         → Finding (gitleaks over fetched .js assets — secret redacted)     [Data Leak]
+Phase 13 cve_intel          → enriches CVE findings (EPSS + CISA KEV; no new findings)
+Phase 13 asn_cluster        → Finding (groups lookalikes by shared hosting ASN — passive)     [Domain Intelligence]
 ```
 
 ### Passive vs active scan modes (the authorization boundary)
@@ -644,7 +646,7 @@ every Cloudflare call → AIInvocation audit row (metadata only, never prompt/re
 
 ### Pipeline + workflow rules
 
-The architecture is a **pipeline** (12 phases) built out of **durable workflows**
+The architecture is a **pipeline** (13 phases) built out of **durable workflows**
 (DBOS). Pipeline outside, workflows inside, Postgres between them. These are the
 same 14-point rules the sibling `cybersecify/backend` follows; OpenEASD adopts the
 foundational ones and consciously differs on the *choreography* ones (it's
@@ -652,7 +654,7 @@ foundational ones and consciously differs on the *choreography* ones (it's
 row notes OpenEASD's stance. Full plan + status: `docs/specs/2026-09-07-producer-queue-consumer-hardening.md`.
 
 **Design**
-1. **Draw the pipeline before writing a workflow** — name the phase, the rows it stores, what triggers the next. ✅ (12 phases in DESIGN.md)
+1. **Draw the pipeline before writing a workflow** — name the phase, the rows it stores, what triggers the next. ✅ (13 phases in DESIGN.md)
 2. **Stages talk through stored data, never workflow calls** — a tool writes rows, the next phase reads them. ✅ (the empty-`models.py` rule)
 3. **One workflow per unit of work** — ⚠️ *deliberate deviation*: OpenEASD runs one multi-step `run_scan` per scan (orchestrated), not per-unit; retry granularity is per phase-group (checkpointed step).
 4. **Every workflow idempotent** (delete-then-insert / upsert, not append) — 🟡 partial: alerts ✅ (H1), phase-step idempotency is **H5**.

--- a/README.md
+++ b/README.md
@@ -195,50 +195,50 @@ Phase 1  Typosquat          - Lookalike / typosquat domain detection (passive;
                              registered lookalikes via public DNS — phishing/brand abuse)
 Phase 1  DNS History        - Historical A/AAAA/MX records via a passive-DNS
                              dataset (passive; BYO DNS_HISTORY_API_URL)
-Phase 12 ASN Clustering     - Groups registered lookalikes by shared hosting ASN
+Phase 13 ASN Clustering     - Groups registered lookalikes by shared hosting ASN
                              (Team Cymru, passive) — coordinated phishing infra
 
 ── Data Leak ────────────────────────────────────────────────────────────────
-Phase 1  Hudson Rock        - Infostealer-log exposure via Hudson Rock's keyless
+Phase 2  Hudson Rock        - Infostealer-log exposure via Hudson Rock's keyless
                              Cavalier API (aggregate counts only, no plaintext)
-Phase 1  GitHub Secrets      - Leaked secrets in public GitHub via gitleaks
+Phase 2  GitHub Secrets      - Leaked secrets in public GitHub via gitleaks
                              (passive; BYO GITHUB_TOKEN, redacted before storage)
-Phase 1  Breach Check       - Data-breach exposure via XposedOrNot (free/keyless)
+Phase 2  Breach Check       - Data-breach exposure via XposedOrNot (free/keyless)
                              or Have I Been Pwned (BYO key); counts only, no PII
-Phase 11 JS Secrets         - Hardcoded secrets in fetched JavaScript via gitleaks
+Phase 12 JS Secrets         - Hardcoded secrets in fetched JavaScript via gitleaks
                              (redacted before storage; runs after web crawl)
 
 ── Surface Enumeration ─────────────────────────────────────────────────────
-Phase 2  Subfinder         - Passive subdomain enumeration
-Phase 2  Amass             - Active subdomain enumeration
-Phase 2  Alterx            - Subdomain permutation from discovered subdomains
-Phase 2  ASN Discovery     - Owned ASN/CIDR ranges via amass intel (reports only)
-Phase 2  GitHub Org Recon  - Infra refs (internal hostnames, cloud buckets, API
+Phase 3  Subfinder         - Passive subdomain enumeration
+Phase 3  Amass             - Active subdomain enumeration
+Phase 3  Alterx            - Subdomain permutation from discovered subdomains
+Phase 3  ASN Discovery     - Owned ASN/CIDR ranges via amass intel (reports only)
+Phase 3  GitHub Org Recon  - Infra refs (internal hostnames, cloud buckets, API
                              endpoints) leaked in the org's public GitHub repos
                              (passive; official API — keyless, richer with a token)
-Phase 3  DNSx              - DNS resolution, public IP filtering
-Phase 4  Takeover Check    - Subdomain takeover detection via subzy
-Phase 4  Cloud Assets      - Public S3/Azure/GCP bucket enumeration (cloud_enum)
+Phase 4  DNSx              - DNS resolution, public IP filtering
+Phase 5  Takeover Check    - Subdomain takeover detection via subzy
+Phase 5  Cloud Assets      - Public S3/Azure/GCP bucket enumeration (cloud_enum)
 
 ── Port Discovery ───────────────────────────────────────────────────────────
-Phase 5  Naabu             - TCP port scanning (top 100; CDN edge IPs excluded)
-Phase 6  Service Detection - Classify ports as web/non-web via nmap -sV (auto)
+Phase 6  Naabu             - TCP port scanning (top 100; CDN edge IPs excluded)
+Phase 7  Service Detection - Classify ports as web/non-web via nmap -sV (auto)
 
 ── Network Exposure ─────────────────────────────────────────────────────────
-Phase 7  Nmap              - CVE scanning via NSE vulners (non-web ports)
-Phase 7  TLS Checker       - Certificate, cipher, and protocol analysis
-Phase 7  SSH Checker       - SSH configuration audit
-Phase 7  Nuclei Network    - Network protocol vuln templates (non-web ports)
+Phase 8  Nmap              - CVE scanning via NSE vulners (non-web ports)
+Phase 8  TLS Checker       - Certificate, cipher, and protocol analysis
+Phase 8  SSH Checker       - SSH configuration audit
+Phase 8  Nuclei Network    - Network protocol vuln templates (non-web ports)
 
 ── Web Exposure ─────────────────────────────────────────────────────────────
-Phase 8  httpx             - Web probing, URL discovery, technology fingerprinting
-Phase 9  Historical URLs   - Archived URL discovery via gau
-Phase 10 Katana            - Deep URL crawl on top of httpx
-Phase 11 Nuclei            - Web vulnerability scanning (community templates)
-Phase 11 Web Checker       - Security headers, cookies, CORS; security.txt (RFC 9116)
+Phase 9  httpx             - Web probing, URL discovery, technology fingerprinting
+Phase 10 Historical URLs   - Archived URL discovery via gau
+Phase 11 Katana            - Deep URL crawl on top of httpx
+Phase 12 Nuclei            - Web vulnerability scanning (community templates)
+Phase 12 Web Checker       - Security headers, cookies, CORS; security.txt (RFC 9116)
 
 ── Prioritization ───────────────────────────────────────────────────────────
-Phase 12 CVE Intel         - Enrich CVE findings with EPSS + CISA KEV
+Phase 13 CVE Intel         - Enrich CVE findings with EPSS + CISA KEV
 
 ── AI analysis (optional; off by default, bring-your-own Cloudflare) ──────────
 Post-scan Triage          - Rank findings by exploitability (CISA KEV + EPSS

--- a/apps/alterx/apps.py
+++ b/apps/alterx/apps.py
@@ -9,7 +9,7 @@ class AlterxConfig(AppConfig):
     tool_meta = {
         "label": "Alterx (Subdomain Permutation)",
         "runner": "apps.alterx.scanner.run_alterx",
-        "phase": 2,
+        "phase": 3,
         "phase_group": "Surface Enumeration",
         "requires": ["subfinder"],
         "produces_findings": False,

--- a/apps/amass/apps.py
+++ b/apps/amass/apps.py
@@ -9,7 +9,7 @@ class AmassConfig(AppConfig):
     tool_meta = {
         "label": "Amass",
         "runner": "apps.amass.scanner.run_amass",
-        "phase": 2,
+        "phase": 3,
         "phase_group": "Surface Enumeration",
         "requires": [],
         "produces_findings": False,

--- a/apps/asn_cluster/apps.py
+++ b/apps/asn_cluster/apps.py
@@ -11,7 +11,7 @@ class AsnClusterConfig(AppConfig):
         "runner": "apps.asn_cluster.scanner.run_asn_cluster",
         # Late phase: it correlates typosquat's already-written lookalike findings,
         # so it must run after phase 1. Sits with cve_intel in Prioritization order.
-        "phase": 12,
+        "phase": 13,
         "phase_group": "Domain Intelligence",
         "requires": ["typosquat"],
         "produces_findings": True,

--- a/apps/asn_discovery/apps.py
+++ b/apps/asn_discovery/apps.py
@@ -9,7 +9,7 @@ class AsnDiscoveryConfig(AppConfig):
     tool_meta = {
         "label": "ASN / IP-range Discovery (amass intel)",
         "runner": "apps.asn_discovery.scanner.run_asn_discovery",
-        "phase": 2,
+        "phase": 3,
         "phase_group": "Surface Enumeration",
         "requires": [],
         "produces_findings": True,

--- a/apps/breach_check/apps.py
+++ b/apps/breach_check/apps.py
@@ -9,7 +9,7 @@ class BreachCheckConfig(AppConfig):
     tool_meta = {
         "label": "Breach Exposure (HIBP / XposedOrNot)",
         "runner": "apps.breach_check.scanner.run_breach_check",
-        "phase": 1,
+        "phase": 2,
         "phase_group": "Data Leak",
         "requires": [],
         "produces_findings": True,

--- a/apps/cloud_assets/apps.py
+++ b/apps/cloud_assets/apps.py
@@ -9,7 +9,7 @@ class CloudAssetsConfig(AppConfig):
     tool_meta = {
         "label": "Cloud Asset Enumeration (cloud-enum)",
         "runner": "apps.cloud_assets.scanner.run_cloud_assets",
-        "phase": 4,
+        "phase": 5,
         "phase_group": "Surface Enumeration",
         "requires": ["subfinder"],
         "produces_findings": True,

--- a/apps/core/engine/service_detection/apps.py
+++ b/apps/core/engine/service_detection/apps.py
@@ -8,7 +8,7 @@ class ServiceDetectionConfig(AppConfig):
     tool_meta = {
         "label": "Service Detection",
         "runner": "apps.core.engine.service_detection.detector.detect_services",
-        "phase": 6,
+        "phase": 7,
         "phase_group": "Port Discovery",
         "requires": ["naabu"],
         "produces_findings": False,

--- a/apps/cve_intel/apps.py
+++ b/apps/cve_intel/apps.py
@@ -10,7 +10,7 @@ class CveIntelConfig(AppConfig):
         "runner": "apps.cve_intel.scanner.run_cve_intel",
         # Phase 12 — after every CVE-producing tool (nmap 7, nuclei_network 7,
         # nuclei 11) so it can enrich all their findings in one pass.
-        "phase": 12,
+        "phase": 13,
         "phase_group": "Prioritization",
         "requires": [],            # no external binary — pure data enrichment
         "produces_findings": False,  # enriches existing Findings, creates none

--- a/apps/dnsx/apps.py
+++ b/apps/dnsx/apps.py
@@ -9,7 +9,7 @@ class DnsxConfig(AppConfig):
     tool_meta = {
         "label": "DNSx (Resolve)",
         "runner": "apps.dnsx.scanner.run_dnsx",
-        "phase": 3,
+        "phase": 4,
         "phase_group": "Surface Enumeration",
         "requires": ["subfinder"],
         "produces_findings": False,

--- a/apps/github_recon/apps.py
+++ b/apps/github_recon/apps.py
@@ -9,7 +9,7 @@ class GithubReconConfig(AppConfig):
     tool_meta = {
         "label": "GitHub Org Recon",
         "runner": "apps.github_recon.scanner.run_github_recon",
-        "phase": 2,
+        "phase": 3,
         "phase_group": "Surface Enumeration",
         "requires": [],
         "produces_findings": True,

--- a/apps/github_secrets/apps.py
+++ b/apps/github_secrets/apps.py
@@ -9,7 +9,7 @@ class GithubSecretsConfig(AppConfig):
     tool_meta = {
         "label": "GitHub Secret Exposure (gitleaks)",
         "runner": "apps.github_secrets.scanner.run_github_secrets",
-        "phase": 1,
+        "phase": 2,
         "phase_group": "Data Leak",
         "requires": ["gitleaks"],
         "produces_findings": True,

--- a/apps/historical_urls/apps.py
+++ b/apps/historical_urls/apps.py
@@ -9,7 +9,7 @@ class HistoricalUrlsConfig(AppConfig):
     tool_meta = {
         "label": "Historical URLs (gau)",
         "runner": "apps.historical_urls.scanner.run_historical_urls",
-        "phase": 9,
+        "phase": 10,
         "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": False,

--- a/apps/httpx/apps.py
+++ b/apps/httpx/apps.py
@@ -9,7 +9,7 @@ class HttpxConfig(AppConfig):
     tool_meta = {
         "label": "HTTPx (Web Probe)",
         "runner": "apps.httpx.scanner.run_httpx",
-        "phase": 8,
+        "phase": 9,
         "phase_group": "Web Exposure",
         "requires": ["naabu"],
         "produces_findings": False,

--- a/apps/hudson_rock/apps.py
+++ b/apps/hudson_rock/apps.py
@@ -9,7 +9,7 @@ class HudsonRockConfig(AppConfig):
     tool_meta = {
         "label": "Infostealer Exposure (Hudson Rock)",
         "runner": "apps.hudson_rock.scanner.run_hudson_rock",
-        "phase": 1,
+        "phase": 2,
         "phase_group": "Data Leak",
         "requires": [],
         "produces_findings": True,

--- a/apps/js_secrets/apps.py
+++ b/apps/js_secrets/apps.py
@@ -9,7 +9,7 @@ class JsSecretsConfig(AppConfig):
     tool_meta = {
         "label": "JS Secrets (gitleaks)",
         "runner": "apps.js_secrets.scanner.run_js_secrets",
-        "phase": 11,
+        "phase": 12,
         "phase_group": "Data Leak",
         "requires": ["gitleaks"],
         "produces_findings": True,

--- a/apps/katana/apps.py
+++ b/apps/katana/apps.py
@@ -9,7 +9,7 @@ class KatanaConfig(AppConfig):
     tool_meta = {
         "label": "Katana",
         "runner": "apps.katana.scanner.run_katana",
-        "phase": 10,
+        "phase": 11,
         "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": False,

--- a/apps/naabu/apps.py
+++ b/apps/naabu/apps.py
@@ -9,7 +9,7 @@ class NaabuConfig(AppConfig):
     tool_meta = {
         "label": "Naabu (Port Scan)",
         "runner": "apps.naabu.scanner.run_naabu",
-        "phase": 5,
+        "phase": 6,
         "phase_group": "Port Discovery",
         "requires": ["dnsx"],
         "produces_findings": False,

--- a/apps/nmap/apps.py
+++ b/apps/nmap/apps.py
@@ -9,7 +9,7 @@ class NmapConfig(AppConfig):
     tool_meta = {
         "label": "Nmap (NSE Vuln Scan)",
         "runner": "apps.nmap.scanner.run_nmap",
-        "phase": 7,
+        "phase": 8,
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,

--- a/apps/nuclei/apps.py
+++ b/apps/nuclei/apps.py
@@ -9,7 +9,7 @@ class NucleiConfig(AppConfig):
     tool_meta = {
         "label": "Nuclei (Web Vuln Scan)",
         "runner": "apps.nuclei.scanner.run_nuclei",
-        "phase": 11,
+        "phase": 12,
         "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": True,

--- a/apps/nuclei_network/apps.py
+++ b/apps/nuclei_network/apps.py
@@ -8,7 +8,7 @@ class NucleiNetworkConfig(AppConfig):
     tool_meta = {
         "label": "Nuclei (Network Scan)",
         "runner": "apps.nuclei_network.scanner.run_nuclei_network",
-        "phase": 7,
+        "phase": 8,
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,

--- a/apps/shodan/apps.py
+++ b/apps/shodan/apps.py
@@ -9,7 +9,7 @@ class ShodanConfig(AppConfig):
     tool_meta = {
         "label": "Shodan Exposure (passive)",
         "runner": "apps.shodan.scanner.run_shodan",
-        "phase": 5,
+        "phase": 6,
         "phase_group": "Port Discovery",
         "requires": [],
         "produces_findings": True,

--- a/apps/ssh_checker/apps.py
+++ b/apps/ssh_checker/apps.py
@@ -8,7 +8,7 @@ class SshCheckerConfig(AppConfig):
     tool_meta = {
         "label": "SSH Checker",
         "runner": "apps.ssh_checker.scanner.run_ssh_check",
-        "phase": 7,
+        "phase": 8,
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,

--- a/apps/subfinder/apps.py
+++ b/apps/subfinder/apps.py
@@ -9,7 +9,7 @@ class SubfinderConfig(AppConfig):
     tool_meta = {
         "label": "Subfinder",
         "runner": "apps.subfinder.scanner.run_subfinder",
-        "phase": 2,
+        "phase": 3,
         "phase_group": "Surface Enumeration",
         "requires": [],
         "produces_findings": False,

--- a/apps/takeover_check/apps.py
+++ b/apps/takeover_check/apps.py
@@ -8,7 +8,7 @@ class TakeoverCheckConfig(AppConfig):
     tool_meta = {
         "label": "Subdomain Takeover Check (subzy)",
         "runner": "apps.takeover_check.scanner.run_takeover_check",
-        "phase": 4,
+        "phase": 5,
         "phase_group": "Surface Enumeration",
         "requires": ["subfinder"],
         "produces_findings": True,

--- a/apps/tls_checker/apps.py
+++ b/apps/tls_checker/apps.py
@@ -8,7 +8,7 @@ class TlsCheckerConfig(AppConfig):
     tool_meta = {
         "label": "TLS Checker",
         "runner": "apps.tls_checker.scanner.run_tls_check",
-        "phase": 7,
+        "phase": 8,
         "phase_group": "Network Exposure",
         "requires": ["naabu", "service_detection"],
         "produces_findings": True,

--- a/apps/web_checker/apps.py
+++ b/apps/web_checker/apps.py
@@ -8,7 +8,7 @@ class WebCheckerConfig(AppConfig):
     tool_meta = {
         "label": "Web Checker",
         "runner": "apps.web_checker.scanner.run_web_check",
-        "phase": 11,
+        "phase": 12,
         "phase_group": "Web Exposure",
         "requires": ["httpx"],
         "produces_findings": True,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -152,7 +152,7 @@ Notes on the mapping's soft edges:
   triggers + hygiene). Under the producer→queue→consumer lens it's a *producer*,
   not the execution core — the one app where the two lenses disagree on placement.
 - **`service_detection`** is the only app that is both core infrastructure and a
-  registry tool (nmap -sV, phase 6).
+  registry tool (nmap -sV, phase 7).
 
 Secrets at rest (`apps/core/crypto.py` + `fields.py`): BYOK API keys and webhook
 URLs stored in the DB are Fernet-encrypted via `EncryptedCharField`/`EncryptedTextField`.
@@ -212,16 +212,17 @@ Deletion cascades top-down: deleting a Domain wipes all session data.
 ### Pipeline phases
 
 ```
-Phase 1   Domain Intelligence  → Finding (DNS/email/RDAP, breach, typosquat, infostealer, public-secret)
-Phase 2   Surface Enumeration  → Subdomain (subfinder/amass/alterx) + Finding (asn_discovery, github_recon)
-Phase 3   dnsx                 → IPAddress (public-IP filter)
-Phase 4   takeover / cloud     → Finding (dangling DNS, open buckets)
-Phase 5   naabu / shodan       → Port + Finding (passive exposure)
-Phase 6   service_detection    → enriches Port.service + Port.is_web
-Phase 7   Network Exposure     → Finding (nmap CVE / tls / ssh / nuclei_network — non-web; run in parallel)
-Phase 8-10 httpx → historical_urls → katana → URL (web probing / archived / crawl)
-Phase 11  Web Exposure         → Finding (nuclei web, web_checker headers, js_secrets)
-Phase 12  cve_intel            → enriches CVE findings with EPSS + CISA-KEV (no new findings)
+Phase 1   Domain Intelligence  → Finding (DNS/DNSSEC/email-auth/RDAP, domain_probe, typosquat, dns_history)
+Phase 2   Data Leak            → Finding (breach_check, hudson_rock infostealer, github_secrets)
+Phase 3   Surface Enumeration  → Subdomain (subfinder/amass/alterx) + Finding (asn_discovery, github_recon)
+Phase 4   dnsx                 → IPAddress (public-IP filter)
+Phase 5   takeover / cloud     → Finding (dangling DNS, open buckets)
+Phase 6   naabu / shodan       → Port + Finding (passive exposure)
+Phase 7   service_detection    → enriches Port.service + Port.is_web
+Phase 8   Network Exposure     → Finding (nmap CVE / tls / ssh / nuclei_network — non-web; run in parallel)
+Phase 9-11 httpx → historical_urls → katana → URL (web probing / archived / crawl)
+Phase 12  Web Exposure         → Finding (nuclei web, web_checker headers, js_secrets)
+Phase 13  cve_intel + asn_cluster → enrich CVE findings (EPSS + CISA-KEV) + cluster lookalikes by ASN
 ```
 
 ### Scan flow (call chain)
@@ -261,7 +262,7 @@ POST /api/scans/start/  (authorization gate: active tools need DomainAuthorizati
 1. **Tools never import from each other.** Shared data flows through the core
    asset/finding models only.
 2. **`Port.is_web`** is the classification gate — set by `service_detection`
-   (Phase 6); nmap skips web ports, nuclei_network targets non-web, tls_checker
+   (Phase 7); nmap skips web ports, nuclei_network targets non-web, tls_checker
    probes all.
 3. **httpx feeds subdomain:port pairs, not IP:port** — needed so SNI matches on
    CDN/Cloudflare-fronted hosts.
@@ -287,7 +288,7 @@ the pipeline's phase *order*.
 | | **Workflow-centric** | **Pipeline-centric** |
 |---|---|---|
 | Controls | *which* tools run | *what order* + *how data flows* |
-| The unit | `Workflow` + `WorkflowStep` (DB rows) | fixed 12 phases + dataflow models |
+| The unit | `Workflow` + `WorkflowStep` (DB rows) | fixed 13 phases + dataflow models |
 | Mutable? | ✅ dynamic — user-configurable | ❌ fixed — hardcoded `tool_meta["phase"]` |
 | Lives in | `apps/core/engine/workflows/` (models, api, runner, registry) | `tool_meta` phases + `apps/core/engine/scans/pipeline.py` |
 | Example control | enable/disable tools; Full / Passive / custom workflows | `dnsx`(3)→`naabu`(5)→`httpx`(8): IPs before ports before web probing |

--- a/tests/unit/test_pipeline_phases.py
+++ b/tests/unit/test_pipeline_phases.py
@@ -2,14 +2,14 @@
 
 
 def test_phase_order():
-    """Non-web tools (7) must run before httpx (8) and web tools (11)."""
+    """Non-web tools (8) must run before httpx (9) and web tools (12)."""
     from apps.core.engine.workflows.registry import get_tool_phases
     phases = get_tool_phases()
 
-    assert phases["httpx"] == 8,           f"httpx: expected 8, got {phases['httpx']}"
-    assert phases["nuclei_network"] == 7,  f"nuclei_network: expected 7, got {phases['nuclei_network']}"
-    assert phases["nuclei"] == 11,         f"nuclei: expected 11, got {phases['nuclei']}"
-    assert phases["web_checker"] == 11,    f"web_checker: expected 11, got {phases['web_checker']}"
+    assert phases["httpx"] == 9,           f"httpx: expected 9, got {phases['httpx']}"
+    assert phases["nuclei_network"] == 8,  f"nuclei_network: expected 8, got {phases['nuclei_network']}"
+    assert phases["nuclei"] == 12,         f"nuclei: expected 12, got {phases['nuclei']}"
+    assert phases["web_checker"] == 12,    f"web_checker: expected 12, got {phases['web_checker']}"
 
     # Non-web tools must all be before httpx
     assert phases["nmap"] < phases["httpx"],          "nmap must run before httpx"


### PR DESCRIPTION
## What

Makes **Data Leak a dedicated phase 2**. The three domain-only Data Leak tools (`hudson_rock`, `breach_check`, `github_secrets`) move from phase 1 into their own phase 2, and every phase at or after the old phase 2 shifts **+1** — so the pipeline is now **13 phases**.

```
phase 1  Domain Intelligence   (domain_security, domain_probe, typosquat, dns_history)
phase 2  Data Leak             (hudson_rock, breach_check, github_secrets)   <-- dedicated
phase 3  Surface Enumeration   (was 2)
phase 4  dnsx  · 5 takeover/cloud · 6 naabu/shodan · 7 service_detection
phase 8  Network Exposure  · 9 httpx · 10 historical_urls · 11 katana
phase 12 Web Exposure (nuclei, web_checker, js_secrets)
phase 13 cve_intel + asn_cluster
```

## Constraint honored

`js_secrets` **can't** move to phase 2 — it fetches the `.js` assets discovered by the web phases — so it stays at phase 12. The Data Leak *category* therefore spans phases 2 and 12 (this was called out and accepted).

## Safety

- **Execution order and all data dependencies are unchanged** — a uniform +1 shift preserves relative ordering (dnsx after subfinder, naabu after dnsx, service_detection after naabu, nuclei after httpx, asn_cluster after typosquat, …). Verified against the generated diagram: every `needs` points to an earlier phase.
- Phase numbers live in each tool's `tool_meta` — **no migration**.
- Only `test_pipeline_phases.py` hardcoded exact numbers (updated); the group-by-phase tests assert *grouping*, which survives.

## Docs

CLAUDE (tool table + ASCII diagram + phase count), README diagram, DESIGN phase list — all renumbered. The generated `render_pipeline_diagram` reflects it automatically.

## Tests

Full fast suite green — **1846 passed, 1 skipped**. No tests added/removed (renumber only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv