### PR TITLE
fix: typosquat handles multi-label ccTLD domains (PSL/ccTLD)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Fixed
+- **typosquat now handles multi-label ccTLD domains (PSL/ccTLD).** The apex was
+  split by a naive last dot, so `example.co.uk` became name=`example.co` /
+  tld=`uk` — TLD-swap then emitted garbage like `example.co.com` (which never
+  resolves) and char-mutations mangled the suffix, so **ccTLD targets got
+  effectively no lookalike detection**. `_split_apex` now recognises common
+  multi-label public suffixes (`co.uk`, `com.au`, `co.in`, …) and splits on the
+  registrable label, so `example.co.uk` → `("example", "co.uk")` and TLD-swap
+  yields real lookalikes (`example.com`, `example.net`, …). Curated set (not the
+  full ~9k-entry PSL — keeps the worker dependency-free and offline); extend via
+  `TYPOSQUAT_MULTI_LABEL_SUFFIXES`.
 - **Review cleanup: honest error handling + de-duplication (F4 / F5 / F-dup / comments).**
   - **F4** — `_count_all_findings` no longer swallows a DB error into `0`
     ("clean"): the error propagates so finalize fails honestly, and the stuck-scan
@@ -125,9 +135,8 @@ commits to recover the reasoning.
     registrar/parking ASNs — AWS/Cloudflare/Google/Namecheap/etc.) where
     millions of unrelated domains co-locate, *unless* the cluster contains a
     weaponized member. Overridable via `ASN_CLUSTER_GENERIC_ASNS`.
-  - Known limitation still open: the apex is split by last-dot, not the Public
-    Suffix List, so TLD-swap candidates are wrong for multi-label ccTLDs
-    (`example.co.uk` → `example.co.com`). Tracked separately.
+  - (The multi-label-ccTLD apex-split limitation noted here originally is now
+    fixed — see "typosquat now handles multi-label ccTLD domains" below.)
 
 ## [v2.15.0] — 2026-09-11
 

--- a/apps/typosquat/collector.py
+++ b/apps/typosquat/collector.py
@@ -130,17 +130,51 @@ _KEYBOARD = {
 }
 
 
