### PR TITLE
fix: let manual AI re-triage actually re-run (F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **Manual AI re-triage actually re-runs now (F2).** The `ai_triage` durable task
+  deduped on `triage-{session_id}` with `return-existing`, so a second manual
+  re-triage returned the prior *completed* workflow and silently did nothing —
+  while the UI sat at "running". Dropped the dedupe (each manual run enqueues a
+  fresh workflow, matching `agent_step`), and moved the concurrency protection it
+  incidentally provided into the `/triage/<uuid>/run/` endpoint as an atomic
+  `select_for_update` in-flight guard (two near-simultaneous clicks → one run +
+  409). The automatic post-scan triage was unaffected (it runs inline, not via
+  this task).
 - **Tool consistency pass (F-tool1 / F-tool4 / config drift).** Aligned a few
   tool apps with the conventions their siblings already follow:
   - `domain_security` and `domain_probe` now wrap collect+analyze in

--- a/apps/core/console/ai/api.py
+++ b/apps/core/console/ai/api.py
@@ -225,11 +225,23 @@ def run_triage_now(request, session_uuid: uuid_lib.UUID):
         raise HttpError(400, "Enable analysis (with consent) on the AI Analysis page first.")
     if session.status in ("pending", "running"):
         raise HttpError(409, "Scan is still running — triage runs automatically when it finishes.")
-    if AITriage.objects.filter(session=session, status="running").exists():
-        raise HttpError(409, "A triage run is already in flight for this scan.")
 
-    # In-flight marker so the UI can poll; the task replaces it with the result.
-    AITriage.objects.update_or_create(session=session, defaults={"status": "running"})
+    # Atomic in-flight guard (F2): the ai_triage task no longer dedupes at the
+    # DBOS layer (that blocked legitimate re-runs), so two near-simultaneous
+    # re-run clicks must be serialized here instead. Lock the triage row (or
+    # create it) and flip to "running" in one transaction; a concurrent request
+    # then sees "running" and gets 409. The marker also lets the UI poll; the
+    # task replaces it with the result.
+    from django.db import transaction
+    with transaction.atomic():
+        triage, created = AITriage.objects.select_for_update().get_or_create(
+            session=session, defaults={"status": "running"}
+        )
+        if not created:
+            if triage.status == "running":
+                raise HttpError(409, "A triage run is already in flight for this scan.")
+            triage.status = "running"
+            triage.save(update_fields=["status"])
     enqueue_triage(session.id)
     return {"ok": True, "status": "running"}
 

--- a/apps/core/engine/durable/workflows.py
+++ b/apps/core/engine/durable/workflows.py
@@ -60,7 +60,12 @@ def run_scan_workflow(session_id: int) -> None:
     logger.info("[dbos] scan workflow complete for session %s", session_id)
 
 
-@durable_task("ai_triage", dedupe="triage-{0}")
+# No dedupe (F2): a "triage-{id}" deduplication_id with return-existing made a
+# manual re-triage return the prior (completed) workflow and silently no-op,
+# defeating the whole point of the re-run endpoint. Each manual run now enqueues
+# a fresh workflow; the API endpoint serializes concurrent runs atomically
+# (run_triage_now). Matches agent_step, which also carries no dedupe.
+@durable_task("ai_triage")
 def ai_triage(session_id: int) -> None:
     """Manual (re-)triage of a finished scan, durably (one-step task)."""
     from apps.core.console.ai.tasks import run_triage_and_summaries

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -187,9 +187,12 @@ fail the whole scan. Specifically:
   a uniform surface: `task(*args)` runs in-process (tests) and
   `task.delay(*args, dedupe_id=...)` durably enqueues. Multi-step work stays an
   explicit `@DBOS.workflow` with per-phase `@DBOS.step`s (the checkpoint unit).
-- **Every durable enqueue carries a stable `deduplication_id`** +
-  `duplication_policy: "return-existing"` — `scan-{session_id}`, `triage-{id}`,
-  etc. (But see finding F2 — the dedupe key must still allow an intended re-run.)
+- **A durable enqueue that must never double-run carries a stable
+  `deduplication_id`** + `duplication_policy: "return-existing"` (e.g.
+  `scan-{session_id}`). But **don't dedupe a re-runnable task**: `ai_triage`
+  dropped its `triage-{id}` dedupe (F2) because return-existing returned the
+  prior completed run and blocked legitimate manual re-triage — serialize
+  concurrency at the caller instead. Match the work to the policy.
 - **Idempotency**: setup steps use `get_or_create` /
   `bulk_create(ignore_conflicts=True)`. The alert dispatcher skips when a
   `status="sent"` Alert already exists, so a finalize replay can't double-notify.
@@ -390,9 +393,12 @@ blockers. Fixed items are struck through with the PR that closed them.
 
 ### Medium — consistency / robustness
 
-- **F2 — `ai_triage` dedupe key blocks manual re-triage.** `triage-{0}` +
-  return-existing returns the old handle, so a "manual re-triage" silently doesn't
-  re-run. (`durable/workflows.py:63`, `durable/task.py:78`)
+- **F2 — ~~`ai_triage` dedupe key blocks manual re-triage~~ — FIXED (#454).**
+  Dropped the `triage-{0}` dedupe (it returned the prior *completed* workflow via
+  return-existing, so a re-run silently no-op'd while the UI sat at "running").
+  Each manual run now enqueues a fresh workflow — matching `agent_step`, which
+  carries no dedupe — and the concurrency the dedupe incidentally provided moved
+  into the API as an atomic `select_for_update` in-flight guard (`run_triage_now`).
 - **F3 — ~~the passive/active auth rule is implemented three times~~ — FIXED
   (#453).** The triplicated authorization check (`DomainAuthorization.objects
   .filter(domain__name=X).exists()` in the scan-start gate, subscan gate, and AI

--- a/tests/unit/test_ai_api.py
+++ b/tests/unit/test_ai_api.py
@@ -270,6 +270,20 @@ class TestTriageRun:
         enqueue.assert_called_once_with(sess.id)
         assert AITriage.objects.get(session=sess).status == "running"
 
+    def test_rerun_after_completed_triage_reenqueues(self, auth_client, settings):
+        # F2: a finished (non-running) triage can be re-run — the endpoint
+        # re-marks it running and enqueues a fresh workflow. Previously the DBOS
+        # return-existing dedupe made the re-enqueue a silent no-op.
+        from apps.core.console.ai.models import AITriage
+        _activate(settings)
+        sess = _finished_session()
+        AITriage.objects.create(session=sess, status="complete")  # a prior run finished
+        with patch("apps.core.console.ai.tasks.enqueue_triage") as enqueue:
+            resp = _post(auth_client, f"/api/ai/triage/{sess.uuid}/run/", {})
+        assert resp.status_code == 200
+        enqueue.assert_called_once_with(sess.id)
+        assert AITriage.objects.get(session=sess).status == "running"
+
 
 @pytest.mark.django_db
 class TestTriageTask:

--- a/tests/unit/test_durable_task.py
+++ b/tests/unit/test_durable_task.py
@@ -80,7 +80,9 @@ def test_real_tasks_are_durable_tasks_with_expected_names():
 
     assert isinstance(workflows.ai_triage, DurableTask)
     assert workflows.ai_triage.name == "ai_triage"
-    assert workflows.ai_triage._dedupe == "triage-{0}"
+    # No dedupe (F2): a triage-{id} return-existing id blocked manual re-runs.
+    # Each manual run enqueues a fresh workflow; concurrency is guarded in the API.
+    assert workflows.ai_triage._dedupe is None
 
     assert isinstance(workflows.agent_step, DurableTask)
     assert workflows.agent_step.name == "agent_step"


### PR DESCRIPTION
## What

Closes **F2**. The `ai_triage` durable task deduped on `triage-{session_id}` with `return-existing`, so a **second manual re-triage returned the prior *completed* workflow and silently did nothing** — while `run_triage_now` had already flipped `AITriage` to `running`, leaving the UI stuck at "running" forever.

(The **automatic** post-scan triage was never affected — it runs *inline* via `hooks.py`, not through this DBOS task.)

## Change
- **Drop the dedupe** from `ai_triage` — each manual run enqueues a fresh workflow. This aligns it with `agent_step`, which already carries no dedupe.
- The dedupe was *incidentally* serializing concurrent double-clicks, so that protection **moves into the endpoint** as an atomic `select_for_update` + `get_or_create` in-flight guard: two near-simultaneous clicks → one run + 409, while a re-run after a previous run completed now works.

## Test
- `test_durable_task.py`: `ai_triage._dedupe is None` (was `"triage-{0}"`).
- `test_ai_api.py`: new `test_rerun_after_completed_triage_reenqueues` — a `complete` triage re-run returns 200, enqueues a fresh workflow, and flips status to `running`. Existing in-flight-409 / enqueue tests unchanged.
- `test_durable_task` + `test_ai_api` + `test_ai_orchestrator`: **62 passed**; ruff clean.

Ledger: F2 → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)