### PR TITLE
fix: make notification webhook config write-only (F7)

### DIFF
--- a/apps/core/console/notifications/api.py
+++ b/apps/core/console/notifications/api.py
@@ -16,9 +16,13 @@ router = Router(auth=JWTAuth())
 # ---------------------------------------------------------------------------
 
 class NotificationConfigIn(Schema):
-    slack_webhook_url:  str = ""
-    teams_webhook_url:  str = ""
-    severity_threshold: str = "high"
+    # Write-only, like the credentials/AI config endpoints: None = leave unchanged,
+    # "" = clear (→ env-var fallback), "value" = set. Defaulting to None (not "")
+    # is what lets the UI save the threshold alone without wiping a stored webhook
+    # it can no longer read back.
+    slack_webhook_url:  str | None = None
+    teams_webhook_url:  str | None = None
+    severity_threshold: str | None = None
 
 
 class TestIn(Schema):
@@ -29,13 +33,29 @@ class TestIn(Schema):
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _webhook_source(db_value: str, env_setting: str) -> str:
+    """Where a webhook resolves from: 'db' | 'env' | 'none' (mirrors the
+    credentials resolver's DB-wins-over-env contract)."""
+    from django.conf import settings
+    if db_value:
+        return "db"
+    if getattr(settings, env_setting, ""):
+        return "env"
+    return "none"
+
+
 def _serialize_config(cfg) -> dict:
+    # Webhook URLs are SECRETS — anyone holding one can post into the channel — so
+    # they are write-only: never returned. Surface only presence + resolution
+    # source, exactly like /api/credentials/ and /api/ai/config/. `*_configured`
+    # reflects effective availability (DB or env fallback).
+    slack_src = _webhook_source(cfg.slack_webhook_url, "SLACK_WEBHOOK_URL")
+    teams_src = _webhook_source(cfg.teams_webhook_url, "MS_TEAMS_WEBHOOK_URL")
     return {
-        "slack_configured":    bool(cfg.slack_webhook_url),
-        "teams_configured":    bool(cfg.teams_webhook_url),
-        # Return URLs so the form can show current values (user set them intentionally)
-        "slack_webhook_url":   cfg.slack_webhook_url,
-        "teams_webhook_url":   cfg.teams_webhook_url,
+        "slack_configured":    slack_src != "none",
+        "teams_configured":    teams_src != "none",
+        "slack_source":        slack_src,
+        "teams_source":        teams_src,
         "severity_threshold":  cfg.severity_threshold,
     }
 
@@ -57,15 +77,26 @@ def get_config(request):
 def save_config(request, data: NotificationConfigIn):
     from apps.core.console.notifications.models import NotificationConfig
 
-    if data.severity_threshold not in VALID_THRESHOLDS:
+    # Validate before mutating so a bad threshold can't partially apply.
+    if data.severity_threshold is not None and data.severity_threshold not in VALID_THRESHOLDS:
         raise HttpError(400, f"severity_threshold must be one of {sorted(VALID_THRESHOLDS)}")
 
     cfg = NotificationConfig.get()
-    cfg.slack_webhook_url  = data.slack_webhook_url.strip()
-    cfg.teams_webhook_url  = data.teams_webhook_url.strip()
-    cfg.severity_threshold = data.severity_threshold
-    cfg.save()
-    logger.info("[notifications] Config updated")
+    changed = []
+    # None = unchanged; "" = clear; "value" = set. Only touch fields the caller sent,
+    # so saving the threshold alone preserves webhooks the UI can no longer read back.
+    if data.severity_threshold is not None:
+        cfg.severity_threshold = data.severity_threshold
+        changed.append("severity_threshold")
+    if data.slack_webhook_url is not None:
+        cfg.slack_webhook_url = data.slack_webhook_url.strip()
+        changed.append("slack_webhook_url")
+    if data.teams_webhook_url is not None:
+        cfg.teams_webhook_url = data.teams_webhook_url.strip()
+        changed.append("teams_webhook_url")
+    if changed:
+        cfg.save(update_fields=changed)
+        logger.info("[notifications] Config updated (%s)", ", ".join(changed))
     return _serialize_config(cfg)
 
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -352,23 +352,26 @@ milestones with semver. Run `just ci` before every PR.
 
 Grounded in a full-tree review (2026-09-11). Ordered by priority. These are the
 deltas between this document and the current code — fix-forward candidates, not
-blockers.
+blockers. Fixed items are struck through with the PR that closed them.
 
 ### High — correctness / security
 
-- **F1 — finalize is not replay-idempotent except for alerts.**
-  `finalize_session_by_id` is a replayable DBOS step, but only `_dispatch_alerts`
-  has a replay guard. On replay, `_detect_deltas`, `_check_coverage_regression`,
-  `build_insights`, and the asset rollup re-run and can duplicate rows.
-  (`apps/core/engine/scans/pipeline.py:238-261`)
+- **F1 — ~~finalize is not replay-idempotent except for alerts~~ — FIXED (#444).**
+  `_detect_deltas` and `_check_coverage_regression` now delete-then-insert, and
+  `_count_all_findings` excludes the `scan_coverage` meta-warning, so a finalize
+  replay duplicates nothing and `total_findings` stays stable. `build_insights`
+  (`update_or_create` + prune) and the asset rollup (`get_or_create`) were
+  verified already replay-safe.
 - **F1b — within-group tool execution is not idempotent.** `base_order` derives
   from `WorkflowStepResult.count()+1`; a crash mid-group re-runs the whole group
   and re-creates StepResults + re-executes already-run tools. Checkpointing is
   only at the group boundary. (`pipeline.py:594-607`)
-- **F7 — notification config GET returns raw webhook URLs.**
-  `_serialize_config` returns `slack_webhook_url`/`teams_webhook_url` in plaintext,
-  violating the write-only/presence-boolean discipline used everywhere else.
-  (`apps/core/console/notifications/api.py:36-38`)
+- **F7 — ~~notification config GET returns raw webhook URLs~~ — FIXED (#445).**
+  `_serialize_config` now returns presence booleans + a `db|env|none` source per
+  channel and never the URL; `save_config` adopts the None=unchanged /
+  ""=clear / value=set write semantics so the threshold can be saved without
+  wiping a stored webhook the UI can no longer read back. Matches
+  `/api/credentials/` and `/api/ai/config/`.
 - **F-sec1 — weak default DB credentials ship silently.** `DB_PASSWORD` defaults
   to `"openeasd"` with no fail-fast guard (unlike `SECRET_KEY`).
   (`openeasd/settings/base.py:210`)

--- a/frontend/src/pages/NotificationsPage.jsx
+++ b/frontend/src/pages/NotificationsPage.jsx
@@ -18,23 +18,66 @@ const THRESHOLD_OPTIONS = [
   { label: 'Low and above',    value: 'low' },
 ];
 
+function sourceBadge(source) {
+  // source: 'db' | 'env' | 'none'. Values are never returned by the API — this
+  // only reflects whether a webhook is set and where it resolves from.
+  if (source === 'db')  return <Badge value="active"   label="Set (UI)" />;
+  if (source === 'env') return <Badge value="info"     label="From env var" />;
+  return <Badge value="inactive" label="Not set" />;
+}
+
+function WebhookField({ label, placeholder, help, source, value, onChange, onTest, testing, onClear, busy }) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <label className="text-xs font-semibold text-dim uppercase tracking-wider">{label}</label>
+        {sourceBadge(source)}
+      </div>
+      <div className="flex gap-2">
+        <input
+          type="url"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          placeholder={source === 'none' ? placeholder : 'Set — enter a new URL to replace'}
+          className="field flex-1"
+          autoComplete="off"
+        />
+        <Button type="button" variant="outline" size="sm" onClick={onTest}
+          disabled={(source === 'none' && !value.trim()) || testing}>
+          {testing ? 'Sending…' : 'Test'}
+        </Button>
+        <Button type="button" variant="outline" size="sm" onClick={onClear}
+          disabled={busy || source !== 'db'}>
+          Clear
+        </Button>
+      </div>
+      <p className="text-xs text-dim">{help}</p>
+    </div>
+  );
+}
+
 function SettingsCard({ config, onSaved }) {
-  const [slack, setSlack]       = useState(config?.slack_webhook_url  ?? '');
-  const [teams, setTeams]       = useState(config?.teams_webhook_url  ?? '');
+  const [slack, setSlack]       = useState('');
+  const [teams, setTeams]       = useState('');
   const [threshold, setThreshold] = useState(config?.severity_threshold ?? 'high');
   const [saving, setSaving]     = useState(false);
   const [testing, setTesting]   = useState(null); // 'slack' | 'teams' | null
+  const slackSource = config?.slack_source ?? 'none';
+  const teamsSource = config?.teams_source ?? 'none';
 
   async function handleSave(e) {
     e.preventDefault();
     setSaving(true);
     try {
-      await apiPost('/notifications/config/', {
-        slack_webhook_url:  slack.trim(),
-        teams_webhook_url:  teams.trim(),
-        severity_threshold: threshold,
-      });
+      // Always send the threshold; send a webhook only when the user typed a new
+      // one (omitted = unchanged server-side), so saving the threshold never
+      // clobbers a stored URL we can't read back.
+      const payload = { severity_threshold: threshold };
+      if (slack.trim()) payload.slack_webhook_url = slack.trim();
+      if (teams.trim()) payload.teams_webhook_url = teams.trim();
+      await apiPost('/notifications/config/', payload);
       toast.success('Notification settings saved.');
+      setSlack(''); setTeams('');
       onSaved();
     } catch (err) {
       toast.error(err.message || 'Failed to save settings.');
@@ -43,9 +86,25 @@ function SettingsCard({ config, onSaved }) {
     }
   }
 
+  async function handleClear(channel) {
+    setSaving(true);
+    try {
+      await apiPost('/notifications/config/', { [`${channel}_webhook_url`]: '' });
+      toast.success(`${channel === 'slack' ? 'Slack' : 'Teams'} webhook cleared.`);
+      channel === 'slack' ? setSlack('') : setTeams('');
+      onSaved();
+    } catch (err) {
+      toast.error(err.message || `Failed to clear ${channel} webhook.`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
   async function handleTest(channel) {
     setTesting(channel);
     try {
+      // The test endpoint uses the STORED webhook, so a configured channel can be
+      // tested without re-entering the URL.
       await apiPost('/notifications/test/', { channel });
       toast.success(`Test ${channel === 'slack' ? 'Slack' : 'Teams'} message sent — check your channel.`);
     } catch (err) {
@@ -62,53 +121,30 @@ function SettingsCard({ config, onSaved }) {
       </CardHeader>
       <CardContent className="px-5 py-5">
         <form onSubmit={handleSave} className="space-y-5">
-          {/* Slack */}
-          <div className="space-y-1.5">
-            <label className="text-xs font-semibold text-dim uppercase tracking-wider">Slack Incoming Webhook URL</label>
-            <div className="flex gap-2">
-              <input
-                type="url"
-                value={slack}
-                onChange={e => setSlack(e.target.value)}
-                placeholder="https://hooks.slack.com/services/…"
-                className="field flex-1"
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => handleTest('slack')}
-                disabled={!slack.trim() || testing === 'slack'}
-              >
-                {testing === 'slack' ? 'Sending…' : 'Test'}
-              </Button>
-            </div>
-            <p className="text-xs text-dim">Create at <span className="font-mono">api.slack.com/apps</span> → Incoming Webhooks</p>
-          </div>
-
-          {/* Teams */}
-          <div className="space-y-1.5">
-            <label className="text-xs font-semibold text-dim uppercase tracking-wider">Microsoft Teams Webhook URL</label>
-            <div className="flex gap-2">
-              <input
-                type="url"
-                value={teams}
-                onChange={e => setTeams(e.target.value)}
-                placeholder="https://outlook.office.com/webhook/…"
-                className="field flex-1"
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => handleTest('teams')}
-                disabled={!teams.trim() || testing === 'teams'}
-              >
-                {testing === 'teams' ? 'Sending…' : 'Test'}
-              </Button>
-            </div>
-            <p className="text-xs text-dim">Create via Power Automate → Post to a channel when a webhook request is received</p>
-          </div>
+          <WebhookField
+            label="Slack Incoming Webhook URL"
+            placeholder="https://hooks.slack.com/services/…"
+            help="Create at api.slack.com/apps → Incoming Webhooks. The stored URL is never displayed."
+            source={slackSource}
+            value={slack}
+            onChange={setSlack}
+            onTest={() => handleTest('slack')}
+            testing={testing === 'slack'}
+            onClear={() => handleClear('slack')}
+            busy={saving}
+          />
+          <WebhookField
+            label="Microsoft Teams Webhook URL"
+            placeholder="https://outlook.office.com/webhook/…"
+            help="Create via Power Automate → Post to a channel when a webhook request is received. The stored URL is never displayed."
+            source={teamsSource}
+            value={teams}
+            onChange={setTeams}
+            onTest={() => handleTest('teams')}
+            testing={testing === 'teams'}
+            onClear={() => handleClear('teams')}
+            busy={saving}
+          />
 
           {/* Threshold */}
           <div className="space-y-1.5">

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -170,6 +170,72 @@ class TestNotificationsConfigAPI:
         resp = client.post("/api/notifications/config/", data={}, content_type="application/json")
         assert resp.status_code == 401
 
+    def test_get_config_never_returns_webhook_urls(self, client, db):
+        """F7: webhook URLs are secrets — GET must surface presence + source only,
+        never the stored URL (anyone holding the URL can post into the channel)."""
+        from apps.core.console.notifications.models import NotificationConfig
+        cfg = NotificationConfig.get()
+        cfg.slack_webhook_url = "https://hooks.slack.com/services/SECRET"
+        cfg.teams_webhook_url = "https://outlook.office.com/webhook/SECRET"
+        cfg.save()
+
+        headers = self._auth_headers(client)
+        resp = client.get("/api/notifications/config/", **headers)
+        data = resp.json()
+
+        assert "slack_webhook_url" not in data
+        assert "teams_webhook_url" not in data
+        assert "SECRET" not in resp.content.decode()
+        assert data["slack_configured"] is True
+        assert data["teams_configured"] is True
+        assert data["slack_source"] == "db"
+        assert data["teams_source"] == "db"
+
+    def test_source_is_env_when_only_env_set(self, client, db, settings):
+        settings.SLACK_WEBHOOK_URL = "https://hooks.slack.com/services/FROM-ENV"
+        headers = self._auth_headers(client)
+        data = client.get("/api/notifications/config/", **headers).json()
+        assert data["slack_configured"] is True
+        assert data["slack_source"] == "env"
+        assert "FROM-ENV" not in client.get("/api/notifications/config/", **headers).content.decode()
+
+    def test_threshold_only_save_preserves_webhooks(self, client, db):
+        """None = unchanged: saving the threshold alone must NOT wipe a stored
+        webhook the UI can no longer read back (the core reason for None-semantics)."""
+        from apps.core.console.notifications.models import NotificationConfig
+        cfg = NotificationConfig.get()
+        cfg.slack_webhook_url = "https://hooks.slack.com/services/KEEP"
+        cfg.save()
+
+        headers = self._auth_headers(client)
+        resp = client.post(
+            "/api/notifications/config/",
+            data={"severity_threshold": "low"},
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 200
+        cfg = NotificationConfig.get()
+        assert cfg.slack_webhook_url == "https://hooks.slack.com/services/KEEP"
+        assert cfg.severity_threshold == "low"
+
+    def test_empty_string_clears_webhook(self, client, db):
+        from apps.core.console.notifications.models import NotificationConfig
+        cfg = NotificationConfig.get()
+        cfg.slack_webhook_url = "https://hooks.slack.com/services/BYE"
+        cfg.save()
+
+        headers = self._auth_headers(client)
+        resp = client.post(
+            "/api/notifications/config/",
+            data={"slack_webhook_url": ""},
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 200
+        assert NotificationConfig.get().slack_webhook_url == ""
+        assert resp.json()["slack_source"] == "none"
+
 
 # ---------------------------------------------------------------------------
 # Notifications API — test endpoint


### PR DESCRIPTION
## What

Fixes **F7** from `docs/CODING_STANDARDS.md`. The notifications config `GET` endpoint returned the **raw Slack/Teams webhook URLs** (`_serialize_config` included `slack_webhook_url`/`teams_webhook_url`), so any authenticated client could read back the stored webhooks. A webhook URL is a secret — anyone holding it can post into the channel — and this broke the write-only/presence-only discipline the credentials and AI config endpoints already follow.

## Changes

- **`_serialize_config`** now returns presence booleans + a `db|env|none` **source** per channel and **never the URL** — mirrors `/api/credentials/` and `/api/ai/config/`. `*_configured` reflects effective availability (DB or env fallback).
- **`NotificationConfigIn` + `save_config`** adopt the **None=unchanged / `""`=clear / value=set** write semantics. Defaulting fields to `None` (not `""`) is what lets the UI save the threshold alone without wiping a stored webhook it can no longer read back; the threshold is validated before any mutation.
- **`NotificationsPage.jsx`** shows a `Set (UI)` / `From env var` / `Not set` source badge per channel, keeps the inputs empty (never pre-filled with a secret), adds a per-channel **Clear**, and enables **Test** from the stored URL without re-entry.
- Marks **F1 + F7 fixed** in `docs/CODING_STANDARDS.md`.

## Test
4 new backend tests (GET never returns URLs / source=`env` when only env set / threshold-only save preserves webhooks / `""` clears) — `test_notifications.py` **45 passed**. Frontend **build OK** + **32 vitest pass**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)