### PR TITLE
fix: split Domain Intelligence into Domain Posture + Brand Threat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Changed
+- **Split "Domain Intelligence" into "Domain Posture" + "Brand Threat."** The old
+  category mixed two subjects: *your own domain's health* and *external
+  impersonation threats*. Now `domain_security`, `domain_probe`, `dns_history`
+  form **Domain Posture** (your DNS/email/RDAP health), and `typosquat` +
+  `asn_cluster` form **Brand Threat** (lookalike domains + coordinated
+  phishing-infra clusters). Split by subject (a tool-clean cut — no rewrites);
+  execution phases unchanged. 8 → 9 phase groups. Display-only `phase_group` change.
 - **Split the exposure findings out of Asset Discovery into a new "Asset
   Exposure" category.** `takeover_check` (subdomain takeover) and `cloud_assets`
   (open cloud buckets) are *findings about exposed assets*, not discovery — so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,12 +481,12 @@ guards that every registered tool appears in the output.
 
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
-| `apps/domain_security/` | 1 | Domain Intelligence | Yes | **Passive** DNS/DNSSEC/CAA/wildcard/lame-delegation, email-auth (SPF/DMARC/DKIM/TLS-RPT/BIMI) via public resolvers, and RDAP (expiry/locks/status). No packets to the target — needs no authorization |
-| `apps/domain_probe/` | 1 | Domain Intelligence | Yes | **Active** domain probes split out of domain_security: AXFR zone transfer (nameservers), SMTP open-relay (MX:25), and MTA-STS policy fetch (`mta-sts.<domain>`). Touches the target directly → requires `DomainAuthorization` |
+| `apps/domain_security/` | 1 | Domain Posture | Yes | **Passive** DNS/DNSSEC/CAA/wildcard/lame-delegation, email-auth (SPF/DMARC/DKIM/TLS-RPT/BIMI) via public resolvers, and RDAP (expiry/locks/status). No packets to the target — needs no authorization |
+| `apps/domain_probe/` | 1 | Domain Posture | Yes | **Active** domain probes split out of domain_security: AXFR zone transfer (nameservers), SMTP open-relay (MX:25), and MTA-STS policy fetch (`mta-sts.<domain>`). Touches the target directly → requires `DomainAuthorization` |
 | `apps/hudson_rock/` | 2 | Credential Exposure | Yes | Infostealer-log exposure via Hudson Rock's keyless Cavalier API (aggregate counts only, no plaintext); passive, fail-graceful |
-| `apps/dns_history/` | 1 | Domain Intelligence | Yes | Historical A/AAAA/MX records via a passive-DNS dataset — surfaces past hosting / stale records (info findings). Passive, BYO `DNS_HISTORY_API_URL` (no-op if unset), fail-graceful |
+| `apps/dns_history/` | 1 | Domain Posture | Yes | Historical A/AAAA/MX records via a passive-DNS dataset — surfaces past hosting / stale records (info findings). Passive, BYO `DNS_HISTORY_API_URL` (no-op if unset), fail-graceful |
 | `apps/github_secrets/` | 2 | Credential Exposure | Yes | Leaked secrets in PUBLIC GitHub — searches GitHub's code-search API (org-scoped by default) for the target org's committed credentials, fetches the hits, runs gitleaks over them (same engine as `js_secrets`), REDACTS before storage (`check_type="exposed_secret"`, shared with js_secrets). Passive (queries GitHub, not the target); BYOK MANDATORY (`GITHUB_TOKEN` — code-search needs auth; no token → logged no-op); fail-graceful |
