### PR TITLE
chore: release v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.15.0] — 2026-09-11
+
 ### Changed
 - **Split "Domain Intelligence" into "Domain Posture" + "Brand Threat."** The old
   category mixed two subjects: *your own domain's health* and *external
@@ -1549,7 +1551,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.14.2...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.15.0...HEAD
+[v2.15.0]: https://github.com/cybersecify/OpenEASD/compare/v2.14.2...v2.15.0
 [v2.14.2]: https://github.com/cybersecify/OpenEASD/compare/v2.14.1...v2.14.2
 [v2.14.1]: https://github.com/cybersecify/OpenEASD/compare/v2.14.0...v2.14.1
 [v2.14.0]: https://github.com/cybersecify/OpenEASD/compare/v2.13.0...v2.14.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.14.2 — 2026-09-11)
+## Status (v2.15.0 — 2026-09-11)
 
-- **Released**: v2.14.2 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.14.2` / `:v2.14` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.15.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.15.0` / `:v2.15` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 29 registered scan tools across 13 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -6,9 +6,9 @@ images:
   # switch to the floating :v2.1 major.minor tag + imagePullPolicy: Always to
   # auto-pick-up patch releases).
   - name: ghcr.io/cybersecify/openeasd-web
-    newTag: v2.14.2
+    newTag: v2.15.0
   - name: ghcr.io/cybersecify/openeasd-worker
-    newTag: v2.14.2
+    newTag: v2.15.0
 resources:
   - configmap.yaml
   - postgres.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.14.2"
+version = "2.15.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.14.2"
+version = "2.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Release **v2.15.0** (minor — a tool removed + pipeline-category restructure). Finalizes CHANGELOG (`Unreleased` → `v2.15.0` + compare link), bumps `pyproject`/`uv.lock`, refreshes the CLAUDE.md status header, and bumps k8s `kustomization.yaml` `newTag` → `v2.15.0`.

## Contents since v2.14.2
- **Removed** the `github_recon` tool (app + tests + workflow steps; migration 0033). Registry 30 → 29.
- **Category taxonomy cleanup** (display-only `phase_group` changes):
  - Surface Enumeration → **Asset Discovery**
  - New **Asset Exposure** category (takeover_check, cloud_assets) split out of discovery
  - Domain Intelligence → **Domain Posture** + **Brand Threat**
  - `js_secrets` → **Web Exposure**
- Result: **9 phase groups, 29 tools, 13 phases.**

Merging this, then tagging `v2.15.0` for the GHCR publish (`:v2.15.0` / `:v2.15` / `:latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRGejrw65nttnhupK7A7wv