### PR TITLE
fix: cloud_assets propagates missing-binary → partial (F-tool3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ commits to recover the reasoning.
   - Added the missing `default_auto_field` to six tool `apps.py`
     (`cve_intel`, `nuclei_network`, `ssh_checker`, `takeover_check`,
     `tls_checker`, `web_checker`). No migrations (these apps define no models).
-  - Deliberately **not** changed: `cloud_assets` — it's a binary tool whose
-    phase-sibling `takeover_check` *propagates* a missing-binary/timeout to a
-    "partial" scan (labeled-partials principle), so whether it should swallow
-    (additive) or propagate is a policy call tracked separately (F-tool2/F-tool3
-    in `docs/CODING_STANDARDS.md`).
+  - `cloud_assets` now **propagates** a missing/timed-out `cloud_enum` (F-tool3):
+    dropped the upfront `shutil.which → []` silent skip, so the binary-missing
+    case raises `ToolBinaryMissing` like every other binary collector and the
+    runner marks the scan "partial" instead of a fake "clean". Ruling: binary
+    tools propagate, matching `takeover_check` — restoring the intent of the
+    earlier "tool failures no longer hidden behind `completed`" change. (F-tool2,
+    the domain_security DNS-timeout fix, is still deferred to its own PR.)
 
 ### Security
 - **Fail fast on the default DB password in production (F-sec1).** `DB_PASSWORD`

--- a/apps/cloud_assets/collector.py
+++ b/apps/cloud_assets/collector.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import shutil
 import subprocess
 import tempfile
 
@@ -18,10 +17,11 @@ def collect(keywords: list[str]) -> list[str]:
         return []
 
     binary = getattr(settings, "TOOL_CLOUD_ENUM", "cloud_enum")
-    if not shutil.which(binary):
-        logger.debug("cloud_enum binary not found at %r — skipping", binary)
-        return []
 
+    # Missing binary raises ToolBinaryMissing (below, via subprocess FileNotFoundError)
+    # rather than skipping silently — consistent with every other binary tool
+    # (takeover_check/nmap/naabu/…). The runner records the failed step so the scan
+    # is labeled "partial" instead of reporting a fake "clean" result.
     with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as kf:
         kf.write("\n".join(keywords))
         keywords_path = kf.name
@@ -42,6 +42,7 @@ def collect(keywords: list[str]) -> list[str]:
             logger.warning("cloud_enum timed out after %ss", _TIMEOUT)
             raise ToolTimeout(f"cloud_enum timed out after {_TIMEOUT}s")
         except FileNotFoundError:
+            logger.warning("cloud_enum binary not found at %r", binary)
             raise ToolBinaryMissing(f"cloud_enum binary not found: {binary}")
 
         if result.returncode != 0:

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -402,21 +402,23 @@ blockers. Fixed items are struck through with the PR that closed them.
 - **F-tool1 — ~~`domain_security`/`domain_probe` orchestrators have no top-level
   try/except~~ — FIXED (#448).** Both now wrap collect+analyze in
   `try/except → return []`, matching their passive Domain-Posture siblings
-  (`breach_check`/`hudson_rock`/`dns_history`). `cloud_assets` was deliberately
-  **excluded**: it's a binary tool, and its phase-sibling `takeover_check`
-  *propagates* `ToolBinaryMissing`/`ToolTimeout` → "partial" (labeled-partials
-  principle). Whether `cloud_assets` should swallow (additive) or propagate
-  (honest-partial) is an open policy call — tracked, not guessed.
+  (`breach_check`/`hudson_rock`/`dns_history`). `cloud_assets` is **not** wrapped:
+  it's a binary tool and follows the binary-tool contract instead (propagate →
+  "partial", like its sibling `takeover_check`) — resolved in F-tool3 below.
 - **F-tool2 — configured `_DNS_TIMEOUT` is honored in only one check** in
   `domain_security`; most `dns.resolver.resolve` calls use the default resolver
   with no explicit timeout. (`domain_security/scanner.py`) **Deferred** from #448:
   the slow real-network `test_domain_security.py` patches `scanner.dns` with
   fixed-signature fakes, so adding a `lifetime=` kwarg needs validating against
   that suite — its own PR.
-- **F-tool3 — `cloud_assets` skips on missing binary** (`shutil.which → []`)
-  instead of raising `ToolBinaryMissing` like every other binary collector —
-  inconsistent binary-missing contract. (`cloud_assets/collector.py:21-23`)
-  **Open**, coupled to the F-tool1 policy call above (raise→partial vs skip).
+- **F-tool3 — ~~`cloud_assets` skips on missing binary~~ — FIXED (#449).**
+  Dropped the upfront `shutil.which → []` silent skip; a missing/timed-out
+  `cloud_enum` now raises `ToolBinaryMissing`/`ToolTimeout` and propagates (the
+  scanner has no swallowing wrapper), so the runner marks the scan "partial"
+  instead of a fake "clean". **Ruling:** binary tools propagate, matching
+  `takeover_check` — this also restores the intent of the earlier "tool failures
+  no longer hidden behind `completed`" change, which had listed `cloud_assets`
+  among the raisers.
 - **F-tool4 — ~~`web_checker` hardcodes its own User-Agent~~ — FIXED (#448).**
   Now uses `settings.OPENEASD_USER_AGENT`, the shared honest UA.
 - **F9 — local fixtures shadow `conftest.py`** in `test_api_endpoints.py` and

--- a/tests/unit/test_cloud_assets.py
+++ b/tests/unit/test_cloud_assets.py
@@ -12,28 +12,29 @@ class TestCollect:
     def test_empty_keywords_returns_empty(self):
         assert collect([]) == []
 
-    @patch("apps.cloud_assets.collector.shutil.which", return_value=None)
-    def test_missing_binary_returns_empty(self, _):
-        assert collect(["example"]) == []
+    @patch("apps.cloud_assets.collector.subprocess.run", side_effect=FileNotFoundError())
+    def test_missing_binary_raises(self, _run):
+        # cloud_enum absent -> ToolBinaryMissing propagates (runner marks the scan
+        # "partial"), instead of silently skipping and reading as a clean result.
+        from apps.core.engine.workflows.exceptions import ToolBinaryMissing
+        with pytest.raises(ToolBinaryMissing):
+            collect(["example"])
 
-    @patch("apps.cloud_assets.collector.shutil.which", return_value="/usr/bin/cloud_enum")
     @patch("apps.cloud_assets.collector.subprocess.run")
-    def test_nonzero_exit_returns_empty(self, mock_run, _):
+    def test_nonzero_exit_returns_empty(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stderr="error")
         assert collect(["example"]) == []
 
-    @patch("apps.cloud_assets.collector.shutil.which", return_value="/usr/bin/cloud_enum")
     @patch("apps.cloud_assets.collector.subprocess.run")
-    def test_timeout_raises(self, mock_run, _):
+    def test_timeout_raises(self, mock_run):
         from apps.core.engine.workflows.exceptions import ToolTimeout
         mock_run.side_effect = subprocess.TimeoutExpired("cloud_enum", 1800)
         with pytest.raises(ToolTimeout):
             collect(["example"])
 
-    @patch("apps.cloud_assets.collector.shutil.which", return_value="/usr/bin/cloud_enum")
     @patch("apps.cloud_assets.collector.subprocess.run", return_value=MagicMock(returncode=0, stderr=""))
     @patch("apps.cloud_assets.collector.os.path.exists", return_value=False)
-    def test_missing_output_file_returns_empty(self, _exists, _run, _which):
+    def test_missing_output_file_returns_empty(self, _exists, _run):
         assert collect(["example"]) == []
 
     def test_happy_path_returns_aws_url(self, tmp_path):
@@ -46,8 +47,7 @@ class TestCollect:
         mock_ntf.__exit__ = MagicMock(return_value=False)
         mock_ntf.name = str(keywords_file)
 
-        with patch("apps.cloud_assets.collector.shutil.which", return_value="/usr/bin/cloud_enum"), \
-             patch("apps.cloud_assets.collector.tempfile.NamedTemporaryFile", return_value=mock_ntf), \
+        with patch("apps.cloud_assets.collector.tempfile.NamedTemporaryFile", return_value=mock_ntf), \
              patch("apps.cloud_assets.collector.subprocess.run", return_value=MagicMock(returncode=0, stderr="")):
             result = collect(["example"])
 
@@ -67,8 +67,7 @@ class TestCollect:
         mock_ntf.__exit__ = MagicMock(return_value=False)
         mock_ntf.name = str(keywords_file)
 
-        with patch("apps.cloud_assets.collector.shutil.which", return_value="/usr/bin/cloud_enum"), \
-             patch("apps.cloud_assets.collector.tempfile.NamedTemporaryFile", return_value=mock_ntf), \
+        with patch("apps.cloud_assets.collector.tempfile.NamedTemporaryFile", return_value=mock_ntf), \
              patch("apps.cloud_assets.collector.subprocess.run", return_value=MagicMock(returncode=0, stderr="")):
             result = collect(["example"])
 
@@ -226,3 +225,20 @@ class TestScanner:
         with patch("apps.cloud_assets.scanner.collect", return_value=[]):
             result = run_cloud_assets(sess)
         assert result == []
+
+    def test_binary_missing_propagates_not_swallowed(self):
+        # Policy: cloud_assets is a binary tool — a missing/timed-out cloud_enum
+        # must propagate so the runner marks the scan "partial", NOT be swallowed
+        # into a fake "clean" result. The scanner deliberately has no try/except.
+        from apps.core.data.assets.models import Subdomain
+        from apps.core.engine.workflows.exceptions import ToolBinaryMissing
+
+        sess = self._session()
+        Subdomain.objects.create(
+            session=sess, domain="example.com",
+            subdomain="dev.example.com", source="subfinder",
+        )
+        with patch("apps.cloud_assets.scanner.collect",
+                   side_effect=ToolBinaryMissing("cloud_enum binary not found")):
+            with pytest.raises(ToolBinaryMissing):
+                run_cloud_assets(sess)


### PR DESCRIPTION
## What

Resolves the **cloud_assets policy ruling** deferred from #448: cloud_assets is a binary tool, so it follows the binary-tool contract of its phase-sibling `takeover_check` — **propagate** `ToolBinaryMissing`/`ToolTimeout` so the runner records a failed step and the scan is labeled **"partial"**, never swallowed into a fake **"clean"** result (the labeled-partials principle). Closes **F-tool3**.

## Change
- **collector** — dropped the upfront `shutil.which → return []` silent skip (and the now-unused `shutil` import). A missing `cloud_enum` now surfaces via `subprocess` `FileNotFoundError → ToolBinaryMissing`, like every other binary collector.
- **scanner** — unchanged: deliberately **no** `try/except` wrapper, so the typed exception propagates to the runner → "partial".

## Why this is the right call
CHANGELOG (a prior release, "tool failures no longer hidden behind `completed`") **already listed `cloud_assets` among the 12 collectors that raise** on a missing essential binary — the upfront `shutil.which` skip had crept back and regressed that. This restores the documented intent.

## Test
- Retargeted `test_missing_binary` → asserts `ToolBinaryMissing` is raised; dropped the now-invalid `shutil.which` patches across the collector tests.
- Added a scanner-level test locking in **propagate-not-swallow**.
- `test_cloud_assets.py` **23 passed**; ruff clean.

Ledger (`docs/CODING_STANDARDS.md`) updated: F-tool3 → FIXED, F-tool1 cloud_assets note resolved. (F-tool2 — domain_security DNS timeout — remains deferred to its own PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)