### PR TITLE
fix: review cleanup — honest error handling + de-dup (F4/F5/F-dup/comments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **Review cleanup: honest error handling + de-duplication (F4 / F5 / F-dup / comments).**
+  - **F4** — `_count_all_findings` no longer swallows a DB error into `0`
+    ("clean"): the error propagates so finalize fails honestly, and the stuck-scan
+    reaper guards its own recount so a hiccup leaves `total_findings` unchanged
+    rather than aborting the watchdog sweep or faking a 0.
+  - **F5** — the scan-status endpoint's bare `except: pass` is gone (it now
+    queries for the `WorkflowRun` instead of catching "no run yet", so a real DB
+    error surfaces); two other broad catches that already log / carry a reason
+    got the `# noqa: BLE001` convention tag.
+  - **F-dup** — `ai/context.py` dropped its private `_SEVERITY_ORDER` in favour of
+    the shared `apps.core.constants.SEVERITY_RANK` (behavior-preserving ordering).
+  - **Comments / frontend:** corrected the stale nuclei wall-clock-cap comment
+    (6h, not "2h"), the `asn_cluster` phase-vs-phase_group comment, and made
+    `Badge.jsx` derive its known-status set from the variant map (one source of
+    truth).
 - **Consistent 404 response shape across the API (F6).** `get_object_or_404`
   misses rendered Django Ninja's default `{"detail": "Not Found"}`, a second
   shape alongside the `{"error": {"code", "message"}}` envelope every

