### PR TITLE
ci: build images once per release (docker job PR-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,14 @@ jobs:
         run: cd frontend && npm run build
 
   docker:
-    # One job (kept named "Docker Build" — a required status check) that builds
-    # both image targets. NOT a matrix: a matrix would report as
-    # "Docker Build (web)"/"(worker)" and the required "Docker Build" context
-    # would never report, permanently blocking the PR.
+    # PR-only build gate. On PRs this proves both images build and warms the
+    # type=gha cache; on main/tag pushes it's SKIPPED because the `publish` job
+    # rebuilds+pushes anyway (from that warm cache) — building here too would be a
+    # redundant full worker build on the release critical path. Kept as ONE job
+    # named "Docker Build" (a required status check); NOT a matrix, or the context
+    # would report as "Docker Build (web)"/"(worker)" and the required check would
+    # never report, permanently blocking the PR.
+    if: github.event_name == 'pull_request'
     name: Docker Build
     runs-on: ubuntu-24.04
 
@@ -153,7 +157,10 @@ jobs:
   publish:
     name: Publish to GHCR
     runs-on: ubuntu-24.04
-    needs: [test, frontend, docker]
+    # NOT `needs: docker` — docker is PR-only and would be skipped here, which
+    # would cascade-skip publish. publish is the sole builder on release and
+    # reuses the type=gha cache the PR's docker job warmed.
+    needs: [test, frontend]
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Faster releases — stop building the images twice.** On a release (main/tag
+  push) the `docker` CI job built both images and then `publish` rebuilt+pushed
+  them again, in series. `docker` is now **PR-only** (its role is the required
+  build gate on PRs, where it also warms the `type=gha` cache); on main/tag pushes
+  it's skipped and `publish` is the sole builder, reusing that cache. Removes a
+  redundant full worker build from the release critical path (~2–4 min/release).
+  No change to what ships or to the PR gate.
+
 ## [v2.14.1] — 2026-09-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,8 @@ git describe --tags --abbrev=0
 - **4 jobs:**
   - `test` — ruff (lint), pytest (fast, excludes `test_domain_security.py`) against a **`postgres:17-alpine` service container** (DB_* env) with a **coverage gate** (`--cov-fail-under=80`; config in `[tool.coverage.run]`, ~83% currently), bandit (SAST), pip-audit (CVE scan)
   - `frontend` — `npm ci`, `npm run test:run` (Vitest + Testing Library, happy-dom env), `npm run build`
-  - `docker` — matrix over the `web` + `worker` build targets, `docker buildx build` for `linux/amd64` (no push, cache check per target)
-  - `publish` — matrix over `web` + `worker`; builds `linux/amd64` and pushes to `ghcr.io/cybersecify/openeasd-web` and `-worker`
+  - `docker` — **PR-only** build gate (`if: github.event_name == 'pull_request'`): one job building both `web` + `worker` targets for `linux/amd64` (no push), warming the `type=gha` cache. **Skipped on main/tag pushes** — `publish` rebuilds+pushes from that warm cache there, so building here too would be a redundant full worker build on the release path.
+  - `publish` — matrix over `web` + `worker`; builds `linux/amd64` and pushes to `ghcr.io/cybersecify/openeasd-web` and `-worker`. `needs: [test, frontend]` only (NOT `docker`, which is PR-only and would cascade-skip publish); it's the sole image builder on release.
 - **Publish triggers:** every push to `main` (`:latest` tag) and `v*` git tags. A tag push emits both the full `:vX.Y.Z` (from `type=ref,event=tag`) and a floating `:vX.Y` major.minor tag (from `type=match,pattern=v\d+\.\d+`) so downstream can pin to a minor line and still get patch updates
 - Runner: `ubuntu-24.04`, Python 3.12, `uv sync --group dev` for deps, `libcairo2-dev gcc libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf-2.0-0` system deps required (WeasyPrint PDF rendering)
 - `pip-audit --ignore-vuln PYSEC-2025-183` — disputed PyJWT weak-key-length CVE, no fix available


### PR DESCRIPTION
## What
Makes the **`docker`** CI job **PR-only** and removes it from `publish`'s `needs`.

## Why
On a release (main/tag push) the images were built **twice, in series**: the `docker` job built both web + worker (`push: false`), then `publish` (which `needed` docker) rebuilt + pushed them. The `docker` job's only real purpose is the **required build gate on PRs** — on a tag there's no PR, so it was a redundant full worker build sitting on the release critical path.

Now:
- **PR:** `docker` runs (the required "Docker Build" check) and warms the `type=gha` cache.
- **main/tag:** `docker` is skipped; `publish` is the sole builder, reusing that warm cache, then pushes.

`publish` drops `docker` from `needs` (a skipped need would cascade-skip publish) — it keeps `needs: [test, frontend]`.

## Impact
**~2–4 min off every release** (one fewer full worker build on the path). No change to what ships, and the PR build gate is unchanged.

## Self-validating
This is a `pull_request`, so the `docker` job **should still run** on this PR (proving the gate survives). `publish` won't run here (PR, not main/tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv