### PR TITLE
fix: fail fast on default DB password in production (F-sec1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Security
+- **Fail fast on the default DB password in production (F-sec1).** `DB_PASSWORD`
+  defaulted to `"openeasd"` with nothing stopping a `DEBUG=False` deploy from
+  booting on it — a trivial foothold on the database that holds every scan
+  result and the encrypted BYOK credentials. A new `_validate_db_password` guard
+  (mirroring the existing `SECRET_KEY` guard) raises `ImproperlyConfigured` at
+  settings import when `DEBUG=False` and the DB_* path still uses the default
+  `"openeasd"`. The `DATABASE_URL` path is exempt (it carries its own creds), and
+  the guard is skipped under the test runner. Like the SECRET_KEY guard it
+  matches only the **code default**, so the shipped docker-compose / k8s configs
+  (which set a real password or `"change-me-in-production"`) boot unchanged.
+
 ### Fixed
 - **Brand-threat false positives (typosquat + asn_cluster).** Triaging a real
   amnic.com report showed the Brand Threat category badly over-calling: a

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,13 @@ COPY config/ config/
 COPY docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
 COPY --from=frontend-builder /build/frontend/dist/ frontend/dist/
-RUN SECRET_KEY=build-time-placeholder python manage.py collectstatic --noinput
+# Build-time placeholders for the production fail-fast guards (settings/base.py):
+# collectstatic imports settings but never touches the DB or signs tokens, so
+# these never leave this RUN layer. SECRET_KEY clears the SECRET_KEY guard;
+# DB_PASSWORD clears the default-password guard. Real values are supplied at
+# runtime by compose / k8s.
+RUN SECRET_KEY=build-time-placeholder DB_PASSWORD=build-time-placeholder \
+    python manage.py collectstatic --noinput
 
 ARG OPENEASD_VERSION=dev
 ARG OPENEASD_GIT_SHA=unknown

--- a/openeasd/settings/__init__.py
+++ b/openeasd/settings/__init__.py
@@ -23,5 +23,6 @@ from .base import (  # noqa: E402,F401
     _PROFILE_TUNING,
     _resolve_profile,
     _security_settings,
+    _validate_db_password,
     _validate_secret_key,
 )

--- a/openeasd/settings/base.py
+++ b/openeasd/settings/base.py
@@ -197,6 +197,27 @@ ASGI_APPLICATION = "openeasd.asgi.application"
 # durable scan execution and so scans can run with real concurrency (no more
 # single-writer lock). Configure via DB_* env vars; DATABASE_URL wins if set.
 _DATABASE_URL = config("DATABASE_URL", default="")
+_DB_PASSWORD = config("DB_PASSWORD", default="openeasd")  # only used on the DB_* path
+
+
+def _validate_db_password(using_database_url: bool, db_password: str, debug: bool) -> None:
+    """Fail fast in production on the well-known default DB password.
+
+    Mirrors _validate_secret_key. Only the DB_* path carries a default
+    ('openeasd'); DATABASE_URL supplies its own credentials, so it's exempt.
+    A shipped default password is a trivial foothold on the database that holds
+    every scan result AND the encrypted BYOK credentials. DEBUG builds keep the
+    default for local dev.
+    """
+    if not debug and not using_database_url and db_password == "openeasd":
+        raise ImproperlyConfigured(
+            "DB_PASSWORD is still the insecure default 'openeasd' while DEBUG=False. "
+            "Set a strong DB_PASSWORD (or a full DATABASE_URL) via the environment. "
+            "This database holds all scan results and encrypted BYOK credentials, "
+            "so the well-known default leaves them open to anyone who can reach it."
+        )
+
+
 if _DATABASE_URL:
     import dj_database_url  # type: ignore
 
@@ -207,12 +228,18 @@ else:
             "ENGINE": "django.db.backends.postgresql",
             "NAME": config("DB_NAME", default="openeasd"),
             "USER": config("DB_USER", default="openeasd"),
-            "PASSWORD": config("DB_PASSWORD", default="openeasd"),
+            "PASSWORD": _DB_PASSWORD,
             "HOST": config("DB_HOST", default="127.0.0.1"),
             "PORT": config("DB_PORT", default="5432"),
             "CONN_MAX_AGE": config("DB_CONN_MAX_AGE", default=600, cast=int),
         }
     }
+
+# Skip under the test runner for the same reason as the SECRET_KEY guard: pytest
+# imports settings before any env hook can set one, and CI sets real DB_* values.
+# The logic is covered by unit + subprocess tests.
+if "pytest" not in sys.modules:
+    _validate_db_password(bool(_DATABASE_URL), _DB_PASSWORD, DEBUG)
 
 # DBOS durable-execution system database. Checkpoints scan workflows/steps so a
 # crashed or restarted worker RESUMES a scan instead of losing it (retiring the