--- a/apps/asn_cluster/apps.py
+++ b/apps/asn_cluster/apps.py
@@ -9,8 +9,11 @@ class AsnClusterConfig(AppConfig):
     tool_meta = {
         "label": "Lookalike ASN Clustering",
         "runner": "apps.asn_cluster.scanner.run_asn_cluster",
-        # Late phase: it correlates typosquat's already-written lookalike findings,
-        # so it must run after phase 1. Sits with cve_intel in Prioritization order.
+        # Late phase (runs with cve_intel in phase 13): it correlates typosquat's
+        # already-written lookalike findings, so it must run after phase 1. It is
+        # grouped under "Brand Threat" (with typosquat), not cve_intel's
+        # "Prioritization" — phase (execution order) and phase_group (display
+        # category) are independent axes.
         "phase": 13,
         "phase_group": "Brand Threat",
         "requires": ["typosquat"],

--- a/apps/core/console/ai/context.py
+++ b/apps/core/console/ai/context.py
@@ -5,7 +5,8 @@ reviewable in one place. Descriptions are truncated hard: prompts carry the
 minimum needed to rank, not full report bodies.
 """
 
-_SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "info": 4}
+from apps.core.constants import SEVERITY_RANK  # critical=4 … info=0 (higher = more severe)
+
 _MAX_DESCRIPTION_CHARS = 300
 
 _SYSTEM_PROMPT = (
@@ -20,7 +21,7 @@ _SYSTEM_PROMPT = (
 def severity_counts(session) -> dict:
     from apps.core.data.findings.models import Finding
 
-    counts = {s: 0 for s in _SEVERITY_ORDER}
+    counts = {s: 0 for s in SEVERITY_RANK}
     for row in Finding.objects.filter(session=session).values_list("severity", flat=True):
         if row in counts:
             counts[row] += 1
@@ -40,7 +41,8 @@ def select_findings(session, cap: int) -> list:
         .exclude(severity="info")
         .select_related("port", "url")
     )
-    findings.sort(key=lambda f: (_SEVERITY_ORDER.get(f.severity, 9), f.id))
+    # Most-severe first (negate the rank, which is higher-is-worse), unknown last.
+    findings.sort(key=lambda f: (-SEVERITY_RANK.get(f.severity, -1), f.id))
     return findings[: max(cap, 0)]
 
 

--- a/apps/core/engine/scans/api.py
+++ b/apps/core/engine/scans/api.py
@@ -581,12 +581,12 @@ def scan_status(request, session_uuid: uuid.UUID):
         "urls": URL.objects.filter(session=session).count(),
     }
 
-    step_results = []
-    try:
-        run = session.workflow_run
-        step_results = list(run.step_results.order_by("order"))
-    except Exception:
-        pass
+    # No broad try/except here (F5): a pending scan simply has no WorkflowRun yet,
+    # so query for it rather than catching RelatedObjectDoesNotExist — that way a
+    # real DB error surfaces instead of being silently swallowed into "no steps".
+    from apps.core.engine.workflows.models import WorkflowRun
+    run = WorkflowRun.objects.filter(session=session).order_by("-id").first()
+    step_results = list(run.step_results.order_by("order")) if run is not None else []
 
     return {
         "session": {
@@ -678,7 +678,7 @@ def list_scheduled(request):
                 j["next_run_time"] or datetime.datetime.max.replace(tzinfo=datetime.timezone.utc),
             )
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 — broad by design: log and return what we have
         logger.exception("[list_scheduled] Failed to fetch scheduled jobs")
 
     return [

--- a/apps/core/engine/scans/pipeline.py
+++ b/apps/core/engine/scans/pipeline.py
@@ -172,19 +172,21 @@ def _check_coverage_regression(session):
 
 
 def _count_all_findings(session) -> int:
-    try:
-        from apps.core.data.findings.models import Finding
-        # Exclude the scan_coverage meta-warning — it's a finalize-generated
-        # marker, not a real attack-surface finding. Excluding it keeps the count
-        # stable across a finalize replay (F1): on the first pass the warning
-        # doesn't exist yet, so a replay would otherwise count N+1.
-        return (
-            Finding.objects.filter(session=session)
-            .exclude(source="scan_coverage")
-            .count()
-        )
-    except Exception:
-        return 0
+    from apps.core.data.findings.models import Finding
+    # Exclude the scan_coverage meta-warning — it's a finalize-generated marker,
+    # not a real attack-surface finding. Excluding it keeps the count stable
+    # across a finalize replay (F1): on the first pass the warning doesn't exist
+    # yet, so a replay would otherwise count N+1.
+    #
+    # No broad `except -> return 0` (F4): a DB error must NOT masquerade as
+    # "0 findings / clean". Let it propagate so finalize fails honestly (the
+    # reaper, the only other caller, guards its own call so a hiccup there can't
+    # abort the watchdog sweep).
+    return (
+        Finding.objects.filter(session=session)
+        .exclude(source="scan_coverage")
+        .count()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -401,7 +403,7 @@ def _seed_apex_into_assets(session) -> None:
                 if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
                     continue
                 public_ips.append((ip_str, ip.version))
-        except Exception:
+        except Exception:  # noqa: BLE001
             # NXDOMAIN, no answer, timeout — all benign; just leave IPs unresolved.
             continue
 

--- a/apps/core/engine/scheduler/scheduler.py
+++ b/apps/core/engine/scheduler/scheduler.py
@@ -254,8 +254,18 @@ def reap_stuck_scans():
         # total_findings is still 0 even though completed steps wrote Findings.
         # Recompute it here so reaped scans show their real count, not 0.
         from apps.core.engine.scans.pipeline import _count_all_findings
-        session.total_findings = _count_all_findings(session)
-        session.save(update_fields=["status", "end_time", "total_findings"])
+        save_fields = ["status", "end_time"]
+        try:
+            session.total_findings = _count_all_findings(session)
+            save_fields.append("total_findings")
+        except Exception:  # noqa: BLE001 — a count hiccup must not abort the sweep
+            # Leave total_findings as-is (don't fake a 0); the scan is already
+            # labeled partial/failed, so a stale count here isn't misread as clean.
+            logger.warning(
+                "[watchdog] could not recount findings for scan %s — leaving total_findings unchanged",
+                session.id, exc_info=True,
+            )
+        session.save(update_fields=save_fields)
 
         if new_status == "partial":
             partial_count += 1

--- a/apps/nuclei/collector.py
+++ b/apps/nuclei/collector.py
@@ -20,21 +20,20 @@ from apps.core.engine.workflows.proc import run_capped
 
 logger = logging.getLogger(__name__)
 
-# Wall-clock cap for the whole nuclei run. Raised from 30m to 2h: on real
-# web-bearing targets nuclei is the single highest-value tool (tens of findings
-# each) but the old 30m wall SIGKILL'd it at ~4% done, reporting a false 0.
-# Time is not the constraint here — value and not
-# missing findings are — and this stays under the 4h worker/watchdog budget
-# even with nuclei_network (1h) also in the Full Scan. If a very large target
-# still exceeds it, the collector DELIVERS the partial findings nuclei already
-# wrote (run_capped carries them on TimeoutExpired.output) rather than discarding
-# them — a time-boxed run is a worthwhile result, and its findings are saved.
+# Wall-clock cap for the whole nuclei run (fallback; settings.NUCLEI_TIMEOUT
+# overrides). On real web-bearing targets nuclei is the single highest-value tool
+# (tens of findings each), so the cap is generous: a too-tight wall SIGKILL'd it
+# early and reported a false 0. Value, not time, is the constraint. If a very
+# large target still exceeds the cap, the collector DELIVERS the partial findings
+# nuclei already wrote (run_capped carries them on TimeoutExpired.output) rather
+# than discarding them — a time-boxed run is a worthwhile result, and its findings
+# are saved.
 TIMEOUT = 21600       # fallback wall-clock cap (6h); settings.NUCLEI_TIMEOUT overrides
 REQUEST_TIMEOUT = 5   # seconds per HTTP request (nuclei -timeout)
 # Lowered 150 -> 100 to be gentler on targets. Observed hosts already self-
 # throttle to ~85-95 rps so this rarely binds, but it caps load on hosts that
 # could absorb more. 100 rps still completes the full template set on a
-# large-target worst case (~330k requests) well within the 2h cap.
+# large-target worst case (~330k requests) well within the wall-clock cap.
 RATE_LIMIT = 100      # fallback -rate-limit; the resource profile overrides it
 CONCURRENCY = 25      # fallback -c; the resource profile overrides it
 # Actual values come from settings.NUCLEI_CONCURRENCY / NUCLEI_RATE_LIMIT, which

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -409,12 +409,16 @@ blockers. Fixed items are struck through with the PR that closed them.
   classmethod — one source of truth for a security gate, so a future change
   (e.g. authorization expiry) lands in one place. The passive-set predicate was
   already shared (`is_passive_tool_set`).
-- **F4 — `_count_all_findings` returns 0 on any DB error** → a transient failure
-  reports "0 findings" into `total_findings` and the reaper, reading as "clean."
-  (`pipeline.py:159`)
-- **F5 — uncommented `except: pass` blocks** swallow failures in the status
-  endpoint (`scans/api.py:588`), scheduled-list (`:681`), and apex-seed DNS
-  (`pipeline.py:377`). Add `# noqa: BLE001` + a reason, or log.
+- **F4 — ~~`_count_all_findings` returns 0 on any DB error~~ — FIXED (#457).**
+  Dropped the `except → return 0` swallow: a count failure now propagates so
+  finalize fails honestly instead of recording "0 findings / completed". The
+  reaper (the only other caller) guards its own recount so a hiccup there leaves
+  `total_findings` unchanged (never a fake 0) rather than aborting the sweep.
+- **F5 — ~~uncommented `except: pass` blocks~~ — FIXED (#457).** The status
+  endpoint's bare `except` was removed entirely (query for the `WorkflowRun`
+  instead of catching `RelatedObjectDoesNotExist`, so a real DB error surfaces);
+  the scheduled-list and apex-seed broad catches — which already log / carry a
+  reason — got the `# noqa: BLE001` tag to match the convention.
 - **F6 — ~~two 404 body shapes~~ — FIXED (#456).** Added a Ninja `Http404`
   exception handler so a `get_object_or_404` miss renders the standard
   `{"error":{"code":"NOT_FOUND",…}}` envelope instead of Ninja's default
@@ -462,13 +466,18 @@ blockers. Fixed items are struck through with the PR that closed them.
   (`credentials/models.py:24`)
 - **F8 — Python-side full-table aggregation** in `_detect_deltas` /
   `_compute_coverage` is fine now but should move DB-side as finding volume grows.
-- **F-dup — severity orderings defined 4× independently** (`SEVERITY_LEVELS`,
-  `SEVERITY_RANK`, `_SEVERITY_ORDER`, `_SEV_RANK`) and the
-  `source:check_type:title` identity key is built inline in three places.
-  Consolidate into shared helpers.
-- **F-misc — stale comments / config drift**: `nuclei` timeout comments say
-  "30m→2h" but the value is 6h; `asn_cluster` comment says "Prioritization" but
-  `phase_group="Brand Threat"`; ~~several tool `apps.py` omit
-  `default_auto_field`~~ (FIXED #448 — the 6 that omitted it now set it);
-  `Badge.jsx` lists status keys twice; `axiosInstance.js` imports `router.jsx`
-  (near-circular — prefer a navigation callback).
+- **F-dup — severity orderings** — mostly already consolidated in
+  `apps/core/constants.py` (`SEVERITY_RANK` / `SEVERITY_LEVELS`, imported by
+  scans/insights/dispatcher). The last straggler, `ai/context.py`'s private
+  `_SEVERITY_ORDER`, now uses the shared `SEVERITY_RANK` too (FIXED #457). Still
+  open: the `source:check_type:title` identity key is built inline in three
+  places (reports/views.py ×2, dispatcher.py) — a small shared helper.
+- **F-misc — stale comments / config drift**: ~~`nuclei` timeout comments say
+  "30m→2h" but the value is 6h~~ (FIXED #457); ~~`asn_cluster` comment says
+  "Prioritization" but `phase_group="Brand Threat"`~~ (FIXED #457); ~~several
+  tool `apps.py` omit `default_auto_field`~~ (FIXED #448); ~~`Badge.jsx` lists
+  status keys twice~~ (FIXED #457 — `KNOWN` is derived from the variant map);
+  `axiosInstance.js` imports `router.jsx` (near-circular — prefer a navigation
+  callback; its own PR). *Separately surfaced:* the nuclei wall-clock cap is 6h
+  while the worker/watchdog budget is ~4h — a real value question, not a comment
+  tidy; left for a dedicated look.

--- a/frontend/src/components/Badge.jsx
+++ b/frontend/src/components/Badge.jsx
@@ -2,44 +2,42 @@ import React from 'react';
 import { cva } from 'class-variance-authority';
 import { cn } from '../lib/utils.js';
 
+const VARIANT_CLASSES = {
+  critical:       'bg-red-900/40 text-red-400 border-red-800',
+  high:           'bg-orange-900/40 text-orange-400 border-orange-800',
+  medium:         'bg-yellow-900/40 text-yellow-400 border-yellow-800',
+  low:            'bg-blue-900/40 text-blue-400 border-blue-800',
+  info:           'bg-gray-800/60 text-gray-400 border-gray-700',
+  pending:        'bg-gray-800/60 text-gray-400 border-gray-700',
+  running:        'bg-blue-900/40 text-blue-400 border-blue-800',
+  completed:      'bg-green-900/40 text-green-400 border-green-800',
+  partial:        'bg-amber-900/40 text-amber-400 border-amber-800',
+  failed:         'bg-red-900/40 text-red-400 border-red-800',
+  cancelled:      'bg-gray-800/60 text-gray-400 border-gray-700',
+  scheduled:      'bg-yellow-900/40 text-yellow-400 border-yellow-800',
+  open:           'bg-red-900/40 text-red-400 border-red-800',
+  acknowledged:   'bg-yellow-900/40 text-yellow-400 border-yellow-800',
+  in_progress:    'bg-blue-900/40 text-blue-400 border-blue-800',
+  resolved:       'bg-green-900/40 text-green-400 border-green-800',
+  false_positive: 'bg-gray-800/60 text-gray-400 border-gray-700',
+  active:         'bg-green-900/40 text-green-400 border-green-800',
+  inactive:       'bg-gray-800/60 text-gray-400 border-gray-700',
+  idle:           'bg-gray-800/60 text-gray-400 border-gray-700',
+  web:            'bg-blue-900/40 text-blue-400 border-blue-800',
+  fallback:       'bg-gray-800/60 text-gray-400 border-gray-700',
+};
+
 const badgeVariants = cva(
   'inline-flex items-center rounded px-2 py-0.5 text-xs font-semibold capitalize border',
   {
-    variants: {
-      variant: {
-        critical:       'bg-red-900/40 text-red-400 border-red-800',
-        high:           'bg-orange-900/40 text-orange-400 border-orange-800',
-        medium:         'bg-yellow-900/40 text-yellow-400 border-yellow-800',
-        low:            'bg-blue-900/40 text-blue-400 border-blue-800',
-        info:           'bg-gray-800/60 text-gray-400 border-gray-700',
-        pending:        'bg-gray-800/60 text-gray-400 border-gray-700',
-        running:        'bg-blue-900/40 text-blue-400 border-blue-800',
-        completed:      'bg-green-900/40 text-green-400 border-green-800',
-        partial:        'bg-amber-900/40 text-amber-400 border-amber-800',
-        failed:         'bg-red-900/40 text-red-400 border-red-800',
-        cancelled:      'bg-gray-800/60 text-gray-400 border-gray-700',
-        scheduled:      'bg-yellow-900/40 text-yellow-400 border-yellow-800',
-        open:           'bg-red-900/40 text-red-400 border-red-800',
-        acknowledged:   'bg-yellow-900/40 text-yellow-400 border-yellow-800',
-        in_progress:    'bg-blue-900/40 text-blue-400 border-blue-800',
-        resolved:       'bg-green-900/40 text-green-400 border-green-800',
-        false_positive: 'bg-gray-800/60 text-gray-400 border-gray-700',
-        active:         'bg-green-900/40 text-green-400 border-green-800',
-        inactive:       'bg-gray-800/60 text-gray-400 border-gray-700',
-        idle:           'bg-gray-800/60 text-gray-400 border-gray-700',
-        web:            'bg-blue-900/40 text-blue-400 border-blue-800',
-        fallback:       'bg-gray-800/60 text-gray-400 border-gray-700',
-      },
-    },
+    variants: { variant: VARIANT_CLASSES },
     defaultVariants: { variant: 'fallback' },
   }
 );
 
-const KNOWN = new Set([
-  'critical','high','medium','low','info','pending','running','completed','partial','failed',
-  'cancelled','scheduled','open','acknowledged','in_progress','resolved',
-  'false_positive','active','inactive','idle','web',
-]);
+// Derived from the variant map — single source of truth, so adding a variant
+// above is recognized automatically (no second hand-maintained list to drift).
+const KNOWN = new Set(Object.keys(VARIANT_CLASSES).filter(k => k !== 'fallback'));
 
 export function Badge({ value, label }) {
   const key     = value ?? '—';

--- a/tests/unit/test_coverage_regression.py
+++ b/tests/unit/test_coverage_regression.py
@@ -173,6 +173,21 @@ class TestCoverageRegressionReport:
 
 
 @pytest.mark.django_db
+class TestCountAllFindings:
+    def test_propagates_db_error_not_fake_zero(self):
+        # F4: a DB error while counting must NOT be swallowed into 0 (which reads
+        # as a clean scan) — it propagates so finalize fails honestly.
+        from unittest.mock import patch
+        from django.db import DatabaseError
+        from apps.core.engine.scans.pipeline import _count_all_findings
+        s = _session()
+        with patch("apps.core.data.findings.models.Finding.objects.filter",
+                   side_effect=DatabaseError("boom")):
+            with pytest.raises(DatabaseError):
+                _count_all_findings(s)
+
+
+@pytest.mark.django_db
 class TestFinalizeReplayIdempotency:
     """F1: finalize is a replayable DBOS step. Running it twice (a worker crash
     after side effects but before the step checkpoints, then resume) must NOT

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -43,6 +43,20 @@ class TestReapStuckScans:
         assert session.status == "failed"
         assert session.end_time is not None
 
+    def test_survives_count_error(self, db):
+        # F4: _count_all_findings now raises on a DB error (instead of returning a
+        # fake 0). The watchdog sweep must still complete — mark the scan and
+        # leave total_findings unchanged — rather than crash on one bad count.
+        from unittest.mock import patch
+        session = self._make_session("running", SCAN_TIMEOUT_MINUTES + 1)
+        with patch("apps.core.engine.scans.pipeline._count_all_findings",
+                   side_effect=Exception("db down")):
+            count = reap_stuck_scans()
+        assert count == 1
+        session.refresh_from_db()
+        assert session.status == "failed"
+        assert session.end_time is not None
+
     def test_reaps_pending_scan_past_timeout(self, db):
         session = self._make_session("pending", SCAN_TIMEOUT_MINUTES + 1)
         count = reap_stuck_scans()


### PR DESCRIPTION
## What

Bundles the remaining small review-ledger findings into one cleanup PR (per request to fold the low-hygiene items together).

- **F4 — no fake-clean on a DB error.** `_count_all_findings` dropped its `except Exception: return 0`; a count failure now propagates so finalize fails honestly instead of recording `completed, 0 findings`. The stuck-scan **reaper** (the only other caller) wraps its own recount so a hiccup leaves `total_findings` unchanged — never a fake 0 — rather than aborting the watchdog sweep.
- **F5 — `except: pass` hygiene.** The scan-status endpoint's **bare `except: pass` is removed** — it queries for the `WorkflowRun` instead of catching `RelatedObjectDoesNotExist`, so a genuine DB error surfaces. The scheduled-list and apex-seed broad catches (which already log / carry a reason) got the `# noqa: BLE001` convention tag.
- **F-dup — severity ordering.** `ai/context.py` dropped its private `_SEVERITY_ORDER` for the shared `apps.core.constants.SEVERITY_RANK` (behavior-preserving — same most-severe-first order, unknown last).
- **Comments / frontend.** Fixed the stale nuclei wall-clock-cap comment (6h, not "2h"), the `asn_cluster` phase-vs-`phase_group` comment, and made `Badge.jsx` derive its known-status `Set` from the variant map (one source of truth).

## Kept out deliberately (flagged, not low-hygiene)
- **F-bug1** (`github_secret`): a *reserved, unused* field — removing it needs a **DB migration** + API/frontend/tests. Own decision.
- **axiosInstance.js** near-circular `router.jsx` import: a frontend **auth-flow refactor**.
- The `source:check_type:title` identity-key dedup (small shared helper).
- **Surfaced separately:** the nuclei wall-clock cap is **6h while the worker/watchdog budget is ~4h** — a real value question, not a comment tidy.

## Test
New: F4 count **propagates** a DB error (not `0`); reaper **survives** a count error and still marks the scan. Plus existing status / `ai_context` / scheduler suites. **Backend 209 + frontend 32 passed**; ruff clean.

Ledger: F4, F5, F-dup, and the stale-comment/Badge items → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)