### PR TITLE
fix: centralize the domain-authorization gate into one predicate (F3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ commits to recover the reasoning.
     `dns.resolver.resolve` calls.
 
 ### Security
+- **Centralized the domain-authorization gate into one predicate (F3).** The
+  "is this domain authorized for active scanning?" check
+  (`DomainAuthorization.objects.filter(domain__name=X).exists()`) was hand-copied
+  in three places — the scan-start gate, the subscan gate, and the AI agent's
+  `gate_subscan_tools`. For a security gate, three copies are a drift hazard; they
+  now all call a single `DomainAuthorization.is_authorized(domain)` classmethod,
+  so any future change (e.g. authorization expiry) applies everywhere at once.
+  Behavior-preserving.
 - **Production guards skip only under the pytest runner, not mere importability
   (F-sec2).** The SECRET_KEY and default-DB-password fail-fast guards skipped
   whenever `"pytest" in sys.modules` — so any process that transitively imported

--- a/apps/core/console/ai/guard.py
+++ b/apps/core/console/ai/guard.py
@@ -44,8 +44,7 @@ def gate_subscan_tools(domain: str, tools: list[str]) -> tuple[list[str], str]:
         return [], "no known tools in the proposed set"
 
     if not is_passive_tool_set(known):
-        authorized = DomainAuthorization.objects.filter(domain__name=domain).exists()
-        if not authorized:
+        if not DomainAuthorization.is_authorized(domain):
             return [], "active tools require DomainAuthorization for this domain"
 
     return known, ""

--- a/apps/core/data/domains/models.py
+++ b/apps/core/data/domains/models.py
@@ -32,5 +32,17 @@ class DomainAuthorization(models.Model):
     authorized_by = models.CharField(max_length=255)
     auth_reference = models.CharField(max_length=500, blank=True)
 
+    @classmethod
+    def is_authorized(cls, domain_name: str) -> bool:
+        """Single source of truth for "may active tools scan this domain?".
+
+        The scan-start gate, the subscan gate, and the AI agent's
+        ``gate_subscan_tools`` must all answer this identically — it's a security
+        gate, and three hand-copied `.filter(...).exists()` checks would drift
+        (F3). Any change to what "authorized" means (e.g. an expiry check) now
+        lands in exactly one place.
+        """
+        return cls.objects.filter(domain__name=domain_name).exists()
+
     def __str__(self):
         return f"{self.domain.name} — {self.get_auth_type_display()}"

--- a/apps/core/engine/scans/api.py
+++ b/apps/core/engine/scans/api.py
@@ -321,7 +321,7 @@ def start_scan(request, data: ScanStartRequest):
     # otherwise the workflow's tools are used. Scheduled scans always keep the gate.
     if not _is_passive_only_scan(data.schedule_type, workflow, tools=tools):
         from apps.core.data.domains.models import DomainAuthorization
-        if not DomainAuthorization.objects.filter(domain__name=domain).exists():
+        if not DomainAuthorization.is_authorized(domain):
             raise HttpError(403, "Domain is not authorized for scanning")
 
     if data.schedule_type == "now":
@@ -648,7 +648,7 @@ def start_subscan(request, session_uuid: uuid.UUID, data: SubScanRequest):
     if not is_passive_tool_set(data.tools):
         from apps.core.data.domains.models import DomainAuthorization
         parent = get_object_or_404(ScanSession, uuid=str(session_uuid))
-        if not DomainAuthorization.objects.filter(domain__name=parent.domain).exists():
+        if not DomainAuthorization.is_authorized(parent.domain):
             raise HttpError(403, "Domain is not authorized for scanning")
 
     session = create_subscan_session(str(session_uuid), tools=data.tools)

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -254,8 +254,8 @@ fail the whole scan. Specifically:
   (`schedule_type="now"`) **all-passive** scan bypasses authorization. Every
   scheduled scan and any active tool keeps the gate. The scheduler and the AI
   agent (`guard.gate_subscan_tools`) **re-check authorization at execution time**
-  — a revoked authorization can never scan. (This rule is currently implemented
-  in three places — finding F3 — keep them in sync.)
+  — a revoked authorization can never scan. All three sites resolve authorization
+  through the single `DomainAuthorization.is_authorized(domain)` classmethod (F3).
 
 ### 7.2 Secrets at rest
 
@@ -393,9 +393,13 @@ blockers. Fixed items are struck through with the PR that closed them.
 - **F2 — `ai_triage` dedupe key blocks manual re-triage.** `triage-{0}` +
   return-existing returns the old handle, so a "manual re-triage" silently doesn't
   re-run. (`durable/workflows.py:63`, `durable/task.py:78`)
-- **F3 — the passive/active auth rule is implemented three times**
-  (`scans/api.py` start + subscan, `ai/guard.py`) — drift risk on a security gate.
-  Extract one shared predicate.
+- **F3 — ~~the passive/active auth rule is implemented three times~~ — FIXED
+  (#453).** The triplicated authorization check (`DomainAuthorization.objects
+  .filter(domain__name=X).exists()` in the scan-start gate, subscan gate, and AI
+  `gate_subscan_tools`) is now a single `DomainAuthorization.is_authorized(domain)`
+  classmethod — one source of truth for a security gate, so a future change
+  (e.g. authorization expiry) lands in one place. The passive-set predicate was
+  already shared (`is_passive_tool_set`).
 - **F4 — `_count_all_findings` returns 0 on any DB error** → a transient failure
   reports "0 findings" into `total_findings` and the reaper, reading as "clean."
   (`pipeline.py:159`)

--- a/tests/unit/test_domain_authorization.py
+++ b/tests/unit/test_domain_authorization.py
@@ -28,6 +28,18 @@ class TestDomainAuthorizationModel:
         assert auth.auth_type == "owner"
         assert auth.authorized_by == "Alice Smith"
 
+    def test_is_authorized_single_source_of_truth(self, domain):
+        # F3: the scan-start, subscan, and AI-agent gates all resolve "may active
+        # tools scan this domain?" through this one classmethod.
+        from apps.core.data.domains.models import DomainAuthorization
+        assert DomainAuthorization.is_authorized(domain.name) is False
+        assert DomainAuthorization.is_authorized("never-seen.example") is False
+        DomainAuthorization.objects.create(
+            domain=domain, auth_type="owner",
+            authorized_at=datetime.date(2026, 1, 15), authorized_by="Alice Smith",
+        )
+        assert DomainAuthorization.is_authorized(domain.name) is True
+
     def test_cascade_delete(self, domain):
         from apps.core.data.domains.models import DomainAuthorization
         DomainAuthorization.objects.create(


### PR DESCRIPTION
## What

Closes **F3**. The authorization check — *"is this domain authorized for active scanning?"* — `DomainAuthorization.objects.filter(domain__name=X).exists()` was **hand-copied in three places**:

- the scan-start gate (`scans/api.py`),
- the subscan gate (`scans/api.py`),
- the AI agent's `gate_subscan_tools` (`ai/guard.py`).

Three copies of a **security gate** are a drift hazard.

## Change
Added **`DomainAuthorization.is_authorized(domain_name)`** as the single source of truth and routed all three sites through it. **Behavior-preserving** (identical query) — and now a future change to what "authorized" means (e.g. an expiry check — see the open "authorization never expires" note) lands in exactly one place. The passive-set predicate was already shared (`is_passive_tool_set`), so it needed no change.

## Test
- New `test_is_authorized_single_source_of_truth` (false when absent / unknown domain, true once a row exists).
- The existing gate suites cover all three call paths unchanged: `test_domain_authorization` + `test_passive_scan` + `test_subscan` + `test_ai_guard` — **62 passed**; ruff clean.

Ledger: F3 → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)