### PR TITLE
fix: make scan finalize replay-idempotent (F1)

### DIFF
--- a/apps/core/engine/scans/pipeline.py
+++ b/apps/core/engine/scans/pipeline.py
@@ -34,6 +34,13 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 def _detect_deltas(session):
+    # Idempotency (F1): finalize is a replayable DBOS step — a worker crash after
+    # this ran but before the step checkpointed re-runs the whole finalize. Clear
+    # any ScanDelta rows from a prior pass before recreating (delete-then-insert),
+    # or a replay double-counts deltas, which build_insights reads as inflated
+    # new/removed-exposure counts.
+    ScanDelta.objects.filter(session=session).delete()
+
     # Exclude subscans: they only run a subset of tools, so using one as the
     # baseline would produce spurious "new finding" deltas on the next full scan.
     # Filter on scan_type (immutable) rather than parent_session, which is
@@ -53,14 +60,19 @@ def _detect_deltas(session):
 
     from apps.core.data.findings.models import Finding
 
-    current_keys = {
-        f"{f.source}:{f.check_type}:{f.title}"
-        for f in Finding.objects.filter(session=session)
-    }
-    prev_keys = {
-        f"{f.source}:{f.check_type}:{f.title}"
-        for f in Finding.objects.filter(session=previous)
-    }
+    # Exclude the scan_coverage meta-warning from delta keys: it's a
+    # finalize-generated marker, not a real attack-surface finding. Including it
+    # would make it a spurious "new" delta on replay (it is created *after* this
+    # runs, so a re-run would see last pass's copy) and a spurious "removed"
+    # delta on the next scan that doesn't regress.
+    def _finding_keys(s):
+        return {
+            f"{f.source}:{f.check_type}:{f.title}"
+            for f in Finding.objects.filter(session=s).exclude(source="scan_coverage")
+        }
+
+    current_keys = _finding_keys(session)
+    prev_keys = _finding_keys(previous)
     deltas = []
     for key in current_keys - prev_keys:
         deltas.append(ScanDelta(session=session, previous_session=previous,
@@ -85,6 +97,13 @@ def _check_coverage_regression(session):
     """
     from apps.core.data.web_assets.models import URL
     from apps.core.data.findings.models import Finding
+
+    # Idempotency (F1): reached via the replayable finalize step. Remove any
+    # coverage_regression finding from a prior pass so a replay recreates it
+    # exactly once instead of stacking duplicates (delete-then-insert).
+    Finding.objects.filter(
+        session=session, source="scan_coverage", check_type="coverage_regression"
+    ).delete()
 
     def _httpx_urls(s):
         return URL.objects.filter(session=s, source="httpx").count()
@@ -155,7 +174,15 @@ def _check_coverage_regression(session):
 def _count_all_findings(session) -> int:
     try:
         from apps.core.data.findings.models import Finding
-        return Finding.objects.filter(session=session).count()
+        # Exclude the scan_coverage meta-warning — it's a finalize-generated
+        # marker, not a real attack-surface finding. Excluding it keeps the count
+        # stable across a finalize replay (F1): on the first pass the warning
+        # doesn't exist yet, so a replay would otherwise count N+1.
+        return (
+            Finding.objects.filter(session=session)
+            .exclude(source="scan_coverage")
+            .count()
+        )
     except Exception:
         return 0
 

--- a/tests/unit/test_coverage_regression.py
+++ b/tests/unit/test_coverage_regression.py
@@ -173,6 +173,78 @@ class TestCoverageRegressionReport:
 
 
 @pytest.mark.django_db
+class TestFinalizeReplayIdempotency:
+    """F1: finalize is a replayable DBOS step. Running it twice (a worker crash
+    after side effects but before the step checkpoints, then resume) must NOT
+    duplicate the rows it produces — ScanDelta rows and the coverage_regression
+    meta-finding — nor drift total_findings."""
+
+    def _setup(self):
+        from django.utils import timezone
+        from apps.core.engine.scans.models import ScanSession
+        from apps.core.data.findings.models import Finding
+        from apps.core.engine.workflows.models import Workflow, WorkflowRun
+
+        # Baseline (completed) with a finding unique to it → a genuine "removed"
+        # delta; the current scan gets a different finding → a genuine "new" delta.
+        base = ScanSession.objects.create(
+            domain="example.com", scan_type="full", status="completed",
+            end_time=timezone.now(),
+        )
+        Finding.objects.create(
+            session=base, source="web_checker", target="example.com",
+            check_type="missing_header", severity="medium",
+            title="Baseline only finding", description="d", remediation="f",
+        )
+        # High block ratio → coverage_regression fires.
+        cur = _session(status="running", endpoints_probed=10, endpoints_blocked=10)
+        Finding.objects.create(
+            session=cur, source="web_checker", target="example.com",
+            check_type="missing_header", severity="medium",
+            title="Current only finding", description="d", remediation="f",
+        )
+        wf = Workflow.objects.create(name="wf")
+        WorkflowRun.objects.create(workflow=wf, session=cur, status="completed")
+        return cur
+
+    def test_second_finalize_does_not_duplicate_rows(self):
+        from apps.core.engine.scans.models import ScanDelta
+        from apps.core.data.findings.models import Finding
+
+        cur = self._setup()
+
+        _finalize_session(cur)
+        cur.refresh_from_db()
+        deltas_1 = ScanDelta.objects.filter(session=cur).count()
+        new_1 = ScanDelta.objects.filter(session=cur, change_type="new").count()
+        total_1 = cur.total_findings
+        reg_1 = Finding.objects.filter(
+            session=cur, check_type="coverage_regression"
+        ).count()
+
+        assert deltas_1 >= 2            # at least one "new" + one "removed"
+        assert new_1 >= 1
+        assert reg_1 == 1
+
+        # Replay the exact same finalize step.
+        _finalize_session(cur)
+        cur.refresh_from_db()
+
+        # Nothing duplicated, nothing drifted.
+        assert ScanDelta.objects.filter(session=cur).count() == deltas_1
+        assert ScanDelta.objects.filter(session=cur, change_type="new").count() == new_1
+        assert cur.total_findings == total_1
+        assert Finding.objects.filter(
+            session=cur, check_type="coverage_regression"
+        ).count() == 1
+
+        # The meta-warning never becomes a delta on replay either.
+        assert not ScanDelta.objects.filter(
+            session=cur, item_identifier__startswith="scan_coverage:"
+        ).exists()
+
+
+@pytest.mark.django_db
 class TestPartialStatus:
     def _run(self, session, status):
         from apps.core.engine.workflows.models import Workflow, WorkflowRun


### PR DESCRIPTION
## What

Fixes **F1** from `docs/CODING_STANDARDS.md`: `finalize_session_by_id` is a replayable DBOS step, but only `_dispatch_alerts` had a replay guard. A worker crash *after* finalize ran but *before* the step checkpointed re-runs the whole finalize and duplicates the rows it produces.

### The duplication
- `_detect_deltas` re-ran `bulk_create` → **duplicate `ScanDelta` rows** (and `build_insights` reads these as inflated new/removed-exposure counts).
- `_check_coverage_regression` re-ran `Finding.create` → **duplicate `coverage_regression` meta-findings**.

### The fix — delete-then-insert (CLAUDE.md H5), mirroring the existing alert guard
- `_detect_deltas` deletes prior `ScanDelta` rows for the session before recreating, and now **excludes the `scan_coverage` meta-warning from delta keys**. That warning is created *after* deltas run, so a replay would otherwise see the prior pass's copy as a spurious `new` delta — and this also fixes a **latent** spurious `removed` delta on the next non-regressing scan.
- `_check_coverage_regression` deletes any prior `coverage_regression` finding before recreating.
- `_count_all_findings` excludes `scan_coverage` so `total_findings` is stable across a replay (first pass has no warning yet; a replay would otherwise count N+1).

`build_insights` (`update_or_create` + prune) and `rollup_session` (`get_or_create` on a unique key) were verified already replay-safe — untouched.

## Test

New `TestFinalizeReplayIdempotency` (`tests/unit/test_coverage_regression.py`): a second `_finalize_session` call duplicates nothing — `ScanDelta` count stable, exactly one `coverage_regression` finding, `total_findings` unchanged, meta-warning never becomes a delta.

## Verification
- `test_coverage_regression` + `test_coverage` + `test_insights_builder`: 25 passed
- scan-flow / scans / subscan / reports / exposure-score / notifications / workflow-runner: 253 passed
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)