### PR TITLE
fix: split exposure findings into new 'Asset Exposure' category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Changed
+- **Split the exposure findings out of Asset Discovery into a new "Asset
+  Exposure" category.** `takeover_check` (subdomain takeover) and `cloud_assets`
+  (open cloud buckets) are *findings about exposed assets*, not discovery — so
+  they now group under **Asset Exposure** (phase 5), leaving **Asset Discovery**
+  (phases 3–4) as pure discovery: `subfinder`, `amass`, `alterx`, `asn_discovery`,
+  `dnsx`. Execution order is unchanged (both still run at phase 5); display-only
+  `phase_group` change. Also refreshed the stale phase-group table in DESIGN.md.
 - **Renamed the "Surface Enumeration" tool category to "Asset Discovery."** More
   accurate and standard: the phases-3–5 tools (`subfinder`, `amass`, `alterx`,
   `asn_discovery`, `dnsx`, `takeover_check`, `cloud_assets`) discover the org's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,8 +493,8 @@ guards that every registered tool appears in the output.
 | `apps/asn_discovery/` | 3 | Asset Discovery | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
 | `apps/alterx/` | 3 | Asset Discovery | No | Subdomain permutation via alterx (generates candidates from discovered subdomains) |
 | `apps/dnsx/` | 4 | Asset Discovery | No | DNS resolution, public IP filtering |
-| `apps/takeover_check/` | 5 | Asset Discovery | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
-| `apps/cloud_assets/` | 5 | Asset Discovery | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
+| `apps/takeover_check/` | 5 | Asset Exposure | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
+| `apps/cloud_assets/` | 5 | Asset Exposure | Yes | Public cloud bucket enumeration via cloud_enum (AWS S3 / Azure Blob / GCP Storage) |
 | `apps/naabu/` | 6 | Port Discovery | No | Port scanning (top 100 TCP) |
 | `apps/shodan/` | 6 | Port Discovery | Yes | Passive exposure intel from Shodan's own scan data — ports/services/CVEs per resolved IP. BYOK: free InternetDB tier (no key, no credits), full host API when `SHODAN_API_KEY` set (`SHODAN_MAX_IPS` caps the paid path). CVEs land in `extra["cve_ids"]` so `cve_intel` enriches them. Passive, fail-graceful |
 | `apps/core/engine/service_detection/` | 7 | Port Discovery | No | nmap -sV enriches Port.service + is_web |

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ Phase 3  Amass             - Active subdomain enumeration
 Phase 3  Alterx            - Subdomain permutation from discovered subdomains
 Phase 3  ASN Discovery     - Owned ASN/CIDR ranges via amass intel (reports only)
 Phase 4  DNSx              - DNS resolution, public IP filtering
-Phase 5  Takeover Check    - Subdomain takeover detection via subzy
+
+── Asset Exposure ───────────────────────────────────────────────────────────
+Phase 5  Takeover Check    - Subdomain takeover detection via subzy (dangling DNS)
 Phase 5  Cloud Assets      - Public S3/Azure/GCP bucket enumeration (cloud_enum)
 
 ── Port Discovery ───────────────────────────────────────────────────────────

--- a/apps/cloud_assets/apps.py
+++ b/apps/cloud_assets/apps.py
@@ -10,7 +10,7 @@ class CloudAssetsConfig(AppConfig):
         "label": "Cloud Asset Enumeration (cloud-enum)",
         "runner": "apps.cloud_assets.scanner.run_cloud_assets",
         "phase": 5,
-        "phase_group": "Asset Discovery",
+        "phase_group": "Asset Exposure",
         "requires": ["subfinder"],
         "produces_findings": True,
         "active": False,

--- a/apps/takeover_check/apps.py
+++ b/apps/takeover_check/apps.py
@@ -9,7 +9,7 @@ class TakeoverCheckConfig(AppConfig):
         "label": "Subdomain Takeover Check (subzy)",
         "runner": "apps.takeover_check.scanner.run_takeover_check",
         "phase": 5,
