### PR TITLE
fix: remove ?token= query-param auth on report endpoints (F-sec3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ commits to recover the reasoning.
     `dns.resolver.resolve` calls.
 
 ### Security
+- **Removed the `?token=<JWT>` query-param auth on report endpoints (F-sec3).**
+  The CSV/PDF report views accepted a JWT in the query string, which leaks into
+  browser history, `Referer` headers, server access logs, and proxy caches.
+  `_report_auth_required` now authenticates only via Django session or the
+  `Authorization: Bearer` header — both SPA report pages already send the header
+  (fetch+Blob, never in the URL), so nothing depended on the query-param path; a
+  token in the query string is now ignored.
 - **Fail fast on the default DB password in production (F-sec1).** `DB_PASSWORD`
   defaulted to `"openeasd"` with nothing stopping a `DEBUG=False` deploy from
   booting on it — a trivial foothold on the database that holds every scan

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -255,14 +255,14 @@ def _report_auth_required(view_func):
     """Accept auth in this order:
 
     1. Django session (request.user already authenticated)
-    2. ``Authorization: Bearer <token>`` header — preferred; React SPA uses
-       this via fetch + Blob for downloads
-    3. ``?token=<token>`` query param — DEPRECATED, retained for backward
-       compatibility only and slated for removal in a future release
+    2. ``Authorization: Bearer <token>`` header — the React SPA uses this via
+       fetch + Blob for downloads
 
-    The ``?token=`` path leaks JWTs into browser history, ``Referer`` headers,
-    server access logs, and proxy caches. The frontend no longer generates
-    such URLs; only manually constructed links exercise this path.
+    A ``?token=<token>`` query-param fallback was removed (F-sec3): it leaked
+    JWTs into browser history, ``Referer`` headers, server access logs, and
+    proxy caches. The frontend never generated such URLs (both report pages send
+    the Bearer header), so nothing depends on it — a token in the query string is
+    now ignored.
     """
     @functools.wraps(view_func)
     def wrapper(request, *args, **kwargs):
@@ -270,10 +270,7 @@ def _report_auth_required(view_func):
             return view_func(request, *args, **kwargs)
 
         auth_header = request.headers.get('Authorization', '')
-        if auth_header.startswith('Bearer '):
-            token = auth_header[7:]
-        else:
-            token = request.GET.get('token', '')
+        token = auth_header[7:] if auth_header.startswith('Bearer ') else ''
 
         if token:
             try:

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -378,9 +378,11 @@ blockers. Fixed items are struck through with the PR that closed them.
 - **F-sec2 — SECRET_KEY guard is skipped whenever `"pytest" in sys.modules`.** Any
   runtime that transitively imports pytest bypasses the production check.
   (`base.py:18,51`)
-- **F-sec3 — `?token=<JWT>` query-param auth on report endpoints** leaks JWTs into
-  history/Referer/access-logs. Documented as deprecated; still live.
-  (`apps/core/console/reports/views.py:276`)
+- **F-sec3 — ~~`?token=<JWT>` query-param auth on report endpoints~~ — FIXED
+  (#451).** Removed the query-param fallback in `_report_auth_required`; report
+  endpoints now authenticate only via Django session or the `Authorization:
+  Bearer` header (both SPA report pages already send the header via fetch+Blob,
+  so nothing depended on it). A token in the query string is now ignored.
 
 ### Medium — consistency / robustness
 

--- a/tests/unit/test_reports.py
+++ b/tests/unit/test_reports.py
@@ -138,9 +138,14 @@ class TestExportFindingsCsv:
                     HTTP_AUTHORIZATION=f"Bearer {token}")
         assert res.status_code == 200
 
-    def test_garbage_token_rejected(self, session, findings):
+    def test_query_param_token_ignored(self, session, findings, user):
+        # F-sec3: the ?token= query-param auth path was removed (it leaked JWTs
+        # into history/Referer/logs). Even a VALID token in the URL must NOT grant
+        # access — only the Authorization header (or a session) does.
+        from ninja_jwt.tokens import AccessToken
         c = Client()
-        res = c.get(f"/reports/{session.uuid}/csv/?token=not.a.jwt")
+        token = str(AccessToken.for_user(user))
+        res = c.get(f"/reports/{session.uuid}/csv/?token={token}")
         assert res.status_code in (302, 301)  # redirect to /login, not 200
 
     def test_deactivated_user_token_rejected(self, session, findings, user):


### PR DESCRIPTION
## What

Closes **F-sec3**. `_report_auth_required` (the CSV/PDF report views' auth decorator) accepted a JWT via `?token=` in the query string. A JWT in a URL **leaks into browser history, `Referer` headers, server access logs, and proxy caches** — a real token-exposure risk.

## Change
Dropped the `request.GET.get('token')` fallback. Report endpoints now authenticate **only** via Django session or the `Authorization: Bearer` header.

### Why it's safe
- Both SPA report pages (`ReportsPage`, `ScanDetailPage`) already send the **Bearer header** via fetch+Blob — their comments literally say *"never in the URL ... doesn't leak into browser history."*
- A repo-wide grep finds **no** code that generates a `?token=` report URL. The fallback was unused.
- Session auth (admin) and header auth (SPA) both remain.

## Test
Converted `test_garbage_token_rejected` → **`test_query_param_token_ignored`**: asserts a **valid** token passed via `?token=` is now *rejected* (redirect to `/login`, not 200), locking in that the leak-prone path is gone. The Bearer-header, unauthenticated-redirect, and deactivated-user tests are unchanged. `test_reports.py` **80 passed**; ruff clean.

Ledger: F-sec3 → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)