### PR TITLE
chore: release v2.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.14.2] — 2026-09-11
+
 ### Changed
 - **Faster releases — stop building the images twice.** On a release (main/tag
   push) the `docker` CI job built both images and then `publish` rebuilt+pushed
@@ -1509,7 +1511,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.14.1...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.14.2...HEAD
+[v2.14.2]: https://github.com/cybersecify/OpenEASD/compare/v2.14.1...v2.14.2
 [v2.14.1]: https://github.com/cybersecify/OpenEASD/compare/v2.14.0...v2.14.1
 [v2.14.0]: https://github.com/cybersecify/OpenEASD/compare/v2.13.0...v2.14.0
 [v2.13.0]: https://github.com/cybersecify/OpenEASD/compare/v2.12.0...v2.13.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.14.1 — 2026-09-11)
+## Status (v2.14.2 — 2026-09-11)
 
-- **Released**: v2.14.1 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.14.1` / `:v2.14` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.14.2 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.14.2` / `:v2.14` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 30 registered scan tools across 13 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -6,9 +6,9 @@ images:
   # switch to the floating :v2.1 major.minor tag + imagePullPolicy: Always to
   # auto-pick-up patch releases).
   - name: ghcr.io/cybersecify/openeasd-web
-    newTag: v2.14.1
+    newTag: v2.14.2
   - name: ghcr.io/cybersecify/openeasd-worker
-    newTag: v2.14.1
+    newTag: v2.14.2
 resources:
   - configmap.yaml
   - postgres.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.14.1"
+version = "2.14.2"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.14.1"
+version = "2.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Release **v2.14.2** (patch). Finalizes the CHANGELOG (`Unreleased` → `v2.14.2` + compare link), bumps the version in `pyproject.toml` / `uv.lock`, refreshes the CLAUDE.md status header, and bumps k8s `kustomization.yaml` `newTag` → `v2.14.2`.

## Contents since v2.14.1
- CI builds the images **once per release** — the `docker` job is now PR-only; `publish` is the sole builder on main/tag (reusing the PR-warmed cache). ~2–4 min faster releases.

Merging this, then tagging `v2.14.2` to trigger the GHCR publish — **the first release to run through the new single-build path.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv