### PR TITLE
fix: make within-phase-group execution resume-idempotent (F1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **Phase-group execution resumes cleanly after a crash (F1b).** The per-phase
+  DBOS step re-runs the *whole* group on a crash-resume, but within-group
+  execution wasn't idempotent — a resume re-created `WorkflowStepResult` rows
+  (no `(run, tool)` unique constraint) and re-executed tools that had already
+  finished. `_run_single_step` now skips a tool that already reached a terminal
+  state and reuses a non-terminal (crashed "running") row instead of duplicating
+  it; `run_one_phase_group` skips already-terminal tools up front. Checkpointing
+  is no longer only at the group boundary.
 - **Manual AI re-triage actually re-runs now (F2).** The `ai_triage` durable task
   deduped on `triage-{session_id}` with `return-existing`, so a second manual
   re-triage returned the prior *completed* workflow and silently did nothing —

--- a/apps/core/engine/workflows/runner.py
+++ b/apps/core/engine/workflows/runner.py
@@ -61,13 +61,35 @@ def _run_single_step(run, session, tool: str, order: int) -> None:
     close_old_connections()
     from .registry import get_tool_produces_findings
 
-    step_result = WorkflowStepResult.objects.create(
-        run=run,
-        tool=tool,
-        order=order,
-        status="running",
-        started_at=django_tz.now(),
+    # Resume idempotency (F1b): the phase-group DBOS step re-runs the WHOLE group
+    # on a crash-resume. Don't re-execute a tool that already reached a terminal
+    # state, and reuse any non-terminal (crashed "running"/"pending") row rather
+    # than creating a duplicate — WorkflowStepResult has no (run, tool) unique
+    # constraint, so a naive create() would stack duplicates on every resume.
+    existing = (
+        WorkflowStepResult.objects.filter(run=run, tool=tool).order_by("id").first()
     )
+    if existing is not None and existing.status in ("completed", "failed", "skipped"):
+        return
+    if existing is not None:
+        step_result = existing
+        step_result.order = order
+        step_result.status = "running"
+        step_result.started_at = django_tz.now()
+        step_result.finished_at = None
+        step_result.error = ""
+        step_result.findings_count = 0
+        step_result.save(update_fields=[
+            "order", "status", "started_at", "finished_at", "error", "findings_count",
+        ])
+    else:
+        step_result = WorkflowStepResult.objects.create(
+            run=run,
+            tool=tool,
+            order=order,
+            status="running",
+            started_at=django_tz.now(),
+        )
 
     status = "completed"
     error_msg = ""
@@ -138,6 +160,18 @@ def run_one_phase_group(run, session, group: list, base_order: int) -> None:
     one checkpointed group at a time."""
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from django.conf import settings
+
+    # Resume (F1b): skip tools that already reached a terminal state this run, so a
+    # crash-resume doesn't re-dispatch them. _run_single_step is the authoritative
+    # guard; this just avoids spinning up threads/connections for already-done work.
+    done = set(
+        WorkflowStepResult.objects
+        .filter(run=run, tool__in=group, status__in=("completed", "failed", "skipped"))
+        .values_list("tool", flat=True)
+    )
+    group = [t for t in group if t not in done]
+    if not group:
+        return
 
     safe = getattr(settings, "SCAN_LOW_MEM_PARALLEL_SAFE", _LOW_MEM_PARALLEL_SAFE)
     low_mem = getattr(settings, "LOW_MEMORY", False)

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -365,10 +365,13 @@ blockers. Fixed items are struck through with the PR that closed them.
   replay duplicates nothing and `total_findings` stays stable. `build_insights`
   (`update_or_create` + prune) and the asset rollup (`get_or_create`) were
   verified already replay-safe.
-- **F1b — within-group tool execution is not idempotent.** `base_order` derives
-  from `WorkflowStepResult.count()+1`; a crash mid-group re-runs the whole group
-  and re-creates StepResults + re-executes already-run tools. Checkpointing is
-  only at the group boundary. (`pipeline.py:594-607`)
+- **F1b — ~~within-group tool execution is not idempotent~~ — FIXED (#455).**
+  `_run_single_step` is now idempotent on `(run, tool)`: on a crash-resume (the
+  phase-group DBOS step re-runs the whole group) a tool that already reached a
+  terminal state is skipped, and a non-terminal ("running"/"pending") row is
+  reused instead of duplicated. `run_one_phase_group` also skips already-terminal
+  tools up front so they aren't re-dispatched. Within-group execution now resumes
+  cleanly, not just at the group boundary.
 - **F7 — ~~notification config GET returns raw webhook URLs~~ — FIXED (#445).**
   `_serialize_config` now returns presence booleans + a `db|env|none` source per
   channel and never the URL; `save_config` adopts the None=unchanged /

--- a/tests/unit/test_workflow_runner.py
+++ b/tests/unit/test_workflow_runner.py
@@ -371,6 +371,44 @@ class TestWorkflowModel:
 
 
 # ---------------------------------------------------------------------------
+# Phase-group resume idempotency (F1b)
+# ---------------------------------------------------------------------------
+
+class TestPhaseGroupResume:
+    """A crash-resume re-runs the whole phase-group DBOS step, so within-group
+    execution must be idempotent: completed tools aren't re-executed and
+    StepResults aren't duplicated."""
+
+    def test_resume_skips_completed_tool_and_does_not_duplicate(self, transactional_db, run):
+        from apps.core.engine.workflows.runner import run_one_phase_group
+        runner = _mock_runner(return_value=[])
+        group = ["subfinder"]
+        with _patch_get_runner({"subfinder": runner}):
+            run_one_phase_group(run, run.session, group, base_order=1)
+            assert runner.call_count == 1
+            assert WorkflowStepResult.objects.filter(run=run, tool="subfinder").count() == 1
+            # Simulate the DBOS step re-running the same group after a crash-resume.
+            run_one_phase_group(run, run.session, group, base_order=2)
+        assert runner.call_count == 1  # NOT re-executed
+        rows = WorkflowStepResult.objects.filter(run=run, tool="subfinder")
+        assert rows.count() == 1       # NOT duplicated
+        assert rows.first().status == "completed"
+
+    def test_single_step_reuses_stale_running_row(self, transactional_db, run):
+        # A crash left a non-terminal "running" row; re-running reuses it (the
+        # tool genuinely didn't finish) instead of stacking a duplicate.
+        from apps.core.engine.workflows.runner import _run_single_step
+        WorkflowStepResult.objects.create(run=run, tool="subfinder", order=1, status="running")
+        runner = _mock_runner(return_value=[])
+        with _patch_get_runner({"subfinder": runner}):
+            _run_single_step(run, run.session, "subfinder", 1)
+        rows = WorkflowStepResult.objects.filter(run=run, tool="subfinder")
+        assert rows.count() == 1
+        assert rows.first().status == "completed"
+        assert runner.call_count == 1
+
+
+# ---------------------------------------------------------------------------
 # WorkflowStepResult
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Closes **F1b** (the last High). The per-phase DBOS step (`run_phase_group_for_session`) re-runs the **whole group** on a crash-resume, but within-group execution wasn't idempotent:

- `base_order` is derived from `WorkflowStepResult.count()+1`, and
- `_run_single_step` always `create()`d a new row (the model has **no `(run, tool)` unique constraint**),

so a worker crash mid-group → on resume the group re-ran, **re-creating StepResult rows and re-executing tools that had already finished**. Checkpointing was effectively only at the group boundary.

## Change
- **`_run_single_step` is now idempotent on `(run, tool)`**: a tool already in a terminal state (`completed`/`failed`/`skipped`) is skipped on resume; a non-terminal (`running`/`pending`) row left by a crash is **reused** (reset to running) rather than duplicated.
- **`run_one_phase_group` skips already-terminal tools up front**, so a resume doesn't even dispatch threads/connections for them (the authoritative guard stays in `_run_single_step`).

## Test
- `test_resume_skips_completed_tool_and_does_not_duplicate` — re-running a group after a tool completed doesn't re-execute it or duplicate its StepResult.
- `test_single_step_reuses_stale_running_row` — a crashed `running` row is reused, not stacked.
- `test_workflow_runner.py` **37** + `test_scan_flow`/`test_subscan`/`test_scheduler` **57** passed; ruff clean.

Ledger: F1b → FIXED — **all High findings now closed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)