-        "phase_group": "Asset Discovery",
+        "phase_group": "Asset Exposure",
         "requires": ["subfinder"],
         "produces_findings": True,
         "active": True,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -182,12 +182,14 @@ full per-tool table is in [CLAUDE.md](../CLAUDE.md); by phase group:
 
 | Phase group | Phases | Tools |
 |---|---|---|
-| Domain Intelligence | 1 | domain_security, hudson_rock, dns_history, github_secrets, typosquat, breach_check |
-| Asset Discovery | 2–4 | subfinder, amass, asn_discovery, alterx, dnsx, takeover_check, cloud_assets |
-| Port Discovery | 5–6 | naabu, shodan, service_detection |
-| Network Exposure | 7 | nmap, tls_checker, ssh_checker, nuclei_network |
-| Web Exposure | 8–11 | httpx, historical_urls, katana, nuclei, web_checker, js_secrets |
-| Prioritization | 12 | cve_intel (enriches CVEs with EPSS + CISA-KEV in place) |
+| Domain Intelligence | 1, 13 | domain_security, domain_probe, typosquat, dns_history, asn_cluster |
+| Credential Exposure | 2 | breach_check, hudson_rock, github_secrets |
+| Asset Discovery | 3–4 | subfinder, amass, alterx, asn_discovery, dnsx |
+| Asset Exposure | 5 | takeover_check, cloud_assets |
+| Port Discovery | 6–7 | naabu, shodan, service_detection |
+| Network Exposure | 8 | nmap, tls_checker, ssh_checker, nuclei_network |
+| Web Exposure | 9–12 | httpx, historical_urls, katana, nuclei, web_checker, js_secrets |
+| Prioritization | 13 | cve_intel (enriches CVEs with EPSS + CISA-KEV in place) |
 
 Binaries: ProjectDiscovery tools (`subfinder`/`dnsx`/`naabu`/`httpx`/`katana`/
 `nuclei`) + `amass`, `gitleaks`, `subzy`, `gau` are pinned static binaries;
@@ -216,7 +218,7 @@ Phase 1   Domain Intelligence  → Finding (DNS/DNSSEC/email-auth/RDAP, domain_p
 Phase 2   Credential Exposure            → Finding (breach_check, hudson_rock infostealer, github_secrets)
 Phase 3   Asset Discovery  → Subdomain (subfinder/amass/alterx) + Finding (asn_discovery)
 Phase 4   dnsx                 → IPAddress (public-IP filter)
-Phase 5   takeover / cloud     → Finding (dangling DNS, open buckets)
+Phase 5   Asset Exposure       → Finding (takeover_check dangling DNS, cloud_assets open buckets)
 Phase 6   naabu / shodan       → Port + Finding (passive exposure)
 Phase 7   service_detection    → enriches Port.service + Port.is_web
 Phase 8   Network Exposure     → Finding (nmap CVE / tls / ssh / nuclei_network — non-web; run in parallel)


### PR DESCRIPTION
Follows the "keep discovery pure, move the findings out" decision.

## What
`takeover_check` (subdomain takeover — dangling DNS) and `cloud_assets` (open cloud buckets) are **findings about exposed assets**, not discovery — so they move to a new **Asset Exposure** category (phase 5). **Asset Discovery** (phases 3–4) is now pure discovery:

```
Asset Discovery (phases 3–4):  subfinder, amass, alterx, asn_discovery, dnsx
Asset Exposure  (phase 5):     takeover_check, cloud_assets
```

Name: **Asset Exposure** pairs with *Asset Discovery* (discover assets → which are exposed) and the *Network/Web Exposure* family, without over-claiming "cloud" (takeover covers non-cloud services too).

## Scope
Display-only `phase_group` change — **execution order unchanged** (both still run at phase 5); check_types/runners/findings unchanged. Registry now has **8 phase groups**. Also refreshed the **stale phase-group table in DESIGN.md** to the current 8-category / 13-phase layout (it was pre-renumber).

## Tests
Ruff clean; `test_passive_scan` / `test_render_pipeline_diagram` / `test_reports` green (119). No test hardcodes the category name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv