### PR TITLE
chore: release v2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.14.0] — 2026-09-11
+
 ### Changed
 - **Renamed the "Data Leak" tool category to "Credential Exposure."** More
   accurate and better-parallel with the sibling "…Exposure" categories: the four
@@ -1484,7 +1486,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.13.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.14.0...HEAD
+[v2.14.0]: https://github.com/cybersecify/OpenEASD/compare/v2.13.0...v2.14.0
 [v2.13.0]: https://github.com/cybersecify/OpenEASD/compare/v2.12.0...v2.13.0
 [v2.12.0]: https://github.com/cybersecify/OpenEASD/compare/v2.11.0...v2.12.0
 [v2.11.0]: https://github.com/cybersecify/OpenEASD/compare/v2.10.1...v2.11.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.13.0 — 2026-09-11)
+## Status (v2.14.0 — 2026-09-11)
 
-- **Released**: v2.13.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.13.0` / `:v2.13` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.14.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.14.0` / `:v2.14` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 30 registered scan tools across 13 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.13.0"
+version = "2.14.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.13.0"
+version = "2.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Release **v2.14.0**. Finalizes the CHANGELOG (`Unreleased` → `v2.14.0` + compare link), bumps the version in `pyproject.toml` / `uv.lock`, and refreshes the CLAUDE.md status header.

## Highlights since v2.13.0
- **Pipeline renumbered to 13 phases** with **Credential Exposure as a dedicated phase 2**
- **Renamed** the "Data Leak" tool category → **"Credential Exposure"**

Merging this, then tagging `main` as `v2.14.0` to trigger the GHCR publish (`:v2.14.0` / `:v2.14` / `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv