### PR TITLE
fix: standardize 404 response shape across the API (F6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **Consistent 404 response shape across the API (F6).** `get_object_or_404`
+  misses rendered Django Ninja's default `{"detail": "Not Found"}`, a second
+  shape alongside the `{"error": {"code", "message"}}` envelope every
+  `HttpError` uses. Added a single `Http404` exception handler so all 404s —
+  current and future `get_object_or_404` call sites — render the standard
+  envelope (`{"error": {"code": "NOT_FOUND", …}}`).
 - **Phase-group execution resumes cleanly after a crash (F1b).** The per-phase
   DBOS step re-runs the *whole* group on a crash-resume, but within-group
   execution wasn't idempotent — a resume re-created `WorkflowStepResult` rows

--- a/apps/core/console/api/ninja.py
+++ b/apps/core/console/api/ninja.py
@@ -1,7 +1,7 @@
 """Central Django Ninja API instance for OpenEASD."""
 
 from django.conf import settings
-from django.http import HttpResponse, JsonResponse
+from django.http import Http404, HttpResponse, JsonResponse
 from ninja import NinjaAPI, Schema
 from ninja.errors import HttpError, ValidationError
 from ninja_jwt.routers.obtain import obtain_pair_router   # POST /pair, POST /refresh
@@ -30,6 +30,17 @@ def http_error_handler(request, exc):
     return JsonResponse(
         {"error": {"code": code, "message": str(exc.message)}},
         status=exc.status_code,
+    )
+
+
+@api.exception_handler(Http404)
+def not_found_handler(request, exc):
+    # get_object_or_404 raises django Http404, which Ninja renders as
+    # {"detail": "Not Found"} by default — a second 404 shape alongside
+    # HttpError(404, …). Render the standard envelope so every 404 matches (F6).
+    return JsonResponse(
+        {"error": {"code": "NOT_FOUND", "message": "Not found"}},
+        status=404,
     )
 
 

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -415,9 +415,11 @@ blockers. Fixed items are struck through with the PR that closed them.
 - **F5 — uncommented `except: pass` blocks** swallow failures in the status
   endpoint (`scans/api.py:588`), scheduled-list (`:681`), and apex-seed DNS
   (`pipeline.py:377`). Add `# noqa: BLE001` + a reason, or log.
-- **F6 — two 404 body shapes**: `get_object_or_404` renders `{"detail":...}` while
-  `HttpError(404,…)` renders the `{"error":{...}}` envelope. Standardize on the
-  envelope.
+- **F6 — ~~two 404 body shapes~~ — FIXED (#456).** Added a Ninja `Http404`
+  exception handler so a `get_object_or_404` miss renders the standard
+  `{"error":{"code":"NOT_FOUND",…}}` envelope instead of Ninja's default
+  `{"detail":"Not Found"}`. One handler covers every current and future
+  `get_object_or_404` call site — no per-endpoint rewrites.
 - **F-tool1 — ~~`domain_security`/`domain_probe` orchestrators have no top-level
   try/except~~ — FIXED (#448).** Both now wrap collect+analyze in
   `try/except → return []`, matching their passive Domain-Posture siblings

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -514,7 +514,13 @@ class TestScanDetail:
         assert "subdomains" in data
 
     def test_not_found(self, auth_client):
-        assert auth_client.get("/api/scans/00000000-0000-0000-0000-000000000000/").status_code == 404
+        res = auth_client.get("/api/scans/00000000-0000-0000-0000-000000000000/")
+        assert res.status_code == 404
+        # F6: a get_object_or_404 miss renders the standard error envelope, not
+        # Ninja's default {"detail": "Not Found"}.
+        body = res.json()
+        assert body["error"]["code"] == "NOT_FOUND"
+        assert "detail" not in body
 
     def test_no_n_plus_one_on_findings(self, auth_client, django_assert_max_num_queries, scan):
         """scan_detail must not issue one query per finding to resolve session.uuid."""


### PR DESCRIPTION
## What

Closes **F6**. `get_object_or_404` raises `django.http.Http404`, which Django Ninja renders as `{"detail": "Not Found"}` — a **second 404 shape** alongside the `{"error": {"code", "message"}}` envelope that every `HttpError(code, …)` uses. So API clients got two different 404 bodies depending on how a given endpoint was written.

## Change
Added a single `@api.exception_handler(Http404)` that renders the standard envelope:
```json
{"error": {"code": "NOT_FOUND", "message": "Not found"}}
```
One handler covers **every** current and future `get_object_or_404` call site (scans, domains, workflows, asset-inventory, …) — no per-endpoint rewrites, and new ones stay consistent automatically.

## Test
`test_not_found` now asserts the envelope (`error.code == "NOT_FOUND"`, no `detail` key). No existing test pinned the old `{"detail": …}` shape (all asserted status only). Full `test_api_endpoints` + `test_asset_inventory_api` + `test_subscan`: **142 passed**; ruff clean.

Ledger: F6 → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)