### PR TITLE
fix: honor configured DNS timeout on all domain_security lookups (F-tool2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,12 @@ commits to recover the reasoning.
     case raises `ToolBinaryMissing` like every other binary collector and the
     runner marks the scan "partial" instead of a fake "clean". Ruling: binary
     tools propagate, matching `takeover_check` — restoring the intent of the
-    earlier "tool failures no longer hidden behind `completed`" change. (F-tool2,
-    the domain_security DNS-timeout fix, is still deferred to its own PR.)
+    earlier "tool failures no longer hidden behind `completed`" change.
+  - `domain_security` now honors the configured DNS timeout on **all** lookups
+    (F-tool2): `_DNS_TIMEOUT` (`SCANNER_DNS_TIMEOUT`, default 5s) was applied to
+    only the lame-delegation probe, so a slow/hung authoritative server could
+    stall a scan past the bound. Added `lifetime=_DNS_TIMEOUT` to all six
+    `dns.resolver.resolve` calls.
 
 ### Security
 - **Fail fast on the default DB password in production (F-sec1).** `DB_PASSWORD`

--- a/apps/domain_security/scanner.py
+++ b/apps/domain_security/scanner.py
@@ -54,7 +54,7 @@ _HTTP_TIMEOUT = getattr(settings, "SCANNER_HTTP_TIMEOUT", 10)
 def _resolve(domain, record_type):
     """Resolve a DNS record, return answers or empty list."""
     try:
-        return dns.resolver.resolve(domain, record_type)
+        return dns.resolver.resolve(domain, record_type, lifetime=_DNS_TIMEOUT)
     except (_DNS_NoAnswer, _DNS_NXDOMAIN, _DNS_NoNameservers):
         return []
     except Exception as e:
@@ -107,7 +107,7 @@ def _check_wildcard(session, domain) -> list:
     test_subdomain = f"openeasd-wildcard-probe.{domain}"
 
     try:
-        answers = dns.resolver.resolve(test_subdomain, "A")
+        answers = dns.resolver.resolve(test_subdomain, "A", lifetime=_DNS_TIMEOUT)
         if answers:
             findings.append(Finding(
             session=session, source="domain_security", target=domain, check_type="dns",
@@ -144,7 +144,7 @@ def _check_lame_delegation(session, domain, ns_records) -> list:
             ns_host = str(ns).rstrip(".")
 
         try:
-            ns_ips = dns.resolver.resolve(ns_host, "A")
+            ns_ips = dns.resolver.resolve(ns_host, "A", lifetime=_DNS_TIMEOUT)
             ns_ip = str(ns_ips[0])
         except Exception:
             lame_servers.append(f"{ns_host} (no A record)")
@@ -193,13 +193,13 @@ def _check_dnssec(session, domain) -> list:
     has_ds = False
 
     try:
-        resp = dns.resolver.resolve(domain, "DNSKEY")
+        resp = dns.resolver.resolve(domain, "DNSKEY", lifetime=_DNS_TIMEOUT)
         has_dnskey = len(resp) > 0
     except Exception:
         pass
 
     try:
-        resp = dns.resolver.resolve(domain, "DS")
+        resp = dns.resolver.resolve(domain, "DS", lifetime=_DNS_TIMEOUT)
         has_ds = len(resp) > 0
     except Exception:
         pass
@@ -327,7 +327,7 @@ def _check_dns(session, domain) -> list:
 def _get_txt_record(domain) -> list:
     """Return all TXT record strings for a domain."""
     try:
-        answers = dns.resolver.resolve(domain, "TXT")
+        answers = dns.resolver.resolve(domain, "TXT", lifetime=_DNS_TIMEOUT)
         return [b"".join(r.strings).decode("utf-8", errors="ignore") for r in answers]
     except Exception:
         return []

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -405,12 +405,12 @@ blockers. Fixed items are struck through with the PR that closed them.
   (`breach_check`/`hudson_rock`/`dns_history`). `cloud_assets` is **not** wrapped:
   it's a binary tool and follows the binary-tool contract instead (propagate →
   "partial", like its sibling `takeover_check`) — resolved in F-tool3 below.
-- **F-tool2 — configured `_DNS_TIMEOUT` is honored in only one check** in
-  `domain_security`; most `dns.resolver.resolve` calls use the default resolver
-  with no explicit timeout. (`domain_security/scanner.py`) **Deferred** from #448:
-  the slow real-network `test_domain_security.py` patches `scanner.dns` with
-  fixed-signature fakes, so adding a `lifetime=` kwarg needs validating against
-  that suite — its own PR.
+- **F-tool2 — ~~configured `_DNS_TIMEOUT` honored in only one check~~ — FIXED
+  (#450).** Added `lifetime=_DNS_TIMEOUT` to all six `dns.resolver.resolve` calls
+  in `domain_security` (was applied only to the lame-delegation `dns.query.udp`);
+  a slow/hung authoritative server can no longer stall a scan past the configured
+  bound. The two DNSSEC test mocks bound to `scanner.dns.resolver.resolve` now
+  take `**kwargs` to tolerate the new arg.
 - **F-tool3 — ~~`cloud_assets` skips on missing binary~~ — FIXED (#449).**
   Dropped the upfront `shutil.which → []` silent skip; a missing/timed-out
   `cloud_enum` now raises `ToolBinaryMissing`/`ToolTimeout` and propagates (the

--- a/tests/unit/test_domain_security.py
+++ b/tests/unit/test_domain_security.py
@@ -102,7 +102,7 @@ class TestDNSChecks:
         from apps.domain_security.scanner import _check_dnssec
         session = self._make_session(db)
 
-        def mock_resolve(domain, rdtype):
+        def mock_resolve(domain, rdtype, **kwargs):  # **kwargs tolerates lifetime=
             if rdtype == "DNSKEY":
                 return [MagicMock()]
             raise Exception("no DS")
@@ -121,7 +121,7 @@ class TestDNSChecks:
         from apps.domain_security.scanner import _check_dnssec
         session = self._make_session(db)
 
-        def mock_resolve(domain, rdtype):
+        def mock_resolve(domain, rdtype, **kwargs):  # **kwargs tolerates lifetime=
             if rdtype == "DS":
                 return [MagicMock()]
             raise Exception("no DNSKEY")


### PR DESCRIPTION
## What

Closes **F-tool2**. `domain_security`'s `_DNS_TIMEOUT` (`SCANNER_DNS_TIMEOUT`, default 5s) was applied to **only** the lame-delegation `dns.query.udp` probe — every other `dns.resolver.resolve()` used the default resolver with no explicit timeout, so a slow or hung authoritative nameserver could stall a scan well past the configured bound.

## Change
Added `lifetime=_DNS_TIMEOUT` to all six `dns.resolver.resolve` calls: the `_resolve` and `_get_txt_record` helpers plus the wildcard-A, NS-A, DNSKEY, and DS lookups.

## The test-mock care (why this was deferred from #448)
The slow real-network `test_domain_security.py` patches `scanner.dns` and binds fixed-signature fakes to `resolver.resolve.side_effect`. I updated the **two** DNSSEC mocks bound to `resolver.resolve` to take `**kwargs` so they tolerate the new `lifetime=` arg. The `_resolve`-bound mock (line 74) is **unchanged** — `_resolve`'s own signature didn't change, only the `dns.resolver.resolve` call inside it.

## Test
- Mocked DNSSEC path (the `resolver.resolve` mock) + CAA/wildcard/missing-NS from `test_domain_security.py`, and the full `test_domain_security_email.py` suite: **25 passed**; ruff clean.
- The slow real-network `test_domain_security.py` is **CI-excluded** by design; `lifetime=` is a standard dnspython kwarg, so real calls simply get a bounded timeout.

Ledger: F-tool2 → FIXED. All F-tool* consistency findings are now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)