### PR TITLE
fix: rename 'Surface Enumeration' category to 'Asset Discovery'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Changed
+- **Renamed the "Surface Enumeration" tool category to "Asset Discovery."** More
+  accurate and standard: the phases-3–5 tools (`subfinder`, `amass`, `alterx`,
+  `asn_discovery`, `dnsx`, `takeover_check`, `cloud_assets`) discover the org's
+  external *assets* — subdomains, IP ranges, cloud storage. Parallels the existing
+  "Port Discovery" category and ties to the `asset_inventory` app. Display-only
+  `phase_group` rename.
+
 ### Removed
 - **Retired the `github_recon` tool.** The GitHub Org Recon tool (infra references —
   internal hostnames/subdomains, cloud-bucket URLs, API endpoints — in the org's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -488,13 +488,13 @@ guards that every registered tool appears in the output.
 | `apps/github_secrets/` | 2 | Credential Exposure | Yes | Leaked secrets in PUBLIC GitHub — searches GitHub's code-search API (org-scoped by default) for the target org's committed credentials, fetches the hits, runs gitleaks over them (same engine as `js_secrets`), REDACTS before storage (`check_type="exposed_secret"`, shared with js_secrets). Passive (queries GitHub, not the target); BYOK MANDATORY (`GITHUB_TOKEN` — code-search needs auth; no token → logged no-op); fail-graceful |
 | `apps/typosquat/` | 1 | Domain Intelligence | Yes | Lookalike / typosquat domain detection — generates lookalike candidates algorithmically (homoglyph/typo/omission/insertion/repetition/transposition/hyphenation/TLD-swap), checks which are registered via public DNS, then scores **weaponization**: registered web-serving lookalikes get a capped, fail-graceful homepage fetch for a login form (credential phishing) or brand mention (impersonation) → **high** (active impersonation, prioritise takedown); A/MX-only → medium; NS-only → low. Passive w.r.t. the target (contacts only the lookalike domains, never yours), no key, fail-graceful. Weaponization model ported from the standalone `tldsquatting` project |
 | `apps/breach_check/` | 2 | Credential Exposure | Yes | Data-breach exposure for the domain. BYOK: free keyless XposedOrNot catalog by default, authoritative Have I Been Pwned `breacheddomain` when `HIBP_API_KEY` set. Aggregate COUNTS + public breach metadata only — never email aliases/credentials. Passive, fail-graceful |
-| `apps/subfinder/` | 3 | Surface Enumeration | No | Passive subdomain enumeration |
-| `apps/amass/` | 3 | Surface Enumeration | No | Active subdomain enumeration |
-| `apps/asn_discovery/` | 3 | Surface Enumeration | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
-| `apps/alterx/` | 3 | Surface Enumeration | No | Subdomain permutation via alterx (generates candidates from discovered subdomains) |
-| `apps/dnsx/` | 4 | Surface Enumeration | No | DNS resolution, public IP filtering |
-| `apps/takeover_check/` | 5 | Surface Enumeration | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
-| `apps/cloud_assets/` | 5 | Surface Enumeration | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
+| `apps/subfinder/` | 3 | Asset Discovery | No | Passive subdomain enumeration |
+| `apps/amass/` | 3 | Asset Discovery | No | Active subdomain enumeration |
+| `apps/asn_discovery/` | 3 | Asset Discovery | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
+| `apps/alterx/` | 3 | Asset Discovery | No | Subdomain permutation via alterx (generates candidates from discovered subdomains) |
+| `apps/dnsx/` | 4 | Asset Discovery | No | DNS resolution, public IP filtering |
+| `apps/takeover_check/` | 5 | Asset Discovery | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
+| `apps/cloud_assets/` | 5 | Asset Discovery | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
 | `apps/naabu/` | 6 | Port Discovery | No | Port scanning (top 100 TCP) |
 | `apps/shodan/` | 6 | Port Discovery | Yes | Passive exposure intel from Shodan's own scan data — ports/services/CVEs per resolved IP. BYOK: free InternetDB tier (no key, no credits), full host API when `SHODAN_API_KEY` set (`SHODAN_MAX_IPS` caps the paid path). CVEs land in `extra["cve_ids"]` so `cve_intel` enriches them. Passive, fail-graceful |
 | `apps/core/engine/service_detection/` | 7 | Port Discovery | No | nmap -sV enriches Port.service + is_web |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Phase 2  GitHub Secrets      - Leaked secrets in public GitHub via gitleaks
 Phase 2  Breach Check       - Data-breach exposure via XposedOrNot (free/keyless)
                              or Have I Been Pwned (BYO key); counts only, no PII
 
-── Surface Enumeration ─────────────────────────────────────────────────────
+── Asset Discovery ──────────────────────────────────────────────────────────
 Phase 3  Subfinder         - Passive subdomain enumeration
 Phase 3  Amass             - Active subdomain enumeration
 Phase 3  Alterx            - Subdomain permutation from discovered subdomains

--- a/apps/alterx/apps.py
+++ b/apps/alterx/apps.py
@@ -10,7 +10,7 @@ class AlterxConfig(AppConfig):
         "label": "Alterx (Subdomain Permutation)",
         "runner": "apps.alterx.scanner.run_alterx",
         "phase": 3,
-        "phase_group": "Surface Enumeration",
+        "phase_group": "Asset Discovery",
         "requires": ["subfinder"],
         "produces_findings": False,
         "active": False,

--- a/apps/amass/apps.py
+++ b/apps/amass/apps.py
@@ -10,7 +10,7 @@ class AmassConfig(AppConfig):
         "label": "Amass",
         "runner": "apps.amass.scanner.run_amass",
         "phase": 3,
-        "phase_group": "Surface Enumeration",
+        "phase_group": "Asset Discovery",
         "requires": [],
         "produces_findings": False,
         "active": True,

--- a/apps/asn_discovery/apps.py
+++ b/apps/asn_discovery/apps.py
@@ -10,7 +10,7 @@ class AsnDiscoveryConfig(AppConfig):
         "label": "ASN / IP-range Discovery (amass intel)",
         "runner": "apps.asn_discovery.scanner.run_asn_discovery",
         "phase": 3,
-        "phase_group": "Surface Enumeration",
+        "phase_group": "Asset Discovery",
         "requires": [],
         "produces_findings": True,
         "active": False,

--- a/apps/cloud_assets/apps.py
+++ b/apps/cloud_assets/apps.py
@@ -10,7 +10,7 @@ class CloudAssetsConfig(AppConfig):
         "label": "Cloud Asset Enumeration (cloud-enum)",
         "runner": "apps.cloud_assets.scanner.run_cloud_assets",
         "phase": 5,
-        "phase_group": "Surface Enumeration",
+        "phase_group": "Asset Discovery",
         "requires": ["subfinder"],
         "produces_findings": True,
         "active": False,

--- a/apps/dnsx/apps.py
+++ b/apps/dnsx/apps.py
@@ -10,7 +10,7 @@ class DnsxConfig(AppConfig):
         "label": "DNSx (Resolve)",
         "runner": "apps.dnsx.scanner.run_dnsx",
         "phase": 4,
-        "phase_group": "Surface Enumeration",
+        "phase_group": "Asset Discovery",
         "requires": ["subfinder"],
         "produces_findings": False,
         "active": False,

--- a/apps/subfinder/apps.py
+++ b/apps/subfinder/apps.py
@@ -10,7 +10,7 @@ class SubfinderConfig(AppConfig):
         "label": "Subfinder",
         "runner": "apps.subfinder.scanner.run_subfinder",
         "phase": 3,
-        "phase_group": "Surface Enumeration",
+        "phase_group": "Asset Discovery",
         "requires": [],
         "produces_findings": False,
         "active": False,

--- a/apps/takeover_check/apps.py
+++ b/apps/takeover_check/apps.py
@@ -9,7 +9,7 @@ class TakeoverCheckConfig(AppConfig):
         "label": "Subdomain Takeover Check (subzy)",
         "runner": "apps.takeover_check.scanner.run_takeover_check",
         "phase": 5,
-        "phase_group": "Surface Enumeration",
+        "phase_group": "Asset Discovery",
         "requires": ["subfinder"],
         "produces_findings": True,
         "active": True,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -183,7 +183,7 @@ full per-tool table is in [CLAUDE.md](../CLAUDE.md); by phase group:
 | Phase group | Phases | Tools |
 |---|---|---|
 | Domain Intelligence | 1 | domain_security, hudson_rock, dns_history, github_secrets, typosquat, breach_check |
-| Surface Enumeration | 2–4 | subfinder, amass, asn_discovery, alterx, dnsx, takeover_check, cloud_assets |
+| Asset Discovery | 2–4 | subfinder, amass, asn_discovery, alterx, dnsx, takeover_check, cloud_assets |
 | Port Discovery | 5–6 | naabu, shodan, service_detection |
 | Network Exposure | 7 | nmap, tls_checker, ssh_checker, nuclei_network |
 | Web Exposure | 8–11 | httpx, historical_urls, katana, nuclei, web_checker, js_secrets |
@@ -214,7 +214,7 @@ Deletion cascades top-down: deleting a Domain wipes all session data.
 ```
 Phase 1   Domain Intelligence  → Finding (DNS/DNSSEC/email-auth/RDAP, domain_probe, typosquat, dns_history)
 Phase 2   Credential Exposure            → Finding (breach_check, hudson_rock infostealer, github_secrets)
-Phase 3   Surface Enumeration  → Subdomain (subfinder/amass/alterx) + Finding (asn_discovery)
+Phase 3   Asset Discovery  → Subdomain (subfinder/amass/alterx) + Finding (asn_discovery)
 Phase 4   dnsx                 → IPAddress (public-IP filter)
 Phase 5   takeover / cloud     → Finding (dangling DNS, open buckets)
 Phase 6   naabu / shodan       → Port + Finding (passive exposure)


### PR DESCRIPTION
Renames the `phase_group` **"Surface Enumeration" → "Asset Discovery"**.

## Why
More accurate and standard. The phases-3–5 tools discover the org's external **assets** — subdomains, IP ranges, cloud storage:
```
Asset Discovery (phases 3–5):
  p3  subfinder, amass, alterx, asn_discovery
  p4  dnsx
  p5  takeover_check, cloud_assets
```
"Asset Discovery" is the standard ASM term, parallels the existing **Port Discovery** category, and ties to the `asset_inventory` app — clearer than the jargon-y "enumeration."

## Scope
Display-only `phase_group` rename across the 7 tool `apps.py` + docs (CLAUDE tool table, README diagram + re-padded header, DESIGN phase list). No execution/behavior change; check_types, runners, findings all unchanged. The historical migration 0010 comment is left as-is. No test hardcodes the category name.

## Tests
Ruff clean; `test_passive_scan` / `test_render_pipeline_diagram` / `test_default_workflow` green (44). Registry renders `Asset Discovery (phases 3–5)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv