### PR TITLE
fix: cut brand-threat false positives (typosquat + asn_cluster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Fixed
+- **Brand-threat false positives (typosquat + asn_cluster).** Triaging a real
+  amnic.com report showed the Brand Threat category badly over-calling: a
+  legitimate ccTLD registry (amnic.net = the Armenia Network Information Centre)
+  flagged as "active impersonation", and parked lookalikes sharing an AWS/
+  Cloudflare/Namecheap IP reported as a "coordinated phishing infrastructure"
+  cluster. Three tuning fixes, no new tools:
+  - **typosquat now gates "high" on a login form only.** A brand-name string on
+    the page is a *review signal* (kept in the description), not proof of
+    impersonation — short brand strings legitimately appear in unrelated
+    organizations' own names. Brand-mention-alone no longer escalates to high.
+  - **typosquat detects domain parking** (known parking/for-sale anycast IPs +
+    sale boilerplate on the homepage) and caps a parked lookalike at **low** —
+    registrar-default A/MX records are speculation, not the buyer's phishing
+    infrastructure. A confirmed login form still outranks the parked signal.
+  - **asn_cluster skips generic networks** (hyperscale clouds, major CDNs,
+    registrar/parking ASNs — AWS/Cloudflare/Google/Namecheap/etc.) where
+    millions of unrelated domains co-locate, *unless* the cluster contains a
+    weaponized member. Overridable via `ASN_CLUSTER_GENERIC_ASNS`.
+  - Known limitation still open: the apex is split by last-dot, not the Public
+    Suffix List, so TLD-swap candidates are wrong for multi-label ccTLDs
+    (`example.co.uk` → `example.co.com`). Tracked separately.
+
 ## [v2.15.0] — 2026-09-11
 
 ### Changed

--- a/apps/asn_cluster/analyzer.py
+++ b/apps/asn_cluster/analyzer.py
@@ -2,16 +2,48 @@
 
 Turns N isolated `lookalike_domain` findings into a campaign signal: when two or
 more lookalikes resolve into the same autonomous system, that shared
-infrastructure is a strong indicator of coordinated phishing — worth prioritising
-as one takedown rather than N separate ones.
+infrastructure is an indicator of coordinated phishing — worth prioritising as
+one takedown rather than N separate ones.
+
+The signal only means something on networks small enough that co-location is a
+choice. On hyperscale clouds, CDNs, and registrar-parking networks, millions of
+unrelated domains "share hosting" the way strangers share a parking lot — a
+cluster of parked lookalikes on AS16509 (Amazon) proves nothing. Those generic
+ASNs are skipped unless the cluster contains a weaponized member (a confirmed
+phishing page makes the grouping meaningful even on shared infrastructure).
 """
 
 import logging
 from collections import defaultdict
 
+from django.conf import settings
+
 from apps.core.data.findings.models import Finding
 
 logger = logging.getLogger(__name__)
+
+# Networks where co-location carries no campaign signal: hyperscale clouds,
+# major CDNs, and registrar / domain-parking infrastructure. Curated, and
+# overridable via settings.ASN_CLUSTER_GENERIC_ASNS.
+_GENERIC_ASNS = frozenset({
+    "16509", "14618",   # Amazon (AWS / Global Accelerator — also Afternic parking)
+    "13335",            # Cloudflare
+    "15169", "396982",  # Google
+    "8075",             # Microsoft
+    "54113",            # Fastly
+    "16625", "20940",   # Akamai
+    "26496",            # GoDaddy
+    "22612",            # Namecheap (incl. registrar parking)
+    "14061",            # DigitalOcean
+    "16276",            # OVH
+    "24940",            # Hetzner
+    "47846",            # Sedo parking
+})
+
+
+def _generic_asns() -> frozenset:
+    override = getattr(settings, "ASN_CLUSTER_GENERIC_ASNS", None)
+    return frozenset(str(a) for a in override) if override is not None else _GENERIC_ASNS
 
 
 def cluster(session, lookalikes: list[dict], asn_by_ip: dict) -> list[Finding]:
@@ -46,11 +78,20 @@ def cluster(session, lookalikes: list[dict], asn_by_ip: dict) -> list[Finding]:
 
     findings: list[Finding] = []
     apex = getattr(session, "domain", "") or ""
+    generic = _generic_asns()
     for asn, candidates in members.items():
         if len(candidates) < 2:
             continue  # not a cluster — a single lookalike per ASN is unremarkable
         cands = sorted(candidates)
         weap = sorted(weaponized[asn])
+        if str(asn) in generic and not weap:
+            # Shared hyperscaler/CDN/parking hosting proves nothing by itself.
+            logger.info(
+                "asn_cluster: skipping AS%s (%s) — generic shared infrastructure, "
+                "no weaponized member (%d lookalikes: %s)",
+                asn, as_names.get(asn, ""), len(cands), ", ".join(cands),
+            )
+            continue
         name = as_names.get(asn) or "unknown network"
         severity = "high" if weap else "medium"
         weap_note = (

--- a/apps/typosquat/analyzer.py
+++ b/apps/typosquat/analyzer.py
@@ -2,12 +2,15 @@
 
 One Finding per registered lookalike domain (``check_type="lookalike_domain"``):
 
-  * ``medium`` when the lookalike has A or MX records — it can already host a
-    phishing page or receive mail, i.e. it is weaponizable against the org's
-    brand / users.
-  * ``low`` when it is only registered / parked (NS but no A/MX) — no live
-    phishing surface yet, but worth monitoring: someone owns a name built to be
-    confused with the org's.
+  * ``high`` when the live homepage carries a login form — confirmed credential
+    phishing, takedown-worthy. (Brand mentions alone never reach high: short
+    brand strings collide with unrelated organizations' legitimate names.)
+  * ``medium`` when the lookalike has A or MX records and is not parked — it
+    can host a phishing page or receive mail, i.e. it is weaponizable against
+    the org's brand / users.
+  * ``low`` when it is only registered (NS but no A/MX) or sits at a known
+    domain-parking / for-sale service — speculation, not live phishing
+    surface; worth monitoring.
 
 This is threat-surface intel: the finding names the lookalike, the records it
 carries, and the technique that produced it, so a defender can prioritise
@@ -47,13 +50,22 @@ def analyze(session, results) -> list[Finding]:
         weaponizable = bool(record.get("has_a") or record.get("has_mx"))
         login_form = bool(record.get("login_form"))
         brand_mentioned = bool(record.get("brand_mentioned"))
-        # Weaponized = the lookalike is actively impersonating: a login form
-        # (credential phishing) or the brand name on a live page. That's a
-        # confirmed threat worth a takedown, so it outranks a merely-registered
-        # (medium) or parked (low) lookalike.
-        weaponized = login_form or brand_mentioned
+        parked = bool(record.get("parked"))
+        # Weaponized = a login form on the live homepage (credential phishing) —
+        # a confirmed threat worth a takedown. Brand mentions alone are NOT
+        # enough for high: short brand strings legitimately appear in unrelated
+        # organizations' own names (a lookalike scan for "amnic" flagged the
+        # Armenia Network Information Centre as "active impersonation" because
+        # its page says AMNIC — its own name). Mentions stay a medium-level
+        # review signal in the description.
+        weaponized = login_form
         if weaponized:
             severity = "high"
+        elif parked:
+            # Parked at a domain-parking / for-sale service: speculation, not
+            # phishing infrastructure. The registrar-default A/MX records don't
+            # make it weaponizable by whoever bought the name.
+            severity = "low"
         elif weaponizable:
             severity = "medium"
         else:
@@ -61,21 +73,30 @@ def analyze(session, results) -> list[Finding]:
         summary = _record_summary(record)
 
         if weaponized:
-            signals = []
-            if login_form:
-                signals.append("a login form (credential phishing)")
-            if brand_mentioned:
-                signals.append("mentions of your brand (impersonation)")
             weapon_line = (
-                "Its live homepage shows " + " and ".join(signals) + " — this is an "
-                "active impersonation of your brand, not just a registered name. "
-                "Prioritise a takedown."
+                "Its live homepage shows a login form (credential phishing)"
+                + (" and mentions your brand" if brand_mentioned else "")
+                + " — this is an active impersonation of your brand, not just a "
+                "registered name. Prioritise a takedown."
+            )
+        elif parked:
+            weapon_line = (
+                "It sits at a domain-parking / for-sale service — registered "
+                "speculation, not live phishing infrastructure. Monitor for a "
+                "change of hosting, and consider buying it if the name is "
+                "convincing."
             )
         elif weaponizable:
             weapon_line = (
                 "Because it resolves and/or accepts mail, it can be used right "
                 "now to host a phishing page impersonating the brand or to send "
                 "spoofed email to staff, customers, or partners."
+                + (
+                    " Its homepage mentions your brand — review it manually "
+                    "(this can also be an unrelated organization with a "
+                    "similar name)."
+                    if brand_mentioned else ""
+                )
             )
         else:
             weapon_line = (
@@ -110,6 +131,7 @@ def analyze(session, results) -> list[Finding]:
                 "has_ns": bool(record.get("has_ns")),
                 "resolved_ips": record.get("resolved_ips") or [],
                 "login_form": login_form,
+                "parked": parked,
                 "brand_mentioned": brand_mentioned,
                 "brand_mention_count": record.get("brand_mention_count", 0),
                 "content_checked": bool(record.get("content_checked")),

--- a/apps/typosquat/collector.py
+++ b/apps/typosquat/collector.py
@@ -54,6 +54,44 @@ CONTENT_MAX_FETCHES = 25          # homepages fetched per scan
 CONTENT_TIMEOUT = 6               # seconds per fetch
 _LOGIN_FORM_RE = re.compile(r"<form[^>]*(?:login|sign.?in|auth|password)[^>]*>", re.I)
 
+# Domain-parking detection. A parked lookalike resolves and often carries
+# registrar-default MX, which used to read as "weaponizable right now" — but a
+# parking lot is speculation, not phishing infrastructure. Two independent
+# signals, either one marks the record parked:
+#
+#   1. Anycast IPs of the major parking / for-sale services. These are stable,
+#      well-known landing addresses (GoDaddy/Afternic ride AWS Global
+#      Accelerator; Namecheap, Sedo, Bodis, ParkingCrew use their own ranges).
+#   2. Sale/parking boilerplate on the fetched homepage.
+_PARKING_IPS = frozenset({
+    "76.223.54.146", "13.248.169.48",    # Afternic / GoDaddy (AWS Global Accelerator)
+    "3.33.130.190", "15.197.148.33",     # GoDaddy parking (AWS Global Accelerator)
+    "34.102.136.180",                    # GoDaddy CashParking
+    "91.195.240.94", "91.195.241.136",   # Sedo
+    "199.59.243.228", "199.59.243.226",  # Bodis
+    "192.64.119.87", "192.64.119.254",   # Namecheap parking
+    "162.255.119.112",                   # Namecheap registrar default
+    "185.53.177.30", "185.53.178.30",    # ParkingCrew / TeamInternet
+    "208.91.197.27",                     # Confluence Networks parking
+})
+_PARKING_PREFIXES = (
+    "185.53.177.", "185.53.178.", "185.53.179.",  # ParkingCrew / TeamInternet
+    "199.59.243.",                                # Bodis
+    "91.195.240.", "91.195.241.",                 # Sedo
+)
+_PARKED_CONTENT_RE = re.compile(
+    r"domain (?:is |may be )?for sale|buy this domain|this domain is parked|"
+    r"domain parking|parked free|hugedomains|afternic|sedo\.com|dan\.com|"
+    r"godaddy\.com/forsale|is available for purchase",
+    re.I,
+)
+
+
+def _parked_by_ip(ips: list[str]) -> bool:
+    return any(
+        ip in _PARKING_IPS or ip.startswith(_PARKING_PREFIXES) for ip in ips or []
+    )
+
 # Per-lookup DNS timeout / overall lifetime (seconds). Short — most candidates are
 # NXDOMAIN and resolve fast; we never want a hung resolver to stall a scan.
 _DNS_TIMEOUT = 3
@@ -256,6 +294,8 @@ def _content_signals(candidate: str, brand: str) -> dict:
     Contacts only the lookalike domain, never the target. Never raises — any
     fetch failure leaves content_checked=False and no signals.
     """
+    # NOTE: no "parked" default here — IP-based parking detection may already
+    # have set it on the record, and this dict is update()ed over the record.
     out = {"content_checked": True, "login_form": False,
            "brand_mentioned": False, "brand_mention_count": 0}
     try:
@@ -266,12 +306,18 @@ def _content_signals(candidate: str, brand: str) -> dict:
         )
         html = resp.text or ""
         out["login_form"] = bool(_LOGIN_FORM_RE.search(html))
+        if _PARKED_CONTENT_RE.search(html):
+            out["parked"] = True
         b = (brand or "").lower()
         if b:
             count = html.lower().count(b)
             out["brand_mention_count"] = count
             # A mention on the page, OR a redirect landing on the real brand, is
-            # an impersonation signal.
+            # an impersonation signal — but only a SIGNAL. A short brand string
+            # legitimately appears in unrelated organizations' own names (a
+            # lookalike of "amnic" hit the Armenia Network Information Centre,
+            # whose page says AMNIC because that IS its name), so the analyzer
+            # never escalates on mentions alone.
             out["brand_mentioned"] = count > 0 or b in (resp.url or "").lower()
     except Exception:  # noqa: BLE001 — never let a lookalike fetch fail the scan
         out["content_checked"] = False
@@ -303,6 +349,12 @@ def collect(session) -> list[dict]:
     dns_workers = max(1, min(_DNS_CONCURRENCY, len(candidates)))
     with ThreadPoolExecutor(max_workers=dns_workers) as executor:
         results = [r for r in executor.map(_check, candidates) if r]
+
+    # Parking detection by IP works even when the homepage fetch fails (parked
+    # domains frequently have no HTTPS), so it runs on every A-bearing record.
+    for r in results:
+        if r.get("has_a") and _parked_by_ip(r.get("resolved_ips") or []):
+            r["parked"] = True
 
     # Weaponization pass: for registered lookalikes that serve web (have an A
     # record), fetch the homepage to spot active phishing / impersonation. Capped,

--- a/tests/unit/test_asn_cluster.py
+++ b/tests/unit/test_asn_cluster.py
@@ -95,8 +95,8 @@ class TestCluster:
             {"candidate": "exampl3.com", "ips": ["1.1.1.2"], "weaponized": False},
         ]
         asn_by_ip = {
-            "1.1.1.1": {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": "1.1.1.0/24"},
-            "1.1.1.2": {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": "1.1.1.0/24"},
+            "1.1.1.1": {"asn": "212238", "as_name": "SMALLHOST", "prefix": "1.1.1.0/24"},
+            "1.1.1.2": {"asn": "212238", "as_name": "SMALLHOST", "prefix": "1.1.1.0/24"},
         }
         out = cluster(sess, lookalikes, asn_by_ip)
         assert len(out) == 1
@@ -131,6 +131,38 @@ class TestCluster:
         assert out[0].severity == "high"
         assert out[0].extra["weaponized_count"] == 1
 
+    def test_generic_asn_without_weaponized_member_is_skipped(self):
+        # Millions of unrelated (often parked) domains share hyperscaler and
+        # registrar networks — co-location on AS16509 proves no campaign.
+        from apps.asn_cluster.analyzer import cluster
+        sess = _session()
+        lookalikes = [
+            {"candidate": "a.com", "ips": ["1.1.1.1"], "weaponized": False},
+            {"candidate": "b.com", "ips": ["1.1.1.2"], "weaponized": False},
+        ]
+        asn_by_ip = {
+            "1.1.1.1": {"asn": "16509", "as_name": "AMAZON-02", "prefix": ""},
+            "1.1.1.2": {"asn": "16509", "as_name": "AMAZON-02", "prefix": ""},
+        }
+        assert cluster(sess, lookalikes, asn_by_ip) == []
+
+    def test_generic_asn_with_weaponized_member_still_reported(self):
+        # A confirmed phishing member makes the grouping meaningful even on
+        # shared infrastructure.
+        from apps.asn_cluster.analyzer import cluster
+        sess = _session()
+        lookalikes = [
+            {"candidate": "a.com", "ips": ["1.1.1.1"], "weaponized": True},
+            {"candidate": "b.com", "ips": ["1.1.1.2"], "weaponized": False},
+        ]
+        asn_by_ip = {
+            "1.1.1.1": {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": ""},
+            "1.1.1.2": {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": ""},
+        }
+        out = cluster(sess, lookalikes, asn_by_ip)
+        assert len(out) == 1
+        assert out[0].severity == "high"
+
     def test_unresolved_ips_ignored(self):
         from apps.asn_cluster.analyzer import cluster
         sess = _session()
@@ -163,8 +195,10 @@ class TestScanner:
         _lookalike(sess, "examp1e.com", ["1.1.1.1"])
         _lookalike(sess, "exampl3.com", ["1.1.1.2"])
 
+        # Non-generic ASN: a small hosting network where co-location is a real
+        # campaign signal (a generic hyperscaler/CDN/parking ASN would be skipped).
         def fake_lookup(ip):
-            return {"asn": "13335", "as_name": "CLOUDFLARENET", "prefix": "1.1.1.0/24"}
+            return {"asn": "212238", "as_name": "SMALLHOST", "prefix": "1.1.1.0/24"}
 
         with patch("apps.asn_cluster.scanner.lookup_asn", side_effect=fake_lookup):
             out = run_asn_cluster(sess)

--- a/tests/unit/test_typosquat.py
+++ b/tests/unit/test_typosquat.py
@@ -259,12 +259,39 @@ class TestAnalyzer:
         assert f.extra["login_form"] is True
         assert "takedown" in f.description.lower()
 
-    def test_brand_mention_elevates_to_high(self):
+    def test_brand_mention_alone_stays_medium(self):
+        # A brand string on the page is a review signal, not proof of
+        # impersonation — short brands collide with unrelated orgs' real names
+        # (e.g. a scan for "amnic" hit the Armenia Network Information Centre).
         sess = _session("example.com")
         results = [{"candidate": "examp1e.com", "technique": "typo",
                     "has_a": True, "has_mx": False, "has_ns": False,
                     "resolved_ips": ["1.2.3.4"], "brand_mentioned": True,
                     "brand_mention_count": 4, "content_checked": True}]
+        f = analyze(sess, results)[0]
+        assert f.severity == "medium"
+        assert "review it manually" in f.description
+
+    def test_parked_lookalike_is_low_even_with_a_and_mx(self):
+        # Parking-lot A/MX records are registrar defaults, not the buyer's
+        # phishing infrastructure.
+        sess = _session("example.com")
+        results = [{"candidate": "examp1e.com", "technique": "typo",
+                    "has_a": True, "has_mx": True, "has_ns": False,
+                    "resolved_ips": ["76.223.54.146"], "parked": True,
+                    "content_checked": True}]
+        f = analyze(sess, results)[0]
+        assert f.severity == "low"
+        assert "parking" in f.description.lower()
+        assert f.extra["parked"] is True
+
+    def test_login_form_on_parked_page_still_high(self):
+        # A confirmed phishing page outranks the parked signal.
+        sess = _session("example.com")
+        results = [{"candidate": "examp1e.com", "technique": "typo",
+                    "has_a": True, "has_mx": False, "has_ns": False,
+                    "resolved_ips": ["1.2.3.4"], "parked": True,
+                    "login_form": True, "content_checked": True}]
         assert analyze(sess, results)[0].severity == "high"
 
     def test_weaponizable_without_content_signal_stays_medium(self):


### PR DESCRIPTION
## What

Triaging a real **amnic.com** scan showed the **Brand Threat** category badly over-calling — a Grade-F headline on a surface that deserves ~B. Root examples:

- **`amnic.net` flagged as "active impersonation"** — it's the legitimate **Armenia Network Information Centre** (the `.am` ccTLD registry). The scanner saw "AMNIC" on its homepage — which is literally its own name — and called it phishing.
- **"6 lookalikes share AS16509 → coordinated phishing infrastructure"** — AS16509 is **Amazon**. The shared IPs are a **domain-parking service** on AWS Global Accelerator; the "cluster" is parked typo domains sharing a parking lot, not a campaign. Same artifact for the Cloudflare/Namecheap cluster findings.

## Fixes (three tuning changes, no new tools)

1. **typosquat gates `high` on a login form only.** A brand string on the page is a *review signal* (kept in the description), not proof of impersonation — short brand strings collide with unrelated orgs' legitimate names. Brand-mention-alone no longer escalates to high.
2. **typosquat detects domain parking** — known parking/for-sale anycast IPs (`_PARKING_IPS`/`_PARKING_PREFIXES`) + sale boilerplate on the homepage — and caps a parked lookalike at **low**. Registrar-default A/MX records are speculation, not the buyer's phishing infra. A confirmed login form still outranks the parked signal.
3. **asn_cluster skips generic networks** (hyperscale clouds, major CDNs, registrar/parking ASNs — AWS/Cloudflare/Google/Namecheap/…) where unrelated domains co-locate, **unless** the cluster contains a weaponized member. Overridable via `ASN_CLUSTER_GENERIC_ASNS`.

This maps the amnic.com report from 3 HIGH + "Grade F" down to the handful of genuine email/DNS-posture issues it actually is.

## Tests

Updated/added: brand-mention-alone→medium, parked→low, login-form-on-parked→high, generic-ASN-skipped, generic-ASN-with-weaponized-member→still reported. Also fixed a pre-existing scanner test that clustered on Cloudflare (now a generic ASN). **typosquat + asn_cluster + passive_scan + reports: 160 passed**; ruff clean.

## Known limitation (tracked separately, NOT in this PR)

The apex is split by last-dot, not the Public Suffix List, so TLD-swap candidates are wrong for multi-label ccTLDs (`example.co.uk` → `example.co.com` instead of `example.com`). Noted in CHANGELOG for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)