### PR TITLE
ci: pin prod image tag + document verify→promote flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Deterministic prod image pinning + a documented verify→promote flow.** The k8s
+  Deployments now use **bare image names**; the version is pinned in one place —
+  `k8s/kustomization.yaml` `images[].newTag` (bumped from a stale `v2.1.1` to the
+  current release) — with `imagePullPolicy: IfNotPresent`. Promotion is now a
+  deliberate, reversible act (bump `newTag` → apply; rollback = set it back),
+  instead of the non-deterministic `:latest` the Deployment fields previously
+  named. `docker-compose.dev.yml` takes an `OPENEASD_TAG` (default `latest`) so
+  `just deploy-dev` can **smoke-test the exact release image** before promoting —
+  closing the "native dev ≠ shipped artifact" gap. Full playbook added to
+  `docs/DEVELOPMENT.md` ("Ship it — verify in dev, then promote to prod").
+
 ## [v2.14.0] — 2026-09-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,8 +266,20 @@ k8s/
   worker-deployment.yaml — openeasd-worker: DBOS worker (tier: worker, NET_RAW, no Service)
   service.yaml           — NodePort 30808 → 8000, selector tier: web ONLY
   ingress.yaml           — nginx Ingress; TLS annotations ready to uncomment
-  kustomization.yaml     — kubectl apply -k k8s/ (does NOT include secret.yaml)
+  kustomization.yaml     — kubectl apply -k k8s/ (does NOT include secret.yaml);
+                           pins the image tag via images[].newTag — the SINGLE
+                           source of truth for which version prod runs
 ```
+
+**Image pinning (deterministic promote + rollback):** the Deployments carry
+**bare image names** (`ghcr.io/cybersecify/openeasd-{web,worker}`, no tag); the
+version is set only by `kustomization.yaml` `images[].newTag`. To promote a
+release, smoke-test the published `:vX.Y.Z` image first (`OPENEASD_TAG=vX.Y.Z
+just deploy-dev`), then bump `newTag` to that version and `kubectl apply -k k8s/`.
+Rollback = set `newTag` back and re-apply. `imagePullPolicy: IfNotPresent` +
+immutable tags make this reproducible. Never pin prod to `:latest`. Enforced by
+`test_k8s_manifests.py::test_images_pinned_to_release_tag` (newTag must be `vX…`).
+See the full flow in `docs/DEVELOPMENT.md` (Ship it — verify, then promote).
 
 **Key constraints:**
 - `replicas: 1` on each Deployment by default. Postgres removes the SQLite single-writer limit, so `openeasd-worker` can scale to multiple replicas pulling the same DBOS queue (`kubectl scale deploy/openeasd-worker --replicas=N`) independently of `openeasd-web`

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,15 +1,17 @@
-# Dev-deployment override: run the CI-published :latest images instead of a local
-# build. Used by `just deploy-dev` for a quick dev deploy that consumes the real
-# GHCR artifacts. Production is unchanged — it uses the base docker-compose.yml
-# with pinned :vX.Y.Z images (published by the GitHub tag pipeline).
+# Dev-deployment override: run a CI-published GHCR image instead of a local build.
+# Used by `just deploy-dev` to smoke-test the REAL artifact before promoting it to
+# prod. The tag defaults to :latest but can be pinned to the exact release you're
+# about to ship — smoke-test that image, then promote the same tag:
 #
-#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --no-build --pull always
+#   OPENEASD_TAG=v2.14.0 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --no-build --pull always
+#
+# Production is unchanged — k8s pins the tag via k8s/kustomization.yaml (newTag).
 #
 services:
   web:
-    image: ghcr.io/cybersecify/openeasd-web:latest
+    image: ghcr.io/cybersecify/openeasd-web:${OPENEASD_TAG:-latest}
     pull_policy: always
 
   worker:
-    image: ghcr.io/cybersecify/openeasd-worker:latest
+    image: ghcr.io/cybersecify/openeasd-worker:${OPENEASD_TAG:-latest}
     pull_policy: always

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -115,6 +115,53 @@ just logs / just ps
 > On Apple Silicon, `just up` builds native arm64 images. `just deploy-dev` pulls
 > the published GHCR images, which are **amd64-only** — they'll run under emulation.
 
+## Ship it — verify in dev, then promote to prod
+
+The rule: **verify everything in dev; never debug on the live instance.** Prod
+only ever receives an already-verified, tagged image.
+
+**1 — Verify the code (native).** Build on a `feat/`/`fix/` branch with `just dev`,
+click through the feature at http://localhost:5173, run a scan on an *authorized*
+test domain, and confirm any new migrations apply (`uv run manage.py migrate`).
+Then the go/no-go gate:
+
+```bash
+just ci           # green here = green in GitHub CI. Don't proceed on red.
+```
+
+**2 — Merge + release.** PR → CI green → squash-merge. Accumulate features in the
+CHANGELOG `[Unreleased]` and cut **one** tagged release for the batch:
+
+```bash
+git tag vX.Y.Z && git push origin vX.Y.Z    # GHCR builds :vX.Y.Z (web + worker)
+```
+
+**3 — Smoke-test the REAL image (closes the "native ≠ image" gap).** Before
+touching prod, run the exact published artifact locally — this catches
+image-only issues (a missing binary in the worker image, entrypoint/env,
+migrations under the real image) that native dev can't:
+
+```bash
+OPENEASD_TAG=vX.Y.Z just deploy-dev     # pulls & runs ghcr.io/…:vX.Y.Z
+# → http://localhost:8000 : login, run one scan, check the feature. Then `just down`.
+```
+
+**4 — Promote.** Bump the **single source of truth** — `newTag` in
+`k8s/kustomization.yaml` — to the version you just smoke-tested, then apply:
+
+```bash
+# edit k8s/kustomization.yaml:  newTag: vX.Y.Z   (both web + worker)
+kubectl apply -k k8s/
+kubectl rollout restart deployment/openeasd-web deployment/openeasd-worker
+```
+
+**Rollback** is the same move in reverse: set `newTag` back to the previous
+version and re-apply. Because tags are immutable, this is deterministic — the
+`imagePullPolicy: IfNotPresent` deployments pull the new tag and cache it.
+
+> The k8s Deployments use **bare image names**; the tag is set *only* by
+> `kustomization.yaml` (`images[].newTag`). Bump it in one place to promote.
+
 ## Where things live
 
 | Concern | File |

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -6,9 +6,9 @@ images:
   # switch to the floating :v2.1 major.minor tag + imagePullPolicy: Always to
   # auto-pick-up patch releases).
   - name: ghcr.io/cybersecify/openeasd-web
-    newTag: v2.1.1
+    newTag: v2.14.0
   - name: ghcr.io/cybersecify/openeasd-worker
-    newTag: v2.1.1
+    newTag: v2.14.0
 resources:
   - configmap.yaml
   - postgres.yaml

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -26,10 +26,10 @@ spec:
         # then exits — so the schema is ready before gunicorn (and the worker)
         # start. Only the web tier runs migrations; the worker waits for them.
         - name: init
-          image: ghcr.io/cybersecify/openeasd-web:latest
+          image: ghcr.io/cybersecify/openeasd-web
           # Always re-pull: the :latest tag is mutable, so a deploy that doesn't
           # change the tag string must still fetch the new digest.
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           command: ["./docker-entrypoint.sh", "true"]
           envFrom:
             - configMapRef:
@@ -38,8 +38,8 @@ spec:
                 name: openeasd-secret
       containers:
         - name: web
-          image: ghcr.io/cybersecify/openeasd-web:latest
-          imagePullPolicy: Always
+          image: ghcr.io/cybersecify/openeasd-web
+          imagePullPolicy: IfNotPresent
           command:
             - gunicorn
             - openeasd.wsgi:application

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -25,8 +25,8 @@ spec:
     spec:
       containers:
         - name: worker
-          image: ghcr.io/cybersecify/openeasd-worker:latest
-          imagePullPolicy: Always
+          image: ghcr.io/cybersecify/openeasd-worker
+          imagePullPolicy: IfNotPresent
           # Go through the role-aware entrypoint so the worker WAITS for the web
           # tier's migrations (migrate --check) before launching dbos_worker —
           # this replaces the shared-pod initContainer ordering now that web and


### PR DESCRIPTION
The two cheap fixes for the dev-verify-then-promote workflow.

## 1 — Deterministic prod image pinning (+ rollback)
- k8s Deployments now use **bare image names**; the version is pinned in **one place** — `k8s/kustomization.yaml` `images[].newTag`, bumped from a **stale `v2.1.1` → `v2.14.0`** — with `imagePullPolicy: IfNotPresent`.
- Promote = bump `newTag` + `kubectl apply -k k8s/`; **rollback** = set it back and re-apply. Immutable tags make it reproducible.
- Replaces the non-deterministic `:latest` the Deployment `image:` fields previously named (kustomize was already overriding to a stale pin — this makes it consistent and current).

## 2 — Smoke-test the real artifact before promoting
- `docker-compose.dev.yml` now takes `OPENEASD_TAG` (default `latest`), so:
  ```bash
  OPENEASD_TAG=vX.Y.Z just deploy-dev    # runs the exact published image locally
  ```
  This closes the **"native dev ≠ shipped image"** gap — catches image-only issues (missing binary, entrypoint/env, migrations under the real image) before prod.

## Docs
Full playbook added to `docs/DEVELOPMENT.md` — *"Ship it — verify in dev, then promote to prod"* — and the CLAUDE.md k8s section documents the single-source-of-truth pin.

## Scope
Deploy-config + docs only; no app behavior change. `test_k8s_manifests.py` (66) green — `test_images_pinned_to_release_tag` now sees `v2.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv