### PR TITLE
chore: release v2.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.15.1] — 2026-09-11
+
 ### Fixed
 - **typosquat now handles multi-label ccTLD domains (PSL/ccTLD).** The apex was
   split by a naive last dot, so `example.co.uk` became name=`example.co` /
@@ -1682,7 +1684,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.15.0...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.15.1...HEAD
+[v2.15.1]: https://github.com/cybersecify/OpenEASD/compare/v2.15.0...v2.15.1
 [v2.15.0]: https://github.com/cybersecify/OpenEASD/compare/v2.14.2...v2.15.0
 [v2.14.2]: https://github.com/cybersecify/OpenEASD/compare/v2.14.1...v2.14.2
 [v2.14.1]: https://github.com/cybersecify/OpenEASD/compare/v2.14.0...v2.14.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.15.0 — 2026-09-11)
+## Status (v2.15.1 — 2026-09-11)
 
-- **Released**: v2.15.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.15.0` / `:v2.15` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.15.1 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.15.1` / `:v2.15` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 29 registered scan tools across 13 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.15.0"
+version = "2.15.1"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release cutting all the fix/ work merged since v2.15.0 (#443–#458). No new features or tools, so per the repo's semver rule this is a **patch** bump.

## Included (highlights)
- **Security:** F-sec1 (default DB-password fail-fast), F-sec2 (guards skip only under the pytest *runner*), F-sec3 (removed `?token=` JWT query-param on report endpoints), F3 (centralized `DomainAuthorization.is_authorized`).
- **Correctness/resilience:** F1 (finalize replay-idempotency), F1b (phase-group resume idempotency), F4 (no fake-clean on a DB error), F2 (manual AI re-triage re-runs), F6 (consistent 404 envelope).
- **Scan quality:** brand-threat false positives cut (parking / generic-ASN / brand-mention), typosquat multi-label ccTLD support (PSL/ccTLD).
- **Consistency/hygiene:** F-tool1–4, F5 except-hygiene, F-dup severity de-dup, stale-comment/Badge fixes, new `docs/CODING_STANDARDS.md`.

## Release mechanics
- `pyproject.toml` `2.15.0` → `2.15.1`
- CHANGELOG `[Unreleased]` → `[v2.15.1]` (dated) + compare-link footer
- CLAUDE.md status line → v2.15.1

After merge: tag `v2.15.1` on `main` and push it → the `publish` job builds & pushes `ghcr.io/cybersecify/openeasd-{web,worker}` at `:v2.15.1` / `:v2.15` / `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)