-| `apps/typosquat/` | 1 | Domain Intelligence | Yes | Lookalike / typosquat domain detection — generates lookalike candidates algorithmically (homoglyph/typo/omission/insertion/repetition/transposition/hyphenation/TLD-swap), checks which are registered via public DNS, then scores **weaponization**: registered web-serving lookalikes get a capped, fail-graceful homepage fetch for a login form (credential phishing) or brand mention (impersonation) → **high** (active impersonation, prioritise takedown); A/MX-only → medium; NS-only → low. Passive w.r.t. the target (contacts only the lookalike domains, never yours), no key, fail-graceful. Weaponization model ported from the standalone `tldsquatting` project |
+| `apps/typosquat/` | 1 | Brand Threat | Yes | Lookalike / typosquat domain detection — generates lookalike candidates algorithmically (homoglyph/typo/omission/insertion/repetition/transposition/hyphenation/TLD-swap), checks which are registered via public DNS, then scores **weaponization**: registered web-serving lookalikes get a capped, fail-graceful homepage fetch for a login form (credential phishing) or brand mention (impersonation) → **high** (active impersonation, prioritise takedown); A/MX-only → medium; NS-only → low. Passive w.r.t. the target (contacts only the lookalike domains, never yours), no key, fail-graceful. Weaponization model ported from the standalone `tldsquatting` project |
 | `apps/breach_check/` | 2 | Credential Exposure | Yes | Data-breach exposure for the domain. BYOK: free keyless XposedOrNot catalog by default, authoritative Have I Been Pwned `breacheddomain` when `HIBP_API_KEY` set. Aggregate COUNTS + public breach metadata only — never email aliases/credentials. Passive, fail-graceful |
 | `apps/subfinder/` | 3 | Asset Discovery | No | Passive subdomain enumeration |
 | `apps/amass/` | 3 | Asset Discovery | No | Active subdomain enumeration |
@@ -509,7 +509,7 @@ guards that every registered tool appears in the output.
 | `apps/web_checker/` | 12 | Web Exposure | Yes | Security headers, cookies, CORS; + security.txt (RFC 9116) responsible-disclosure check on the apex |
 | `apps/js_secrets/` | 12 | Web Exposure | Yes | Hardcoded-secret detection — fetches discovered `.js` assets and runs gitleaks over them; secret is redacted before storage |
 | `apps/cve_intel/` | 13 | Prioritization | No | Enriches CVE findings in place with EPSS scores + CISA KEV flags (no new findings) |
-| `apps/asn_cluster/` | 13 | Domain Intelligence | Yes | Lookalike ASN clustering — reads typosquat's `lookalike_domain` findings, resolves their IPs to ASNs via Team Cymru (keyless DNS), and groups lookalikes sharing an autonomous system into `lookalike_cluster` campaign findings (weaponized member → high). Passive, fail-graceful, `requires: [typosquat]` |
+| `apps/asn_cluster/` | 13 | Brand Threat | Yes | Lookalike ASN clustering — reads typosquat's `lookalike_domain` findings, resolves their IPs to ASNs via Team Cymru (keyless DNS), and groups lookalikes sharing an autonomous system into `lookalike_cluster` campaign findings (weaponized member → high). Passive, fail-graceful, `requires: [typosquat]` |
 
 ### Tool app structure
 ```
@@ -559,7 +559,7 @@ Phase 12 nuclei             → Finding (web vulns via templates on URLs)
 Phase 12 web_checker        → Finding (headers, cookies, CORS on URLs; + security.txt RFC 9116 on apex)
 Phase 12 js_secrets         → Finding (gitleaks over fetched .js assets — secret redacted)
 Phase 13 cve_intel          → enriches CVE findings (EPSS + CISA KEV; no new findings)
-Phase 13 asn_cluster        → Finding (groups lookalikes by shared hosting ASN — passive)     [Domain Intelligence]
+Phase 13 asn_cluster        → Finding (groups lookalikes by shared hosting ASN — passive)     [Brand Threat]
 ```
 
 ### Passive vs active scan modes (the authorization boundary)

--- a/README.md
+++ b/README.md
@@ -185,16 +185,18 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 ## Scan Pipeline
 
 ```
-── Domain Intelligence ──────────────────────────────────────────────────────
+── Domain Posture ───────────────────────────────────────────────────────────
 Phase 1  Domain Security   - DNS, DNSSEC chain-of-trust, email auth
                              (SPF/DMARC/DKIM/TLS-RPT/BIMI), RDAP checks (passive;
                              public resolvers + rdap.org — no auth needed)
 Phase 1  Domain Probes      - Active target probes (needs authorization): AXFR
                              zone transfer, SMTP open-relay, MTA-STS policy fetch
-Phase 1  Typosquat          - Lookalike / typosquat domain detection (passive;
-                             registered lookalikes via public DNS — phishing/brand abuse)
 Phase 1  DNS History        - Historical A/AAAA/MX records via a passive-DNS
                              dataset (passive; BYO DNS_HISTORY_API_URL)
+
+── Brand Threat ─────────────────────────────────────────────────────────────
+Phase 1  Typosquat          - Lookalike / typosquat domain detection (passive;
+                             registered lookalikes via public DNS — phishing/brand abuse)
 Phase 13 ASN Clustering     - Groups registered lookalikes by shared hosting ASN
                              (Team Cymru, passive) — coordinated phishing infra
 

--- a/apps/asn_cluster/apps.py
+++ b/apps/asn_cluster/apps.py
@@ -12,7 +12,7 @@ class AsnClusterConfig(AppConfig):
         # Late phase: it correlates typosquat's already-written lookalike findings,
         # so it must run after phase 1. Sits with cve_intel in Prioritization order.
         "phase": 13,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Brand Threat",
         "requires": ["typosquat"],
         "produces_findings": True,
         # PASSIVE: IP→ASN via Team Cymru's keyless DNS service (a third party) —

--- a/apps/dns_history/apps.py
+++ b/apps/dns_history/apps.py
@@ -10,7 +10,7 @@ class DnsHistoryConfig(AppConfig):
         "label": "Historical DNS Records",
         "runner": "apps.dns_history.scanner.run_dns_history",
         "phase": 1,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Domain Posture",
         "requires": [],
         "produces_findings": True,
         # Passive: queries a third-party passive-DNS dataset, never the target's

--- a/apps/domain_probe/apps.py
+++ b/apps/domain_probe/apps.py
@@ -10,7 +10,7 @@ class DomainProbeConfig(AppConfig):
         "label": "Domain Probes",
         "runner": "apps.domain_probe.scanner.run_domain_probe",
         "phase": 1,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Domain Posture",
         "requires": [],
         "produces_findings": True,
         # ACTIVE: these checks touch the target directly — AXFR zone transfers

--- a/apps/domain_security/apps.py
+++ b/apps/domain_security/apps.py
@@ -10,7 +10,7 @@ class DomainSecurityConfig(AppConfig):
         "label": "Domain Security",
         "runner": "apps.domain_security.scanner.run_domain_security",
         "phase": 1,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Domain Posture",
         "requires": [],
         "produces_findings": True,
         # PASSIVE: DNS/DNSSEC/CAA/email-auth via public resolvers + RDAP via

--- a/apps/typosquat/apps.py
+++ b/apps/typosquat/apps.py
@@ -10,7 +10,7 @@ class TyposquatConfig(AppConfig):
         "label": "Lookalike / Typosquat Domains",
         "runner": "apps.typosquat.scanner.run_typosquat",
         "phase": 1,
-        "phase_group": "Domain Intelligence",
+        "phase_group": "Brand Threat",
         "requires": [],
         "produces_findings": True,
         # Passive: generates lookalike candidates algorithmically from the apex

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -182,7 +182,8 @@ full per-tool table is in [CLAUDE.md](../CLAUDE.md); by phase group:
 
 | Phase group | Phases | Tools |
 |---|---|---|
-| Domain Intelligence | 1, 13 | domain_security, domain_probe, typosquat, dns_history, asn_cluster |
+| Domain Posture | 1 | domain_security, domain_probe, dns_history |
+| Brand Threat | 1, 13 | typosquat, asn_cluster |
 | Credential Exposure | 2 | breach_check, hudson_rock, github_secrets |
 | Asset Discovery | 3–4 | subfinder, amass, alterx, asn_discovery, dnsx |
 | Asset Exposure | 5 | takeover_check, cloud_assets |
@@ -214,7 +215,7 @@ Deletion cascades top-down: deleting a Domain wipes all session data.
 ### Pipeline phases
 
 ```
-Phase 1   Domain Intelligence  → Finding (DNS/DNSSEC/email-auth/RDAP, domain_probe, typosquat, dns_history)
+Phase 1   Domain Posture + Brand Threat → Finding (DNS/DNSSEC/email-auth/RDAP, domain_probe, dns_history; typosquat lookalikes)
 Phase 2   Credential Exposure            → Finding (breach_check, hudson_rock infostealer, github_secrets)
 Phase 3   Asset Discovery  → Subdomain (subfinder/amass/alterx) + Finding (asn_discovery)
 Phase 4   dnsx                 → IPAddress (public-IP filter)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -722,7 +722,7 @@ class TestWorkflowTools:
         tools = auth_client.get("/api/workflows/tools/").json()["tools"]
         assert tools
         assert all("phase_group" in t for t in tools)
-        assert any(t["phase_group"] == "Domain Intelligence" for t in tools)
+        assert any(t["phase_group"] == "Domain Posture" for t in tools)
 
     def test_requires_auth(self, client):
         assert client.get("/api/workflows/tools/").status_code == 401

--- a/tests/unit/test_asn_cluster.py
+++ b/tests/unit/test_asn_cluster.py
@@ -35,7 +35,7 @@ class TestMeta:
 
     def test_phase_group(self):
         from apps.core.engine.workflows.registry import get_tool_phase_groups
-        assert get_tool_phase_groups().get("asn_cluster") == "Domain Intelligence"
+        assert get_tool_phase_groups().get("asn_cluster") == "Brand Threat"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_domain_probe.py
+++ b/tests/unit/test_domain_probe.py
@@ -24,7 +24,7 @@ class TestDomainProbeMeta:
 
     def test_phase_group(self):
         from apps.core.engine.workflows.registry import get_tool_phase_groups
-        assert get_tool_phase_groups().get("domain_probe") == "Domain Intelligence"
+        assert get_tool_phase_groups().get("domain_probe") == "Domain Posture"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_passive_scan.py
+++ b/tests/unit/test_passive_scan.py
@@ -73,7 +73,7 @@ class TestRegistryActiveFlag:
 
 class TestPhaseGroupCategories:
     # The leak-detection tools live in their own "Credential Exposure" category
-    # rather than being mixed into Domain Intelligence / Web Exposure.
+    # rather than being mixed into Domain Posture / Web Exposure.
     _CRED_EXPOSURE = {"hudson_rock", "breach_check", "github_secrets"}
 
     def test_credential_exposure_tools_grouped_together(self):
@@ -84,11 +84,11 @@ class TestPhaseGroupCategories:
                 f"{tool} should be in the Credential Exposure phase_group, got {groups.get(tool)!r}"
             )
 
-    def test_domain_intelligence_excludes_leak_tools(self):
-        # Domain Intelligence keeps domain-posture tools only; leak tools moved out.
+    def test_domain_posture_excludes_leak_tools(self):
+        # Domain Posture keeps domain-posture tools only; leak tools moved out.
         from apps.core.engine.workflows.registry import get_tool_phase_groups
         groups = get_tool_phase_groups()
-        di = {t for t, g in groups.items() if g == "Domain Intelligence"}
+        di = {t for t, g in groups.items() if g == "Domain Posture"}
         assert di.isdisjoint(self._CRED_EXPOSURE)
         assert "domain_security" in di
 


### PR DESCRIPTION
The last taxonomy split: "Domain Intelligence" mixed two subjects — *your own domain's health* and *external impersonation threats*. Split by **subject** (a tool-clean cut — no rewrites, unlike a discovery/exposure split would need):

```
Domain Posture (phase 1):     domain_security, domain_probe, dns_history
                              → your DNS / email-auth / RDAP health
Brand Threat (phases 1, 13):  typosquat, asn_cluster
                              → lookalike domains + coordinated phishing-infra clusters
```

## Why this axis (not discovery/exposure)
Domain Intelligence couldn't be split on discovery/exposure — those are *fused inside* its tools (`domain_security` looks up records *and* judges posture in one pass). But **subject** is a clean fault line: `typosquat`/`asn_cluster` only ever touch external lookalikes, so they regroup with zero tool changes.

## Scope
Display-only `phase_group` change — execution phases unchanged; check_types/runners/findings unchanged. Registry **8 → 9 phase groups**. Docs (CLAUDE table + diagram, README diagram, DESIGN table + list) + 4 test assertions updated; historical migration 0010 left as-is.

## Tests
Ruff clean; `test_passive_scan` / `test_render_pipeline_diagram` / `test_domain_probe` / `test_asn_cluster` / `test_api_endpoints` green (185).

## The category set is now 9
Domain Posture · Brand Threat · Credential Exposure · Asset Discovery · Asset Exposure · Port Discovery · Network Exposure · Web Exposure · Prioritization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv