### PR TITLE
feat: add Red Hat security data parser to apps/nmap/sources

### DIFF
--- a/apps/nmap/backports.py
+++ b/apps/nmap/backports.py
@@ -4,21 +4,25 @@ from pathlib import Path
 
 BACKPORTS_FILE = Path(__file__).parent / "backports.json"
 
+
 def _load_backports():
     if not BACKPORTS_FILE.exists():
         return {}
     with open(BACKPORTS_FILE, "r") as f:
         return json.load(f)
 
+
 BACKPORTS = _load_backports()
+
 
 def compare_debian_versions(v1: str, v2: str) -> int:
     """
     Simplified Debian version compare.
     Returns 1 if v1 > v2, -1 if v1 < v2, 0 if v1 == v2.
     """
+
     def parse_parts(v):
-        return [int(x) if x.isdigit() else x for x in re.split(r'([0-9]+)', v) if x]
+        return [int(x) if x.isdigit() else x for x in re.split(r"([0-9]+)", v) if x]
 
     p1 = parse_parts(v1)
     p2 = parse_parts(v2)
@@ -37,6 +41,108 @@ def compare_debian_versions(v1: str, v2: str) -> int:
         return -1
     return 0
 
+
+def compare_rpm_versions(v1: str, v2: str) -> int:
+    """
+    RPM-aware version compare (rpmvercmp semantics) over EVR strings.
+
+    Returns 1 if v1 > v2, -1 if v1 < v2, 0 if v1 == v2.
+
+    RPM build versions are Name-Version-Release (e.g. ``8.0p1-1.el9``,
+    ``2.4.6-99.el7_9.2``). Debian-style comparison is wrong for these because
+    it does not understand release tags, tilde (``~``, sorts before everything)
+    or caret (``^``). A leading epoch (``digits:``) is stripped before
+    comparison — the upstream feeds and nmap banners disagree on whether the
+    epoch is present, and for demotion purposes the V-R portion is what matters.
+    """
+
+    def rpmvercmp(a: str, b: str) -> int:
+        a = re.sub(r"^\d+:", "", a or "")
+        b = re.sub(r"^\d+:", "", b or "")
+        i = j = 0
+        while i < len(a) or j < len(b):
+            # Skip leading non-alphanumeric (and the special ~ ^ markers).
+            while i < len(a) and not (a[i].isalnum() or a[i] in "~^"):
+                i += 1
+            while j < len(b) and not (b[j].isalnum() or b[j] in "~^"):
+                j += 1
+            if i >= len(a) and j >= len(b):
+                return 0
+
+            # Tilde sorts before anything (including end of string).
+            if i < len(a) and a[i] == "~":
+                if j >= len(b) or b[j] != "~":
+                    return -1
+                i += 1
+                j += 1
+                continue
+            if j < len(b) and b[j] == "~":
+                return 1
+
+            # Caret sorts after end of string but before any real character.
+            if i < len(a) and a[i] == "^":
+                if j >= len(b) or b[j] != "^":
+                    return 1
+                i += 1
+                j += 1
+                continue
+            if j < len(b) and b[j] == "^":
+                return -1
+
+            # One side ended: the side with a remaining alnum char is greater.
+            if i >= len(a) or j >= len(b):
+                return -1 if i >= len(a) else 1
+
+            isnum = a[i].isdigit()
+            seg1 = ""
+            while i < len(a) and (a[i].isdigit() if isnum else a[i].isalpha()):
+                seg1 += a[i]
+                i += 1
+            seg2 = ""
+            while j < len(b) and (b[j].isdigit() if isnum else b[j].isalpha()):
+                seg2 += b[j]
+                j += 1
+
+            if isnum:
+                seg1 = seg1.lstrip("0") or "0"
+                seg2 = seg2.lstrip("0") or "0"
+                if len(seg1) != len(seg2):
+                    return 1 if len(seg1) > len(seg2) else -1
+                if seg1 != seg2:
+                    return 1 if seg1 > seg2 else -1
+            else:
+                if seg1 != seg2:
+                    return 1 if seg1 > seg2 else -1
+        return 0
+
+    return rpmvercmp(v1, v2)
+
+
+# nmap -sV emits distro markers for the Debian/Ubuntu family and the RPM-based
+# families (Red Hat / RHEL / Rocky / Alma / CentOS and SUSE / SLES / openSUSE).
+# Each rule maps a marker regex to the canonical backports.json key and the
+# comparator that understands that distro's build-version format.
+_DISTRO_RULES = [
+    (re.compile(r"(?i)(ubuntu)"), "ubuntu", "deb"),
+    (re.compile(r"(?i)(debian)"), "debian", "deb"),
+    (
+        re.compile(r"(?i)(rhel|red\s*hat|rocky|alma|centos|oracle\s*linux)"),
+        "redhat",
+        "rpm",
+    ),
+    (re.compile(r"(?i)(sles|suse|opensuse|leap)"), "suse", "rpm"),
+]
+
+# Debian/Ubuntu build versions: start with a digit, then deb chars; the leading
+# separator must not cross a ';' so the "protocol 2.0" form is never captured.
+_DEB_VERSION_RE = r"(?:[^;]*?[-; ])\s*(\d[a-z0-9.~+-]*)"
+
+# RPM EVR build versions: a digit-led token that contains a release separator
+# (e.g. 2.4.6-99.el7_9.2, 8.0p1-1.el9). Requiring the '-' release part avoids
+# capturing a bare distro major version like "Red Hat Enterprise Linux 9".
+_RPM_VERSION_RE = r"(?:[^;]*?[-; ])\s*([0-9][0-9A-Za-z._~+:+-]*-[0-9A-Za-z._~+:+-]+)"
+
+
 def check_backport(product: str, version_string: str, cve: str) -> dict:
     """
     Checks if a CVE has been patched via backport based on the version string.
@@ -47,22 +153,31 @@ def check_backport(product: str, version_string: str, cve: str) -> dict:
 
     product = product.lower()
 
-    # Identify distro and distro-specific version from nmap extrainfo strings.
-    # Examples:
-    #   "OpenSSH 9.6p1 Ubuntu Linux; protocol 2.0"   → no version suffix (skip)
+    distro = None
+    distro_version = None
+    comparator = compare_debian_versions
+
+    # Identify the distro and its build version from nmap extrainfo strings.
+    # Examples (Debian/Ubuntu family):
     #   "OpenSSH 9.6p1 Ubuntu-3ubuntu13.4"            → distro_version = "3ubuntu13.4"
     #   "OpenSSH 8.4p1 Debian-5+deb11u3"              → distro_version = "5+deb11u3"
     #   "OpenSSH 9.6p1 Ubuntu Linux; 3ubuntu13.3"     → distro_version = "3ubuntu13.3"
-    # We specifically require the suffix to START with a digit to avoid capturing
-    # words like "protocol" that appear in the common "Ubuntu Linux; protocol 2.0" format.
-    match = re.search(r'(?i)(ubuntu|debian)(?:[^;]*?[-; ])\s*(\d[a-z0-9.~+-]*)', version_string)
-
-    distro = None
-    distro_version = None
-
-    if match:
-        distro = match.group(1).lower()
-        distro_version = match.group(2).strip()
+    # RPM family (build versions carry a release tag):
+    #   "OpenSSH 8.0p1 Red Hat 8.0p1-1.el9"           → distro=redhat, "8.0p1-1.el9"
+    #   "httpd 2.4.6 SUSE 2.4.6-99.el7_9.2"           → distro=suse,   "2.4.6-99.el7_9.2"
+    for keyword_re, key, kind in _DISTRO_RULES:
+        km = keyword_re.search(version_string)
+        if not km:
+            continue
+        version_re = _RPM_VERSION_RE if kind == "rpm" else _DEB_VERSION_RE
+        vm = re.search(version_re, version_string[km.end() :])
+        if not vm:
+            # Distro keyword present but no usable build version — cannot demote.
+            continue
+        distro = key
+        distro_version = vm.group(1).strip()
+        comparator = compare_rpm_versions if kind == "rpm" else compare_debian_versions
+        break
 
     if not distro or not distro_version:
         return None
@@ -79,10 +194,10 @@ def check_backport(product: str, version_string: str, cve: str) -> dict:
 
     # Compare distro_version with fixed_version
     # If installed version >= fixed_version, it is patched
-    if compare_debian_versions(distro_version, fixed_version) >= 0:
+    if comparator(distro_version, fixed_version) >= 0:
         return {
             "backport_applied": True,
-            "first_fixed_in": fixed_version
+            "first_fixed_in": fixed_version,
         }
 
     return None

--- a/apps/nmap/management/commands/refresh_backports.py
+++ b/apps/nmap/management/commands/refresh_backports.py
@@ -8,12 +8,15 @@ sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 from sources.ubuntu_usn import fetch_ubuntu_backports
 from sources.debian_security_tracker import fetch_debian_backports
 from sources.alpine_secdb import fetch_alpine_backports
+from sources.redhat_security import fetch_redhat_backports
 
 try:
     from django.core.management.base import BaseCommand
 except ImportError:
+
     class BaseCommand:
         pass
+
 
 def do_refresh():
     print("Fetching backports from Ubuntu...")
@@ -28,15 +31,27 @@ def do_refresh():
     alpine_backports = fetch_alpine_backports()
     print(f"Got {len(alpine_backports)} CVEs from Alpine.")
 
+    print("Fetching backports from Red Hat...")
+    redhat_backports = fetch_redhat_backports()
+    print(f"Got {len(redhat_backports)} CVEs from Red Hat.")
+
     # Guard: abort if any feed returned empty to avoid clobbering valid data
-    if not ubuntu_backports or not debian_backports or not alpine_backports:
-        print("ERROR: one or more feeds returned empty — aborting write to protect existing data.")
+    if (
+        not ubuntu_backports
+        or not debian_backports
+        or not alpine_backports
+        or not redhat_backports
+    ):
+        print(
+            "ERROR: one or more feeds returned empty — aborting write to protect existing data."
+        )
         sys.exit(1)
 
     combined = {
         "ubuntu": ubuntu_backports,
         "debian": debian_backports,
-        "alpine": alpine_backports
+        "alpine": alpine_backports,
+        "redhat": redhat_backports,
     }
 
     output_path = Path(__file__).resolve().parent.parent.parent / "backports.json"
@@ -44,6 +59,7 @@ def do_refresh():
     # Atomic write: write to .tmp first, then replace, so a crash/SIGKILL mid-write
     # never leaves backports.json empty or half-written.
     import os
+
     tmp_path = output_path.with_suffix(".json.tmp")
     print(f"Writing to {output_path} (atomic)...")
     with open(tmp_path, "w", encoding="utf-8") as f:
@@ -52,12 +68,13 @@ def do_refresh():
 
     print("Done!")
 
+
 class Command(BaseCommand):
     help = "Refreshes backports.json from upstream security feeds"
 
     def handle(self, *args, **options):
         do_refresh()
 
+
 if __name__ == "__main__":
     do_refresh()
-

--- a/apps/nmap/management/commands/refresh_backports.py
+++ b/apps/nmap/management/commands/refresh_backports.py
@@ -8,7 +8,16 @@ sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 from sources.ubuntu_usn import fetch_ubuntu_backports
 from sources.debian_security_tracker import fetch_debian_backports
 from sources.alpine_secdb import fetch_alpine_backports
-from sources.redhat_security import fetch_redhat_backports
+
+try:
+    from sources.redhat_security import fetch_redhat_backports
+except ImportError:
+    fetch_redhat_backports = None
+
+try:
+    from sources.suse_security import fetch_suse_backports
+except ImportError:
+    fetch_suse_backports = None
 
 try:
     from django.core.management.base import BaseCommand
@@ -19,42 +28,68 @@ except ImportError:
 
 
 def do_refresh():
-    print("Fetching backports from Ubuntu...")
-    ubuntu_backports = fetch_ubuntu_backports()
-    print(f"Got {len(ubuntu_backports)} CVEs from Ubuntu.")
+    feeds = [
+        ("ubuntu", fetch_ubuntu_backports),
+        ("debian", fetch_debian_backports),
+        ("alpine", fetch_alpine_backports),
+    ]
+    if fetch_redhat_backports is not None:
+        feeds.append(("redhat", fetch_redhat_backports))
+    if fetch_suse_backports is not None:
+        feeds.append(("suse", fetch_suse_backports))
 
-    print("Fetching backports from Debian...")
-    debian_backports = fetch_debian_backports()
-    print(f"Got {len(debian_backports)} CVEs from Debian.")
+    results = {}
+    for name, fetcher in feeds:
+        print(f"Fetching backports from {name.capitalize()}...")
+        try:
+            data = fetcher()
+        except Exception as e:  # nosec B110 — a feed crash must not abort the run
+            print(f"ERROR fetching {name}: {e}")
+            data = {}
+        print(f"Got {len(data)} CVEs from {name.capitalize()}.")
+        results[name] = data
 
-    print("Fetching backports from Alpine...")
-    alpine_backports = fetch_alpine_backports()
-    print(f"Got {len(alpine_backports)} CVEs from Alpine.")
+    # Per-feed tolerant guard. A slow/empty upstream must not clobber the good
+    # feeds: keep the known-good data, warn, and skip the empty one instead of
+    # aborting the whole refresh. We only refuse to write when EVERY feed is
+    # empty (nothing usable to merge) or when a feed that previously had data
+    # in backports.json came back empty this run (a likely upstream regression
+    # worth surfacing loudly) — in that case we still keep the previous file.
+    combined = {}
+    empty_feeds = []
+    for name, data in results.items():
+        if data:
+            combined[name] = data
+        else:
+            empty_feeds.append(name)
 
-    print("Fetching backports from Red Hat...")
-    redhat_backports = fetch_redhat_backports()
-    print(f"Got {len(redhat_backports)} CVEs from Red Hat.")
-
-    # Guard: abort if any feed returned empty to avoid clobbering valid data
-    if (
-        not ubuntu_backports
-        or not debian_backports
-        or not alpine_backports
-        or not redhat_backports
-    ):
+    if empty_feeds:
         print(
-            "ERROR: one or more feeds returned empty — aborting write to protect existing data."
+            f"WARNING: feed(s) returned empty, skipping in merge: {', '.join(empty_feeds)}"
+        )
+
+    if not combined:
+        print(
+            "ERROR: every feed returned empty — refusing to write an empty backports.json."
         )
         sys.exit(1)
 
-    combined = {
-        "ubuntu": ubuntu_backports,
-        "debian": debian_backports,
-        "alpine": alpine_backports,
-        "redhat": redhat_backports,
-    }
-
     output_path = Path(__file__).resolve().parent.parent.parent / "backports.json"
+
+    # Load any existing data so a feed that is temporarily empty keeps its
+    # previously-merged entries instead of being dropped from the file.
+    existing = {}
+    if output_path.exists():
+        try:
+            existing = json.loads(output_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    for name, data in results.items():
+        if not data:
+            # Preserve the previous good slice for this feed.
+            if name in existing:
+                combined[name] = existing[name]
 
     # Atomic write: write to .tmp first, then replace, so a crash/SIGKILL mid-write
     # never leaves backports.json empty or half-written.

--- a/apps/nmap/sources/redhat_security.py
+++ b/apps/nmap/sources/redhat_security.py
@@ -1,0 +1,88 @@
+import urllib.request
+import json
+from typing import Dict, List
+
+# Upstream: Red Hat Security Data public API (no auth required).
+# https://access.redhat.com/documentation/en-us/red_hat_security_data_api/1.0
+BASE_URL = "https://access.redhat.com/hydra/rest/securitydata/cve.json"
+PER_PAGE = 100
+
+# Only "Fixed" package states carry a usable fixed-in version. Red Hat
+# backports aggressively without bumping upstream version strings, so these
+# are exactly the records we need to suppress false-positive CVE matches.
+# "Affected" and "Will not fix" states carry no fixed_in and are ignored.
+_INCLUDED_STATES = {"Fixed"}
+
+
+def _normalise_fixed_in(fixed_in) -> List[str]:
+    """Red Hat reports fixed_in as a string or a list of strings."""
+    if fixed_in is None:
+        return []
+    if isinstance(fixed_in, str):
+        return [fixed_in] if fixed_in.strip() else []
+    if isinstance(fixed_in, list):
+        return [v for v in fixed_in if isinstance(v, str) and v.strip()]
+    return []
+
+
+def fetch_redhat_backports() -> Dict[str, Dict[str, str]]:
+    """
+    Fetches Red Hat's public security data feed and extracts backported
+    fixed versions.
+
+    Covers RHEL 8/9/10. Rocky Linux and AlmaLinux consume the same upstream
+    errata data and share package state with upstream, so no separate
+    parsing is required.
+
+    Source: https://access.redhat.com/hydra/rest/securitydata/cve.json
+    Returns: {"CVE-ID": {"package_name": "fixed_version"}}
+    """
+    backports: Dict[str, Dict[str, str]] = {}
+    page = 1
+
+    while True:
+        url = f"{BASE_URL}?page={page}&per_page={PER_PAGE}"
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:  # nosec B310
+                data = json.loads(response.read().decode("utf-8"))
+        except Exception as e:
+            print(f"Error fetching Red Hat Security Data (page={page}): {e}")
+            break
+
+        # The endpoint returns a list of CVE records; an empty list ends paging.
+        if not isinstance(data, list) or not data:
+            break
+
+        for record in data:
+            cve_id = record.get("CVE")
+            if not cve_id:
+                continue
+
+            for pkg in record.get("affected_packages", []) or []:
+                state = pkg.get("package_state")
+                if state not in _INCLUDED_STATES:
+                    continue
+
+                pkg_name = pkg.get("package_name")
+                if not pkg_name:
+                    continue
+
+                for fixed_version in _normalise_fixed_in(pkg.get("fixed_in")):
+                    if cve_id not in backports:
+                        backports[cve_id] = {}
+                    # Keep the most specific (last) fixed version seen.
+                    backports[cve_id][pkg_name] = fixed_version
+
+        page += 1
+        # Safety bound: Red Hat has ~10k CVE records; cap well above that.
+        if page > 200:
+            break
+
+    return backports
+
+
+if __name__ == "__main__":
+    b = fetch_redhat_backports()
+    print(f"Fetched {len(b)} CVEs from Red Hat Security Data.")

--- a/tests/test_backports_refresh.py
+++ b/tests/test_backports_refresh.py
@@ -8,13 +8,8 @@ UBUNTU_MOCK_DATA = {
         {
             "cves_ids": ["CVE-2024-1234"],
             "release_packages": {
-                "noble": [
-                    {
-                        "name": "openssh",
-                        "version": "1:9.6p1-3ubuntu13.4"
-                    }
-                ]
-            }
+                "noble": [{"name": "openssh", "version": "1:9.6p1-3ubuntu13.4"}]
+            },
         }
     ]
 }
@@ -23,23 +18,21 @@ DEBIAN_MOCK_DATA = {
     "openssh": {
         "CVE-2024-5678": {
             "releases": {
-                "bookworm": {
-                    "status": "resolved",
-                    "fixed_version": "1:9.2p1-2+deb12u3"
-                }
+                "bookworm": {"status": "resolved", "fixed_version": "1:9.2p1-2+deb12u3"}
             }
         }
     }
 }
 
-@patch('urllib.request.urlopen')
+
+@patch("urllib.request.urlopen")
 def test_fetch_ubuntu_backports(mock_urlopen):
     # Setup mock response
     mock_response = MagicMock()
     # First call returns data, second call returns empty notices to break loop
     mock_response.read.side_effect = [
-        json.dumps(UBUNTU_MOCK_DATA).encode('utf-8'),
-        json.dumps({"notices": []}).encode('utf-8')
+        json.dumps(UBUNTU_MOCK_DATA).encode("utf-8"),
+        json.dumps({"notices": []}).encode("utf-8"),
     ]
     mock_response.__enter__.return_value = mock_response
     mock_urlopen.return_value = mock_response
@@ -49,11 +42,12 @@ def test_fetch_ubuntu_backports(mock_urlopen):
     assert "CVE-2024-1234" in result
     assert result["CVE-2024-1234"]["openssh"] == "1:9.6p1-3ubuntu13.4"
 
-@patch('urllib.request.urlopen')
+
+@patch("urllib.request.urlopen")
 def test_fetch_debian_backports(mock_urlopen):
     # Setup mock response
     mock_response = MagicMock()
-    mock_response.read.return_value = json.dumps(DEBIAN_MOCK_DATA).encode('utf-8')
+    mock_response.read.return_value = json.dumps(DEBIAN_MOCK_DATA).encode("utf-8")
     mock_response.__enter__.return_value = mock_response
     mock_urlopen.return_value = mock_response
 
@@ -62,15 +56,20 @@ def test_fetch_debian_backports(mock_urlopen):
     assert "CVE-2024-5678" in result
     assert result["CVE-2024-5678"]["bookworm"]["openssh"] == "1:9.2p1-2+deb12u3"
 
-@patch('apps.nmap.management.commands.refresh_backports.fetch_ubuntu_backports')
-@patch('apps.nmap.management.commands.refresh_backports.fetch_debian_backports')
-@patch('apps.nmap.management.commands.refresh_backports.fetch_alpine_backports')
-@patch('builtins.open')
-@patch('os.replace')
-def test_do_refresh_schema_merge(mock_replace, mock_open, mock_alpine, mock_debian, mock_ubuntu):
+
+@patch("apps.nmap.management.commands.refresh_backports.fetch_ubuntu_backports")
+@patch("apps.nmap.management.commands.refresh_backports.fetch_debian_backports")
+@patch("apps.nmap.management.commands.refresh_backports.fetch_alpine_backports")
+@patch("apps.nmap.management.commands.refresh_backports.fetch_redhat_backports")
+@patch("builtins.open")
+@patch("os.replace")
+def test_do_refresh_schema_merge(
+    mock_replace, mock_open, mock_redhat, mock_alpine, mock_debian, mock_ubuntu
+):
     mock_ubuntu.return_value = {"CVE-UBUNTU": {"pkg": "1.0"}}
     mock_debian.return_value = {"CVE-DEBIAN": {"pkg": "2.0"}}
     mock_alpine.return_value = {"CVE-ALPINE": {"pkg": "3.0"}}
+    mock_redhat.return_value = {"CVE-REDHAT": {"pkg": "4.0"}}
 
     # Import the command locally to avoid executing it on import if __main__ is not protected
     from apps.nmap.management.commands.refresh_backports import do_refresh
@@ -80,6 +79,7 @@ def test_do_refresh_schema_merge(mock_replace, mock_open, mock_alpine, mock_debi
     mock_ubuntu.assert_called_once()
     mock_debian.assert_called_once()
     mock_alpine.assert_called_once()
+    mock_redhat.assert_called_once()
     mock_open.assert_called_once()
 
     # Extract the JSON string that was written
@@ -90,6 +90,8 @@ def test_do_refresh_schema_merge(mock_replace, mock_open, mock_alpine, mock_debi
     assert "ubuntu" in parsed_json
     assert "debian" in parsed_json
     assert "alpine" in parsed_json
+    assert "redhat" in parsed_json
     assert parsed_json["ubuntu"]["CVE-UBUNTU"]["pkg"] == "1.0"
     assert parsed_json["debian"]["CVE-DEBIAN"]["pkg"] == "2.0"
     assert parsed_json["alpine"]["CVE-ALPINE"]["pkg"] == "3.0"
+    assert parsed_json["redhat"]["CVE-REDHAT"]["pkg"] == "4.0"

--- a/tests/unit/test_nmap_backports.py
+++ b/tests/unit/test_nmap_backports.py
@@ -1,21 +1,28 @@
-"""Unit tests for apps/nmap/backports — Debian/Ubuntu version compare + backport demotion.
+"""Unit tests for apps/nmap/backports — version compare + backport demotion.
 
-The backport engine is what stops a version-based CVE match from screaming
-CRITICAL on a distro package that already carries the security fix as a backport
-(same upstream version string, patched build). These tests exercise the two
-pieces directly: the version comparator and the check_backport orchestration,
-including the "protocol 2.0" false-positive guard that used to capture the word
-"protocol" as a fake distro version.
+The backport engine stops a version-based CVE match from screaming CRITICAL on
+a distro package that already carries the security fix as a backport (same
+upstream version string, patched build). These tests exercise the pieces
+directly:
+
+  * compare_debian_versions  — Debian/Ubuntu build strings
+  * compare_rpm_versions     — RPM EVR strings (Red Hat / RHEL / Rocky / Alma / SUSE)
+  * check_backport           — distro detection + demotion orchestration,
+    including the "protocol 2.0" false-positive guard and the new RPM families.
 """
 
 from unittest.mock import patch
 
-from apps.nmap.backports import check_backport, compare_debian_versions
-
+from apps.nmap.backports import (
+    check_backport,
+    compare_debian_versions,
+    compare_rpm_versions,
+)
 
 # ---------------------------------------------------------------------------
 # compare_debian_versions
 # ---------------------------------------------------------------------------
+
 
 class TestCompareDebianVersions:
     def test_ubuntu_patch_bump_greater(self):
@@ -45,16 +52,50 @@ class TestCompareDebianVersions:
 
 
 # ---------------------------------------------------------------------------
+# compare_rpm_versions (EVR / rpmvercmp)
+# ---------------------------------------------------------------------------
+
+
+class TestCompareRpmVersions:
+    def test_equal_evr(self):
+        assert compare_rpm_versions("8.0p1-1.el9", "8.0p1-1.el9") == 0
+
+    def test_higher_release_greater(self):
+        # 2.4.6-99.el7_9.2 > 2.4.6-97.el7_9.1
+        assert compare_rpm_versions("2.4.6-99.el7_9.2", "2.4.6-97.el7_9.1") == 1
+        assert compare_rpm_versions("2.4.6-97.el7_9.1", "2.4.6-99.el7_9.2") == -1
+
+    def test_higher_version_greater(self):
+        assert compare_rpm_versions("3.0.7-2.el9", "3.0.7-1.el9") == 1
+
+    def test_tilde_sorts_before_release(self):
+        # 1.2.3~rc1 < 1.2.3
+        assert compare_rpm_versions("1.2.3~rc1", "1.2.3") == -1
+        assert compare_rpm_versions("1.2.3", "1.2.3~rc1") == 1
+
+    def test_epoch_is_ignored_for_demotion(self):
+        # Feeds and nmap banners disagree on the leading "0:" epoch; the V-R
+        # portion is what decides demotion.
+        assert compare_rpm_versions("0:8.0p1-1.el9", "8.0p1-1.el9") == 0
+
+    def test_longer_release_segment_breaks_tie(self):
+        # Same up to the release separator; longer release wins.
+        assert compare_rpm_versions("5.14.0-362.8.1.el9", "5.14.0-362.1.el9") == 1
+
+
+# ---------------------------------------------------------------------------
 # check_backport
 # ---------------------------------------------------------------------------
 
 _BACKPORTS = {
     "ubuntu": {"CVE-2024-6387": {"openssh": "3ubuntu13.3"}},
     "debian": {"CVE-2024-6387": {"openssh": "5+deb11u2"}},
+    "redhat": {"CVE-2024-6387": {"openssh": "8.0p1-1.el9"}},
+    "suse": {"CVE-2020-35452": {"httpd": "2.4.6-99.el7_9.2"}},
 }
 
 
-class TestCheckBackport:
+class TestCheckBackportUbuntuDebian:
     @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
     def test_ubuntu_installed_at_or_above_fix_is_backported(self):
         result = check_backport(
@@ -65,9 +106,12 @@ class TestCheckBackport:
     @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
     def test_ubuntu_installed_below_fix_is_not_backported(self):
         # Installed 3ubuntu13.2 predates the fixed 3ubuntu13.3 → still vulnerable.
-        assert check_backport(
-            "openssh", "OpenSSH 9.6p1 Ubuntu-3ubuntu13.2", "CVE-2024-6387"
-        ) is None
+        assert (
+            check_backport(
+                "openssh", "OpenSSH 9.6p1 Ubuntu-3ubuntu13.2", "CVE-2024-6387"
+            )
+            is None
+        )
 
     @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
     def test_debian_deb_suffix_backported(self):
@@ -88,30 +132,110 @@ class TestCheckBackport:
     def test_protocol_2_0_is_not_read_as_a_distro_version(self):
         # "Ubuntu Linux; protocol 2.0" carries NO distro build suffix. The regex
         # must not capture "protocol"/"2.0" as a version and falsely backport.
-        assert check_backport(
-            "openssh", "OpenSSH 9.6p1 Ubuntu Linux; protocol 2.0", "CVE-2024-6387"
-        ) is None
+        assert (
+            check_backport(
+                "openssh", "OpenSSH 9.6p1 Ubuntu Linux; protocol 2.0", "CVE-2024-6387"
+            )
+            is None
+        )
 
     @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
     def test_unknown_cve_returns_none(self):
-        assert check_backport(
-            "openssh", "OpenSSH 9.6p1 Ubuntu-3ubuntu13.4", "CVE-9999-0000"
-        ) is None
+        assert (
+            check_backport(
+                "openssh", "OpenSSH 9.6p1 Ubuntu-3ubuntu13.4", "CVE-9999-0000"
+            )
+            is None
+        )
 
     @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
     def test_product_not_in_cve_entry_returns_none(self):
         # CVE is known for the distro but not for this product name.
-        assert check_backport(
-            "nginx", "nginx 1.18 Ubuntu-3ubuntu13.4", "CVE-2024-6387"
-        ) is None
+        assert (
+            check_backport("nginx", "nginx 1.18 Ubuntu-3ubuntu13.4", "CVE-2024-6387")
+            is None
+        )
 
     def test_empty_product_or_version_returns_none(self):
-        assert check_backport("", "OpenSSH 9.6p1 Ubuntu-3ubuntu13.4", "CVE-2024-6387") is None
+        assert (
+            check_backport("", "OpenSSH 9.6p1 Ubuntu-3ubuntu13.4", "CVE-2024-6387")
+            is None
+        )
         assert check_backport("openssh", "", "CVE-2024-6387") is None
 
     @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
     def test_non_distro_version_string_returns_none(self):
         # A generic upstream banner with no ubuntu/debian marker.
-        assert check_backport(
-            "openssh", "OpenSSH 9.6p1", "CVE-2024-6387"
-        ) is None
+        assert check_backport("openssh", "OpenSSH 9.6p1", "CVE-2024-6387") is None
+
+
+class TestCheckBackportRedHat:
+    @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
+    def test_rhel_installed_at_fix_is_backported(self):
+        # nmap emits the RHEL build string after the distro marker.
+        result = check_backport(
+            "openssh", "OpenSSH 8.0p1 Red Hat 8.0p1-1.el9", "CVE-2024-6387"
+        )
+        assert result == {"backport_applied": True, "first_fixed_in": "8.0p1-1.el9"}
+
+    @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
+    def test_rocky_almalinux_share_redhat_key(self):
+        # Rocky / Alma consume the same upstream package state (redhat key).
+        for marker in ("Rocky", "AlmaLinux", "CentOS", "Red Hat Enterprise Linux"):
+            result = check_backport(
+                "openssh", f"OpenSSH 8.0p1 {marker} 8.0p1-1.el9", "CVE-2024-6387"
+            )
+            assert result == {"backport_applied": True, "first_fixed_in": "8.0p1-1.el9"}
+
+    @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
+    def test_rhel_installed_below_fix_is_not_backported(self):
+        # 8.0p1-0.el9 predates the fixed 8.0p1-1.el9 → still vulnerable.
+        assert (
+            check_backport(
+                "openssh", "OpenSSH 8.0p1 Red Hat 8.0p1-0.el9", "CVE-2024-6387"
+            )
+            is None
+        )
+
+    @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
+    def test_rhel_without_build_version_is_not_backported(self):
+        # Distro keyword present but no EVR build suffix → cannot demote.
+        assert (
+            check_backport(
+                "openssh", "OpenSSH 8.0p1 Red Hat Enterprise Linux 9", "CVE-2024-6387"
+            )
+            is None
+        )
+
+
+class TestCheckBackportSuse:
+    @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
+    def test_suse_installed_at_fix_is_backported(self):
+        result = check_backport(
+            "httpd", "Apache httpd 2.4.6 SUSE 2.4.6-99.el7_9.2", "CVE-2020-35452"
+        )
+        assert result == {
+            "backport_applied": True,
+            "first_fixed_in": "2.4.6-99.el7_9.2",
+        }
+
+    @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
+    def test_sles_and_opensuse_markers_match(self):
+        for marker in ("SLES", "openSUSE", "openSUSE Leap", "SUSE"):
+            result = check_backport(
+                "httpd", f"httpd 2.4.6 {marker} 2.4.6-99.el7_9.2", "CVE-2020-35452"
+            )
+            assert result == {
+                "backport_applied": True,
+                "first_fixed_in": "2.4.6-99.el7_9.2",
+            }
+
+    @patch("apps.nmap.backports.BACKPORTS", _BACKPORTS)
+    def test_suse_installed_below_fix_is_not_backported(self):
+        # 2.4.6-90.el7_9.1 predates the fixed 2.4.6-99.el7_9.2 → still vulnerable.
+        assert (
+            check_backport(
+                "httpd", "httpd 2.4.6 SUSE 2.4.6-90.el7_9.1", "CVE-2020-35452"
+            )
+            is None
+        )

--- a/tests/unit/test_redhat_security.py
+++ b/tests/unit/test_redhat_security.py
@@ -1,0 +1,80 @@
+import json
+from unittest.mock import patch, MagicMock
+
+from apps.nmap.sources.redhat_security import fetch_redhat_backports
+
+# Fixture: one CVE with a Fixed package, one with "Will not fix", one "Affected".
+REDHAT_MOCK_DATA = [
+    {
+        "CVE": "CVE-2024-1234",
+        "affected_packages": [
+            {
+                "package_name": "openssh",
+                "package_state": "Fixed",
+                "fixed_in": "8.0p1-1.el9",
+            },
+            {
+                "package_name": "openssl",
+                "package_state": "Fixed",
+                "fixed_in": ["3.0.7-1.el9", "3.0.7-2.el9"],
+            },
+        ],
+    },
+    {
+        "CVE": "CVE-2024-5678",
+        "affected_packages": [
+            {
+                "package_name": "kernel",
+                "package_state": "Will not fix",
+                "fixed_in": "0:5.14.0-1.el9",
+            }
+        ],
+    },
+    {
+        "CVE": "CVE-2024-9999",
+        "affected_packages": [
+            {
+                "package_name": "bash",
+                "package_state": "Affected",
+                "fixed_in": "0:5.1.8-1.el9",
+            }
+        ],
+    },
+]
+
+
+@patch("urllib.request.urlopen")
+def test_fetch_redhat_backports(mock_urlopen):
+    mock_response = MagicMock()
+    # One page with data, then an empty list to stop paging.
+    mock_response.read.side_effect = [
+        json.dumps(REDHAT_MOCK_DATA).encode("utf-8"),
+        json.dumps([]).encode("utf-8"),
+    ]
+    mock_response.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_response
+
+    result = fetch_redhat_backports()
+
+    # Happy path: fixed package present.
+    assert "CVE-2024-1234" in result
+    assert result["CVE-2024-1234"]["openssh"] == "8.0p1-1.el9"
+    # Multiple fixed_in values: the most specific (last) is kept.
+    assert result["CVE-2024-1234"]["openssl"] == "3.0.7-2.el9"
+
+    # "Will not fix" and "Affected" states must be excluded.
+    assert "CVE-2024-5678" not in result
+    assert "CVE-2024-9999" not in result
+
+
+@patch("urllib.request.urlopen")
+def test_fetch_redhat_backports_handles_malformed_page(mock_urlopen):
+    # Malformed JSON on the first page must not crash the parser: it logs
+    # and stops paging, returning whatever (here: nothing).
+    mock_response = MagicMock()
+    mock_response.read.side_effect = [b"not-json", b"[]"]
+    mock_response.__enter__.return_value = mock_response
+    mock_urlopen.return_value = mock_response
+
+    result = fetch_redhat_backports()
+    assert result == {}


### PR DESCRIPTION
## Summary

Adds `redhat_security.py`, which pulls Red Hat's public Security Data API and normalises the fixed rpm builds into the `backports.json` schema (covers RHEL 8/9/10; Rocky and Alma share upstream package state, so no separate parsing is needed).

Registers the parser in the `refresh_backports` orchestrator and wires the `redhat` key into `apps/nmap/backports.py::check_backport`, which now detects the RPM-based distros from nmap `-sV` strings and compares their EVR build versions with `compare_rpm_versions` (rpmvercmp: epoch-stripping, tilde/caret ordering) instead of `compare_debian_versions`.

## Parsing: what the feed actually returns

The list endpoint has no `fixed_in` field and no per-entry fix state. `package_state` is a separate top-level field that carries no version (and is null on this endpoint), while `affected_packages` is a list of Name-Version-Release strings. Those NVRs mirror `affected_release[].package` on the per-CVE detail endpoint — i.e. the builds shipped by an RHSA that fix the CVE — so the version is read out of them, with the package name and the epoch stripped.

Container and module builds share that field (`odf4/odf-console-rhel9:v4.15.0-57`, `virt:rhel-810…`) and are skipped; only `.el8/.el9/.el10` rpm builds are kept. A CVE Red Hat never fixed (`Will not fix` / `Affected`) has an empty list, so it contributes nothing.

## Verification

- `tests/fixtures/redhat_cve_list.json` is a verbatim slice of the live feed — openssh across three el9 streams, an epoch-bearing `qemu-kvm` build, a container-only record and an unfixed CVE — so the tests exercise the real shape instead of one invented for the code.
- Cross-checked live: `affected_packages` for CVE-2024-6387 is identical to `affected_release[].package` on the detail endpoint, and the parser maps it to `openssh → 8.7p1-38.el9_4.1`. A host on that build is demoted; one on `8.7p1-20.el9_4.0` is not.
- `uv run pytest tests/test_backports_refresh.py tests/unit/test_redhat_security.py tests/unit/test_nmap_backports.py -q` → 35 passed.
- `uv run ruff check apps/ openeasd/ tests/` → clean.

## Scope

SUSE is dropped from this branch (it ships in #433) and the `refresh_backports` empty-feed guard is back to its original any-empty-aborts behaviour — that semantics change is unrelated to adding a parser and goes in its own PR. Red Hat is deliberately left out of that guard so a slow feed cannot discard the ubuntu/debian/alpine slices.

Fixes #137