--- a/tests/unit/test_settings_security.py
+++ b/tests/unit/test_settings_security.py
@@ -6,7 +6,8 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 from openeasd.settings import (
-    _validate_secret_key, _security_settings, _resolve_profile, _PROFILE_TUNING,
+    _validate_secret_key, _validate_db_password, _security_settings,
+    _resolve_profile, _PROFILE_TUNING,
 )
 
 
@@ -138,6 +139,11 @@ class TestSecretKeyGuardWiring:
         env = {
             **os.environ,
             "SECRET_KEY": "x" * 50,  # strong enough to pass the guard
+            # A strong DB_PASSWORD too — the production boot now also refuses the
+            # default DB password (see TestDbPasswordGuard), so a valid prod boot
+            # must satisfy both guards.
+            "DB_PASSWORD": "a-strong-db-password",
+            "DATABASE_URL": "",  # force the DB_* path, ignoring any repo .env
             "DEBUG": "False",
         }
         env.pop("PYTEST_CURRENT_TEST", None)
@@ -146,3 +152,49 @@ class TestSecretKeyGuardWiring:
             cwd=str(repo_root), env=env, capture_output=True, text=True,
         )
         assert result.returncode == 0, result.stderr
+
+
+class TestDbPasswordGuard:
+    def test_raises_on_default_password_in_production(self):
+        with pytest.raises(ImproperlyConfigured):
+            _validate_db_password(using_database_url=False, db_password="openeasd", debug=False)
+
+    def test_allows_default_password_when_debug(self):
+        # Local dev is permitted to keep the placeholder password.
+        _validate_db_password(using_database_url=False, db_password="openeasd", debug=True)
+
+    def test_allows_strong_password_in_production(self):
+        _validate_db_password(using_database_url=False, db_password="s3cure-p@ss", debug=False)
+
+    def test_database_url_path_is_exempt(self):
+        # DATABASE_URL carries its own credentials — the DB_* default never applies,
+        # so the guard must not fire even if db_password is left at the default.
+        _validate_db_password(using_database_url=True, db_password="openeasd", debug=False)
+
+
+class TestDbPasswordGuardWiring:
+    """Prove the DB-password guard is actually WIRED into settings import — a
+    real subprocess, since the in-process call is skipped under pytest. A strong
+    SECRET_KEY is set so boot reaches the DB guard rather than aborting earlier."""
+
+    def test_settings_import_aborts_on_default_db_password_in_production(self):
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        env = {
+            **os.environ,
+            "SECRET_KEY": "x" * 50,        # pass the SECRET_KEY guard first
+            "DB_PASSWORD": "openeasd",     # the insecure default
+            "DATABASE_URL": "",            # force the DB_* path, ignoring any repo .env
+            "DEBUG": "False",
+        }
+        env.pop("PYTEST_CURRENT_TEST", None)
+        result = subprocess.run(
+            [sys.executable, "-c", "import openeasd.settings"],
+            cwd=str(repo_root), env=env, capture_output=True, text=True,
+        )
+        assert result.returncode != 0, "settings booted with the default DB password + DEBUG=False"
+        assert "ImproperlyConfigured" in result.stderr or "DB_PASSWORD" in result.stderr


### PR DESCRIPTION
## What

Fixes **F-sec1** from `docs/CODING_STANDARDS.md`. `DB_PASSWORD` defaulted to `"openeasd"` and nothing stopped a `DEBUG=False` deploy from booting on it — unlike `SECRET_KEY`, which already fails fast. That's a trivial-to-guess foothold on the database that holds **every scan result** and the **encrypted BYOK credentials**.

## Change

- New **`_validate_db_password`** in `openeasd/settings/base.py`, mirroring `_validate_secret_key`: raises `ImproperlyConfigured` at settings import when `DEBUG=False` **and** the `DB_*` path still uses the default `"openeasd"`.
- The **`DATABASE_URL` path is exempt** (it carries its own credentials).
- **Skipped under the test runner** (`"pytest" not in sys.modules`), same as the SECRET_KEY guard.
- Exported from `openeasd/settings/__init__.py` for testing.

### Why it doesn't break existing deploys
It matches **only the code default**, exactly like the SECRET_KEY guard (which rejects only the `django-insecure*` default, not the compose placeholder). The shipped `docker-compose.yml` / k8s configs set a real password or `"change-me-in-production"`, so they boot unchanged. The guard only trips the genuinely dangerous case: a production process started with no DB config at all.

## Tests
- `_validate_db_password` units: default→raises, `DEBUG=True`→allowed, strong→allowed, `DATABASE_URL`→exempt.
- A **real-subprocess wiring test** proving `import openeasd.settings` aborts on the default password + `DEBUG=False` (the in-process guard is skipped under pytest by design).
- Updated the SECRET_KEY positive wiring test to also supply a strong `DB_PASSWORD` (a valid prod boot must now satisfy both guards); pinned `DATABASE_URL=""` in both subprocess tests so a repo `.env` can't mask the DB_* path.

`test_settings_security.py` **24 passed**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)