### PR TITLE
fix: guards skip only under the pytest runner, not importability (F-sec2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ commits to recover the reasoning.
     `dns.resolver.resolve` calls.
 
 ### Security
+- **Production guards skip only under the pytest runner, not mere importability
+  (F-sec2).** The SECRET_KEY and default-DB-password fail-fast guards skipped
+  whenever `"pytest" in sys.modules` — so any process that transitively imported
+  pytest (a dependency, a debug shell) silently disabled them. A new
+  `_under_pytest()` detects the test *runner* via the process entrypoint
+  (`sys.argv[0]`), so the guards still skip during `pytest` runs but fire
+  everywhere else. (Prod images install only `.[prod]`, so pytest isn't present
+  there anyway — this is defense-in-depth.)
 - **Removed the `?token=<JWT>` query-param auth on report endpoints (F-sec3).**
   The CSV/PDF report views accepted a JWT in the query string, which leaks into
   browser history, `Referer` headers, server access logs, and proxy caches.

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -375,9 +375,13 @@ blockers. Fixed items are struck through with the PR that closed them.
 - **F-sec1 — weak default DB credentials ship silently.** `DB_PASSWORD` defaults
   to `"openeasd"` with no fail-fast guard (unlike `SECRET_KEY`).
   (`openeasd/settings/base.py:210`)
-- **F-sec2 — SECRET_KEY guard is skipped whenever `"pytest" in sys.modules`.** Any
-  runtime that transitively imports pytest bypasses the production check.
-  (`base.py:18,51`)
+- **F-sec2 — ~~SECRET_KEY guard skipped whenever `"pytest" in sys.modules`~~ —
+  FIXED (#452).** Both the SECRET_KEY and DB-password guards now skip only under
+  the pytest *runner* — a new `_under_pytest()` checks the process entrypoint
+  (`sys.argv[0]` basename), not mere importability — so a transitive import of
+  pytest in a production process (a dependency, a debug shell) can no longer
+  disable a security guard. A subprocess regression test imports pytest *then*
+  settings with an insecure key + `DEBUG=False` and asserts it still aborts.
 - **F-sec3 — ~~`?token=<JWT>` query-param auth on report endpoints~~ — FIXED
   (#451).** Removed the query-param fallback in `_report_auth_required`; report
   endpoints now authenticate only via Django session or the `Authorization:

--- a/openeasd/settings/__init__.py
+++ b/openeasd/settings/__init__.py
@@ -23,6 +23,7 @@ from .base import (  # noqa: E402,F401
     _PROFILE_TUNING,
     _resolve_profile,
     _security_settings,
+    _under_pytest,
     _validate_db_password,
     _validate_secret_key,
 )

--- a/openeasd/settings/base.py
+++ b/openeasd/settings/base.py
@@ -44,11 +44,21 @@ def _validate_secret_key(secret_key: str, debug: bool) -> None:
         )
 
 
-# Skip enforcement under the test runner: pytest-django imports settings before
-# any conftest/env hook can set a key, and token-signing key strength is
-# irrelevant to tests. The logic itself is covered by unit tests that call
-# _validate_secret_key directly.
-if "pytest" not in sys.modules:
+def _under_pytest() -> bool:
+    """True only when the pytest runner is the actual process entrypoint.
+
+    The production fail-fast guards below skip under the test runner: pytest-django
+    imports settings before any conftest/env hook can provide real secrets, and
+    key/password strength is irrelevant to tests. We detect the *runner* via
+    ``sys.argv[0]`` rather than ``"pytest" in sys.modules`` (F-sec2) — a transitive
+    import of pytest in a production process (a dependency, a debug shell) must
+    never disable a security guard. The subprocess wiring tests run ``python -c``
+    (argv[0] != pytest), so the guards still fire there and prove it.
+    """
+    return os.path.basename(sys.argv[0] or "").startswith(("pytest", "py.test"))
+
+
+if not _under_pytest():
     _validate_secret_key(SECRET_KEY, DEBUG)
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="localhost,127.0.0.1").split(",")
@@ -235,10 +245,9 @@ else:
         }
     }
 
-# Skip under the test runner for the same reason as the SECRET_KEY guard: pytest
-# imports settings before any env hook can set one, and CI sets real DB_* values.
-# The logic is covered by unit + subprocess tests.
-if "pytest" not in sys.modules:
+# Skip under the test runner for the same reason as the SECRET_KEY guard (see
+# _under_pytest — runner-entrypoint detection, not mere importability).
+if not _under_pytest():
     _validate_db_password(bool(_DATABASE_URL), _DB_PASSWORD, DEBUG)
 
 # DBOS durable-execution system database. Checkpoints scan workflows/steps so a

--- a/tests/unit/test_settings_security.py
+++ b/tests/unit/test_settings_security.py
@@ -6,7 +6,7 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 from openeasd.settings import (
-    _validate_secret_key, _validate_db_password, _security_settings,
+    _validate_secret_key, _validate_db_password, _under_pytest, _security_settings,
     _resolve_profile, _PROFILE_TUNING,
 )
 
@@ -198,3 +198,44 @@ class TestDbPasswordGuardWiring:
         )
         assert result.returncode != 0, "settings booted with the default DB password + DEBUG=False"
         assert "ImproperlyConfigured" in result.stderr or "DB_PASSWORD" in result.stderr
+
+
+class TestPytestRunnerDetection:
+    """F-sec2: the production guards skip only under the pytest *runner*
+    (argv[0]), not merely because pytest is importable."""
+
+    def test_true_under_the_pytest_runner(self):
+        # This suite runs under pytest, so argv[0] is the pytest console script.
+        assert _under_pytest() is True
+
+    def test_false_for_non_pytest_entrypoints(self):
+        import sys
+        for argv0 in ("/usr/local/bin/gunicorn", "manage.py", "-c", ""):
+            with patch.object(sys, "argv", [argv0]):
+                assert _under_pytest() is False
+
+    def test_guard_fires_even_when_pytest_is_importable(self):
+        # The core F-sec2 regression: a process that merely imports pytest (a
+        # transitive dep, a debug shell) must NOT get the guard disabled — only
+        # the runner (argv[0]) skips it. Import pytest THEN settings with an
+        # insecure key + DEBUG=False in a subprocess; it must still abort.
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        env = {
+            **os.environ,
+            "SECRET_KEY": "django-insecure-change-me-in-production",
+            "DB_PASSWORD": "a-strong-db-password",
+            "DATABASE_URL": "",
+            "DEBUG": "False",
+        }
+        env.pop("PYTEST_CURRENT_TEST", None)
+        result = subprocess.run(
+            [sys.executable, "-c", "import pytest; import openeasd.settings"],
+            cwd=str(repo_root), env=env, capture_output=True, text=True,
+        )
+        assert result.returncode != 0, "guard was bypassed merely because pytest was importable"
+        assert "ImproperlyConfigured" in result.stderr or "SECRET_KEY" in result.stderr


### PR DESCRIPTION
## What

Closes **F-sec2**. The SECRET_KEY and default-DB-password fail-fast guards (`openeasd/settings/base.py`) skipped whenever `"pytest" in sys.modules` — so **any process that transitively imports pytest** (a dependency, a debug shell) silently disabled a production security guard.

## Change
New `_under_pytest()` detects the test **runner** via the process entrypoint (`os.path.basename(sys.argv[0])` starts with `pytest`/`py.test`), not mere importability. Both guards now gate on `not _under_pytest()`.

- Normal `pytest` / `uv run pytest` runs still skip — `argv[0]` is the pytest console script (verified: basename `pytest`).
- The subprocess wiring tests (`python -c …`, `argv[0] == "-c"`) still **fire** the guards, as they must.
- A production `gunicorn` / `manage.py` process — or one that merely `import pytest` — no longer skips.

Prod images install only `.[prod]` (no pytest), so this is **defense-in-depth**, but the old check was a genuine bypass primitive.

## Test
- `_under_pytest()` → True under the runner; False for `gunicorn`/`manage.py`/`-c`/empty argv.
- **Regression (the core F-sec2 proof):** a subprocess runs `python -c "import pytest; import openeasd.settings"` with an insecure `SECRET_KEY` + `DEBUG=False` and asserts it **still aborts** — i.e. importing pytest does not disable the guard.

`test_settings_security.py` **27 passed**; ruff clean. (CI test job runs with `DEBUG=True`, so it never depended on the skip regardless.)

Ledger: F-sec2 → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)