-def _split_apex(domain: str) -> tuple[str, str]:
-    """Split an apex domain into (name, tld). A leading ``www.`` is stripped.
+# Common multi-label public suffixes — ccTLD second-level registries. NOT the
+# full ~9k-entry Public Suffix List: a curated set of the ones real targets use,
+# which keeps us dependency-free (tldextract fetches the PSL over the network by
+# default — a scanner worker shouldn't). Override/extend via
+# settings.TYPOSQUAT_MULTI_LABEL_SUFFIXES.
+_MULTI_LABEL_SUFFIXES = (
+    "co.uk", "org.uk", "gov.uk", "ac.uk", "me.uk", "net.uk", "ltd.uk", "plc.uk", "sch.uk",
+    "com.au", "net.au", "org.au", "edu.au", "gov.au", "id.au",
+    "co.nz", "net.nz", "org.nz", "govt.nz",
+    "co.za", "org.za", "net.za", "web.za",
+    "co.in", "net.in", "org.in", "firm.in", "gen.in", "ind.in",
+    "co.jp", "or.jp", "ne.jp", "ac.jp", "go.jp",
+    "com.br", "net.br", "org.br", "gov.br",
+    "com.cn", "net.cn", "org.cn", "gov.cn",
+    "co.kr", "or.kr",
+    "com.sg", "com.my", "com.hk", "com.tw", "com.mx", "com.tr", "com.ar",
+    "com.ua", "com.ph", "com.pk", "com.ng", "co.id", "co.th", "com.vn", "com.sa",
+)
 
-    Uses a simple last-dot split: ``example.com`` → ``("example", "com")``. For a
-    multi-label public suffix (``example.co.uk``) the ``name`` keeps the inner
-    label(s); techniques mutate ``name`` and TLD swaps replace only the final
-    label. This is deliberately conservative — good enough for candidate seeding.
+
+def _split_apex(domain: str) -> tuple[str, str]:
+    """Split an apex domain into (registrable_name, public_suffix).
+
+    ``example.com`` → ``("example", "com")``; ``example.co.uk`` →
+    ``("example", "co.uk")``. A leading ``www.`` is stripped.
+
+    Multi-label public suffixes (ccTLD second-level registries) are recognised
+    from ``_MULTI_LABEL_SUFFIXES`` so char-mutation and TLD-swap operate on the
+    registrable label, not a partial suffix. The old last-dot split turned
+    ``example.co.uk`` into name=``example.co`` / tld=``uk`` and emitted garbage
+    candidates like ``example.co.net`` that never resolve — so ccTLD targets got
+    effectively no lookalike detection. Curated, not the full PSL — good enough
+    for candidate seeding.
     """
     d = (domain or "").strip().lower().rstrip(".")
     if d.startswith("www."):
         d = d[4:]
+
+    suffixes = getattr(settings, "TYPOSQUAT_MULTI_LABEL_SUFFIXES", _MULTI_LABEL_SUFFIXES)
+    for suffix in suffixes:
+        if d.endswith("." + suffix):
+            head = d[: -(len(suffix) + 1)]      # everything before ".<suffix>"
+            name = head.rsplit(".", 1)[-1]       # registrable label (drop sub-labels)
+            return (name, suffix) if name else (d, "")
+
     name, _, tld = d.rpartition(".")
     if not name:  # no dot at all — treat whole thing as the name, no tld
         return d, ""

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -446,6 +446,13 @@ blockers. Fixed items are struck through with the PR that closed them.
   among the raisers.
 - **F-tool4 — ~~`web_checker` hardcodes its own User-Agent~~ — FIXED (#448).**
   Now uses `settings.OPENEASD_USER_AGENT`, the shared honest UA.
+- **PSL/ccTLD — ~~typosquat apex split by last-dot, broken for multi-label
+  ccTLDs~~ — FIXED (#458).** `_split_apex` recognises common multi-label public
+  suffixes (`co.uk`, `com.au`, …) so `example.co.uk` → `("example", "co.uk")`
+  and TLD-swap/char-mutation operate on the registrable label (was emitting
+  non-resolving garbage like `example.co.com`, i.e. no ccTLD detection). Curated
+  set, not the full PSL — dependency-free/offline; extend via
+  `TYPOSQUAT_MULTI_LABEL_SUFFIXES`.
 - **F9 — local fixtures shadow `conftest.py`** in `test_api_endpoints.py` and
   `test_reports.py`; the two `auth_client`s differ subtly and can drift.
 - **F11 — brittle report tests** assert exact HTML/CSS/copy strings rather than

--- a/tests/unit/test_typosquat.py
+++ b/tests/unit/test_typosquat.py
@@ -103,13 +103,13 @@ class TestGenerateCandidates:
     def test_cctld_char_mutation_keeps_full_suffix(self):
         # Character techniques mutate the registrable label and keep the full
         # ".co.uk" suffix — the old last-dot split mutated the "co" label too.
+        # Use set-intersection (like the other technique tests) rather than
+        # `"host" in names`, which CodeQL misreads as URL-substring sanitization.
         names = {c["candidate"] for c in generate_candidates("example.co.uk")}
-        assert "xample.co.uk" in names      # omission on "example", suffix intact
-        assert "e-xample.co.uk" in names    # hyphenation on "example", suffix intact
-        # Garbage the old bug produced (mutating the "co" label) must be absent —
-        # exact set-membership checks, not host-substring matching.
-        assert "example.c.uk" not in names
-        assert "exampleco.uk" not in names
+        assert names & {"xample.co.uk"}     # omission on "example", suffix intact
+        assert names & {"e-xample.co.uk"}   # hyphenation on "example", suffix intact
+        # Garbage the old bug produced (mutating the "co" label) must be absent.
+        assert not (names & {"example.c.uk", "exampleco.uk"})
 
     def test_empty_domain_returns_empty(self):
         assert generate_candidates("") == []

--- a/tests/unit/test_typosquat.py
+++ b/tests/unit/test_typosquat.py
@@ -101,11 +101,15 @@ class TestGenerateCandidates:
         assert not any(n.startswith("example.co.") for n in names)  # no example.co.<tld> garbage
 
     def test_cctld_char_mutation_keeps_full_suffix(self):
-        # Character techniques mutate the registrable label and keep ".co.uk".
+        # Character techniques mutate the registrable label and keep the full
+        # ".co.uk" suffix — the old last-dot split mutated the "co" label too.
         names = {c["candidate"] for c in generate_candidates("example.co.uk")}
-        assert "xample.co.uk" in names          # omission on "example"
-        assert not any(".co.uk" not in n and n.endswith(".uk") for n in names
-                       if n.startswith("exampl"))  # suffix never mangled to bare .uk
+        assert "xample.co.uk" in names      # omission on "example", suffix intact
+        assert "e-xample.co.uk" in names    # hyphenation on "example", suffix intact
+        # Garbage the old bug produced (mutating the "co" label) must be absent —
+        # exact set-membership checks, not host-substring matching.
+        assert "example.c.uk" not in names
+        assert "exampleco.uk" not in names
 
     def test_empty_domain_returns_empty(self):
         assert generate_candidates("") == []

--- a/tests/unit/test_typosquat.py
+++ b/tests/unit/test_typosquat.py
@@ -85,6 +85,28 @@ class TestGenerateCandidates:
         assert names & {"example.net"}
         assert not (names & {"www.example.com"})
 
+    def test_split_apex_handles_multi_label_suffix(self):
+        from apps.typosquat.collector import _split_apex
+        assert _split_apex("example.com") == ("example", "com")
+        assert _split_apex("example.co.uk") == ("example", "co.uk")
+        assert _split_apex("mybank.com.au") == ("mybank", "com.au")
+        assert _split_apex("www.example.co.uk") == ("example", "co.uk")
+
+    def test_cctld_tld_swap_uses_registrable_name(self):
+        # PSL/ccTLD: the old last-dot split produced garbage like "example.co.net";
+        # the whole public suffix must be swapped, yielding real lookalikes.
+        names = {c["candidate"] for c in generate_candidates("example.co.uk")
+                 if c["technique"] == "tld_swap"}
+        assert {"example.com", "example.net", "example.org"} <= names
+        assert not any(n.startswith("example.co.") for n in names)  # no example.co.<tld> garbage
+
+    def test_cctld_char_mutation_keeps_full_suffix(self):
+        # Character techniques mutate the registrable label and keep ".co.uk".
+        names = {c["candidate"] for c in generate_candidates("example.co.uk")}
+        assert "xample.co.uk" in names          # omission on "example"
+        assert not any(".co.uk" not in n and n.endswith(".uk") for n in names
+                       if n.startswith("exampl"))  # suffix never mangled to bare .uk
+
     def test_empty_domain_returns_empty(self):
         assert generate_candidates("") == []
 


### PR DESCRIPTION
## What

Fixes the **PSL/ccTLD** bug surfaced during the amnic.com triage. `_split_apex` split the apex by a **naive last dot**, so `example.co.uk` became name=`example.co` / tld=`uk`. Consequences:
- **TLD-swap** emitted `example.co.com`, `example.co.net`, … — none of which resolve, so nothing was ever flagged.
- **Char-mutations** mangled the `.co` part of the suffix.

Net effect: **ccTLD targets (`.co.uk`, `.com.au`, `.co.in`, …) got effectively no lookalike/typosquat detection.**

## Change
`_split_apex` now recognises a **curated set of common multi-label public suffixes** and splits on the registrable label:
- `example.co.uk` → `("example", "co.uk")`, `mybank.com.au` → `("mybank", "com.au")`, `example.com` → `("example", "com")` (unchanged).
- TLD-swap swaps the **whole** public suffix → real lookalikes (`example.com`, `example.net`, `example.org`, …); char-mutations keep `.co.uk`.

**Why a curated set, not `tldextract`:** tldextract fetches the full Public Suffix List **over the network** by default — a scanner worker shouldn't depend on that. The curated set covers the ccTLDs real targets use, stays dependency-free and offline, and matches the codebase's curated-list idiom (`_COMMON_TLDS`, `_PARKING_IPS`). Extend via `settings.TYPOSQUAT_MULTI_LABEL_SUFFIXES`.

## Test
- `_split_apex` multi-label cases (+ `.com` unchanged, `www.` strip).
- ccTLD TLD-swap yields `{example.com, example.net, example.org}` with **no `example.co.<tld>` garbage**.
- char-mutation keeps the full `.co.uk` suffix.

`test_typosquat.py` **41 passed**; ruff clean.

Ledger: PSL/ccTLD → FIXED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)