### PR TITLE
fix: tool consistency pass (F-tool1, F-tool4, config drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Fixed
+- **Tool consistency pass (F-tool1 / F-tool4 / config drift).** Aligned a few
+  tool apps with the conventions their siblings already follow:
+  - `domain_security` and `domain_probe` now wrap collect+analyze in
+    `try/except → return []` so an unexpected DNS/RDAP/probe error can never
+    propagate and fail the whole scan — matching their passive Domain-Posture
+    siblings (`breach_check`/`hudson_rock`/`dns_history`).
+  - `web_checker` now sends the shared honest User-Agent
+    (`settings.OPENEASD_USER_AGENT`) instead of a tool-specific string — it was
+    the only tool that diverged, so a target allowlisting the scanner now sees a
+    consistent UA across httpx/katana/nuclei/web_checker.
+  - Added the missing `default_auto_field` to six tool `apps.py`
+    (`cve_intel`, `nuclei_network`, `ssh_checker`, `takeover_check`,
+    `tls_checker`, `web_checker`). No migrations (these apps define no models).
+  - Deliberately **not** changed: `cloud_assets` — it's a binary tool whose
+    phase-sibling `takeover_check` *propagates* a missing-binary/timeout to a
+    "partial" scan (labeled-partials principle), so whether it should swallow
+    (additive) or propagate is a policy call tracked separately (F-tool2/F-tool3
+    in `docs/CODING_STANDARDS.md`).
+
 ### Security
 - **Fail fast on the default DB password in production (F-sec1).** `DB_PASSWORD`
   defaulted to `"openeasd"` with nothing stopping a `DEBUG=False` deploy from

--- a/apps/cve_intel/apps.py
+++ b/apps/cve_intel/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class CveIntelConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "apps.cve_intel"
     label = "cve_intel"
     verbose_name = "CVE Intel (EPSS + KEV)"

--- a/apps/domain_probe/scanner.py
+++ b/apps/domain_probe/scanner.py
@@ -266,10 +266,16 @@ def run_domain_probe(session) -> list:
     domain = session.domain
     logger.info(f"[domain_probe:{session.id}] Starting active probes for {domain}")
 
-    findings = []
-    findings += _check_zone_transfer(session, domain, _resolve(domain, "NS"))
-    findings += _stamp_control(_check_mta_sts(session, domain), "mta_sts")
-    findings += _stamp_control(_check_open_relay(session, domain), "open_relay")
+    # Fail-graceful like the passive Domain Posture siblings: a probe error
+    # (AXFR/SMTP/MTA-STS) must never propagate and fail the whole scan.
+    try:
+        findings = []
+        findings += _check_zone_transfer(session, domain, _resolve(domain, "NS"))
+        findings += _stamp_control(_check_mta_sts(session, domain), "mta_sts")
+        findings += _stamp_control(_check_open_relay(session, domain), "open_relay")
+    except Exception:  # noqa: BLE001 — never let this tool fail a scan
+        logger.exception("[domain_probe:%s] unexpected error — skipping", session.id)
+        return []
 
     if findings:
         Finding.objects.bulk_create(findings)

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -879,10 +879,17 @@ def run_domain_security(session) -> list:
     domain = session.domain
     logger.info(f"[domain_security:{session.id}] Starting checks for {domain}")
 
-    findings = []
-    findings += _check_dns(session, domain)
-    findings += _check_email(session, domain)
-    findings += _check_rdap(session, domain)
+    # Fail-graceful like the other passive Domain Posture / intel tools
+    # (breach_check, hudson_rock, dns_history): a DNS/RDAP hiccup must never
+    # propagate and fail the whole scan — skip with zero findings instead.
+    try:
+        findings = []
+        findings += _check_dns(session, domain)
+        findings += _check_email(session, domain)
+        findings += _check_rdap(session, domain)
+    except Exception:  # noqa: BLE001 — never let this tool fail a scan
+        logger.exception("[domain_security:%s] unexpected error — skipping", session.id)
+        return []
 
     if findings:
         Finding.objects.bulk_create(findings)

--- a/apps/nuclei_network/apps.py
+++ b/apps/nuclei_network/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class NucleiNetworkConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "apps.nuclei_network"
     label = "nuclei_network"
     verbose_name = "Nuclei Network"

--- a/apps/ssh_checker/apps.py
+++ b/apps/ssh_checker/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class SshCheckerConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "apps.ssh_checker"
     label = "ssh_checker"
     verbose_name = "SSH Checker"

--- a/apps/takeover_check/apps.py
+++ b/apps/takeover_check/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class TakeoverCheckConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "apps.takeover_check"
     label = "takeover_check"
     verbose_name = "Subdomain Takeover Check"

--- a/apps/tls_checker/apps.py
+++ b/apps/tls_checker/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class TlsCheckerConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "apps.tls_checker"
     label = "tls_checker"
     verbose_name = "TLS Checker"

--- a/apps/web_checker/apps.py
+++ b/apps/web_checker/apps.py
@@ -2,6 +2,7 @@ from django.apps import AppConfig
 
 
 class WebCheckerConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "apps.web_checker"
     label = "web_checker"
     verbose_name = "Web Checker"

--- a/apps/web_checker/collector.py
+++ b/apps/web_checker/collector.py
@@ -15,6 +15,7 @@ import re
 
 import requests
 import urllib3
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,11 @@ logger = logging.getLogger(__name__)
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 REQUEST_TIMEOUT = 10  # seconds
-USER_AGENT = "openeasd-web-checker/1.0"
+# Honest scanner identity — use the shared UA so a target can allowlist us, same
+# as httpx/katana/nuclei (was a tool-specific string; the only tool that diverged).
+USER_AGENT = getattr(
+    settings, "OPENEASD_USER_AGENT", "OpenEASD/1.0 (+https://cybersecify.com/openeasd)"
+)
 BODY_SNIPPET_SIZE = 4096  # chars to read for directory listing check
 SECURITY_TXT_MAX = 8192  # chars to read from a security.txt response
 _TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -399,19 +399,26 @@ blockers. Fixed items are struck through with the PR that closed them.
 - **F6 — two 404 body shapes**: `get_object_or_404` renders `{"detail":...}` while
   `HttpError(404,…)` renders the `{"error":{...}}` envelope. Standardize on the
   envelope.
-- **F-tool1 — `domain_security`/`domain_probe` orchestrators have no top-level
-  try/except** (unlike `typosquat`/`shodan`), so a finding-producing tool could
-  still raise into the runner. (`domain_security/scanner.py:877`,
-  `domain_probe/scanner.py:264`)
+- **F-tool1 — ~~`domain_security`/`domain_probe` orchestrators have no top-level
+  try/except~~ — FIXED (#448).** Both now wrap collect+analyze in
+  `try/except → return []`, matching their passive Domain-Posture siblings
+  (`breach_check`/`hudson_rock`/`dns_history`). `cloud_assets` was deliberately
+  **excluded**: it's a binary tool, and its phase-sibling `takeover_check`
+  *propagates* `ToolBinaryMissing`/`ToolTimeout` → "partial" (labeled-partials
+  principle). Whether `cloud_assets` should swallow (additive) or propagate
+  (honest-partial) is an open policy call — tracked, not guessed.
 - **F-tool2 — configured `_DNS_TIMEOUT` is honored in only one check** in
   `domain_security`; most `dns.resolver.resolve` calls use the default resolver
-  with no explicit timeout. (`domain_security/scanner.py`)
+  with no explicit timeout. (`domain_security/scanner.py`) **Deferred** from #448:
+  the slow real-network `test_domain_security.py` patches `scanner.dns` with
+  fixed-signature fakes, so adding a `lifetime=` kwarg needs validating against
+  that suite — its own PR.
 - **F-tool3 — `cloud_assets` skips on missing binary** (`shutil.which → []`)
   instead of raising `ToolBinaryMissing` like every other binary collector —
   inconsistent binary-missing contract. (`cloud_assets/collector.py:21-23`)
-- **F-tool4 — `web_checker` hardcodes its own User-Agent** instead of
-  `settings.OPENEASD_USER_AGENT` — the only tool that breaks the honest-UA rule.
-  (`web_checker/collector.py:25`)
+  **Open**, coupled to the F-tool1 policy call above (raise→partial vs skip).
+- **F-tool4 — ~~`web_checker` hardcodes its own User-Agent~~ — FIXED (#448).**
+  Now uses `settings.OPENEASD_USER_AGENT`, the shared honest UA.
 - **F9 — local fixtures shadow `conftest.py`** in `test_api_endpoints.py` and
   `test_reports.py`; the two `auth_client`s differ subtly and can drift.
 - **F11 — brittle report tests** assert exact HTML/CSS/copy strings rather than
@@ -438,6 +445,7 @@ blockers. Fixed items are struck through with the PR that closed them.
   Consolidate into shared helpers.
 - **F-misc — stale comments / config drift**: `nuclei` timeout comments say
   "30m→2h" but the value is 6h; `asn_cluster` comment says "Prioritization" but
-  `phase_group="Brand Threat"`; several tool `apps.py` omit `default_auto_field`;
+  `phase_group="Brand Threat"`; ~~several tool `apps.py` omit
+  `default_auto_field`~~ (FIXED #448 — the 6 that omitted it now set it);
   `Badge.jsx` lists status keys twice; `axiosInstance.js` imports `router.jsx`
   (near-circular — prefer a navigation callback).


### PR DESCRIPTION
## What

A consistency cleanup aligning a few tool apps with the conventions their siblings already follow (from the `docs/CODING_STANDARDS.md` open-findings appendix).

- **F-tool1** — `domain_security` + `domain_probe` now wrap collect+analyze in `try/except → return []`, so an unexpected DNS/RDAP/probe error can never propagate and fail the whole scan. Matches their passive Domain-Posture siblings (`breach_check`/`hudson_rock`/`dns_history`), which all do this.
- **F-tool4** — `web_checker` now sends the shared honest UA (`settings.OPENEASD_USER_AGENT`) instead of a tool-specific `"openeasd-web-checker/1.0"` — it was the only tool diverging from the httpx/katana/nuclei honest-UA convention.
- **config drift** — added the missing `default_auto_field` to six tool `apps.py` (`cve_intel`, `nuclei_network`, `ssh_checker`, `takeover_check`, `tls_checker`, `web_checker`). **No migrations** — these apps define no models (`makemigrations --check` clean).

## Deliberately scoped out (flagged, not guessed)

Two findings I'd listed turned out to involve a real design policy, so I did **not** force them:

- **`cloud_assets` (F-tool1 wrapper / F-tool3 raise)** — it's a *binary* tool, and its phase-sibling `takeover_check` **propagates** `ToolBinaryMissing`/`ToolTimeout` to a **"partial"** scan (the labeled-partials principle). Wrapping cloud_assets would make it inconsistent with takeover_check; making it raise changes partial semantics. Whether cloud_assets should swallow (additive, like shodan) or propagate (honest-partial, like takeover_check) is a policy call — tracked in the doc, not guessed.
- **F-tool2 (domain_security DNS timeout)** — the slow real-network `test_domain_security.py` patches `scanner.dns` with fixed-signature fakes; adding a `lifetime=` kwarg needs validating against that suite. Deferred to its own PR.

The `docs/CODING_STANDARDS.md` appendix is updated to reflect fixed vs deferred vs open.

## Test
`web_checker` · `domain_probe` · `domain_security_email` · `takeover_check` · `tls_checker` · `ssh_checker` · `nuclei_network` · `cve_intel` — **325 passed**; `makemigrations --check` clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)