### PR TITLE
feat: restore Assets inventory UI + finding-centric UI-direction spec (PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **Assets inventory UI restored (asset-centric grounding).** Re-introduces the
+  persistent **Assets** page (list) + **Asset detail** page over the existing
+  `/api/assets/` layer, with a nav entry and `/assets` + `/assets/:id` routes.
+  The list filters by kind/status/domain/search, paginates, and shows per-asset
+  open-finding severity chips; the detail page shows metadata, findings, and the
+  scan timeline. This is step 1 of the finding-centric-grounded-on-asset-centric
+  UI direction (`docs/specs/2026-09-12-finding-centric-ui-direction.md`), which
+  supersedes the "strictly scan-centric" decision (#406). The `/api/assets/` data
+  layer was never removed — this is UI wiring only.
+
 ## [v2.15.1] — 2026-09-11
 
 ### Fixed

--- a/docs/specs/2026-09-12-finding-centric-ui-direction.md
+++ b/docs/specs/2026-09-12-finding-centric-ui-direction.md
@@ -1,0 +1,103 @@
+# Finding-Centric UI, Grounded on Asset-Centric — Direction Spec
+
+> **Status:** 🚧 In progress.
+> - PR1 — restore the **Assets inventory UI** (list + detail), nav + routes (the
+>   asset-centric grounding). *This PR.* The `/api/assets/` layer was never
+>   removed, so this is UI wiring only.
+> - PR2 — **persistent finding identity** (cross-scan Issue register + finalize
+>   rollup). *The make-or-break prerequisite for finding-centric.*
+> - PR3 — **Findings/Issues register UI** as the primary triage surface.
+> - PR4 — dashboard cross-links + a "changes since last scan" feed.
+>
+> **This decision supersedes #406** ("make the UI strictly scan-centric"), which
+> had removed the global Findings page and the Assets inventory pages. See
+> *Relationship to #406* below.
+
+## Goal
+
+Make the console **finding-centric, grounded on an asset-centric surface**, with
+scans as the supporting activity/history layer:
+
+- **Assets** (the attack surface: subdomains / IPs / ports / URLs) are the
+  durable, persistent spine — "what is exposed, since when, what changed."
+- **Findings/Issues** (what's wrong, ranked, with a lifecycle) are the primary
+  daily surface — "what do I fix / dismiss next."
+- **Scans** become the *activity/history* substrate — how the data was produced,
+  coverage/partial status, per-run deltas — not the organizing principle.
+
+Rationale (why not scan-centric): OpenEASD is a **continuous** External Attack
+Surface *Detection* platform (scheduled/monitoring scans, delta detection,
+exposure-score trends). The objects a single operator reasons about persist
+across scans — the surface and the issues on it. A scan is a point-in-time
+collection run; organizing the UI around it forces scan-hopping to answer every
+enduring question (as seen triaging the amnic.com false positives).
+
+## Relationship to #406 (explicit reversal)
+
+#406 deliberately went "strictly scan-centric": it removed the global Findings
+page, the Assets inventory pages (list + detail), their nav/routes, and the
+dashboard cards for them, and **moved finding triage into the Scan-Detail finding
+modal** — with the note that "removing the global Findings page loses no
+capability" because status stays editable there. The `/api/assets/` endpoints and
+the `asset_inventory` data layer were **left intact**.
+
+The gap that reversal left: **triage is scan-scoped and doesn't persist.**
+`Finding` rows are per-`session` (`status` defaults `open` each run), so
+dismissing a false positive in one scan's modal does not carry to the next scan —
+the same false positives re-appear every run. For a product whose day-to-day is
+*managing* recurring findings (exactly the amnic case), that is the wrong model.
+This spec restores the cross-scan surfaces **and** adds the persistence that #406
+never had (PR2), so the finding-centric view is durable, not re-noised each scan.
+
+## The make-or-break prerequisite: persistent finding identity (PR2)
+
+**Do not ship a finding-centric primary UI on per-scan findings.** Today a
+"false positive" dismissal lives on a per-scan `Finding` row and is lost on the
+next scan. Before the Findings register becomes the primary surface, findings
+need a **cross-scan identity** so triage sticks.
+
+**Chosen approach — a persistent `Issue` register, mirroring `asset_inventory`**
+(which already solves the identical problem for assets, with a finalize rollup):
+
+- New model keyed by `(domain, source, check_type, title[, asset])`, carrying
+  `first_seen` / `last_seen` / `status` (`open`/`acknowledged`/`resolved`/
+  `false_positive`) and a link to the latest `Finding` row.
+- Rolled up at finalize (reuse the `rollup_session` pattern + fail-graceful hook).
+- **`status` lives on the `Issue`, not the per-scan `Finding`.** Triage a false
+  positive once → it stays dismissed across scans; if a `resolved` issue's
+  finding reappears, the rollup re-opens it (regressed), while `false_positive`
+  and `acknowledged` persist.
+- Scope/group issues by `Finding.asset` — this is where "grounded on
+  asset-centric" pays off: "the issues on *this* exposed host."
+
+(A lighter interim — status carry-forward by key at finalize — is possible, but
+the `Issue` model is the consistent choice and reuses a proven pattern + tests.)
+
+## Coverage honesty (guardrail for PR3)
+
+A findings-first landing must never let an empty/short list read as "clean" when
+it is really low coverage or a partial scan — the same "never fake-clean"
+principle behind the coverage-regression finding and the F4 fix. The Findings
+register and dashboard must surface a **coverage / partial-scan banner**
+(endpoints probed vs blocked, WAF vendor, last-scan status) alongside the counts.
+
+## Phased delivery
+
+| PR | Scope | Risk |
+|----|-------|------|
+| **PR1** *(this)* | Restore Assets list + detail UI, nav + routes | Low — API intact, restores #339 code |
+| **PR2** | `Issue` model + finalize rollup + cross-scan status; tests | Medium — new model + migration |
+| **PR3** | Findings/Issues register UI (primary), ranked (severity + EPSS/KEV + AI triage), triage actions that persist; coverage banner | Medium |
+| **PR4** | Dashboard: asset KPI + issue summary + Finding→asset cross-links; "changes since last scan" feed | Low |
+
+Scans stay first-class as **Activity/History** throughout — starting/monitoring
+scans, live progress, coverage/partial signals, and per-run deltas remain
+scan-level and are not removed.
+
+## Non-goals
+
+- No multi-user/RBAC (single-admin by design).
+- Not removing scans or the scan-detail view — only demoting scans from *the*
+  organizing principle to the activity layer.
+- PR1 does not yet change the dashboard or add the Findings register; it only
+  restores the asset surface as the grounding for PR3.

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -9,6 +9,7 @@ const NAV = [
   { label: 'Dashboard',      path: '/' },
   { label: 'Domains',        path: '/domains' },
   { label: 'Scans',          path: '/scans' },
+  { label: 'Assets',         path: '/assets' },
   { label: 'Workflows',      path: '/workflows' },
   { label: 'Insights',       path: '/insights' },
   { label: 'Reports',        path: '/reports' },

--- a/frontend/src/pages/AssetDetailPage.jsx
+++ b/frontend/src/pages/AssetDetailPage.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Layout } from '../components/Layout.jsx';
+import { Badge } from '../components/Badge.jsx';
+import { Spinner } from '../components/Spinner.jsx';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
+import { apiGet } from '../api/client.js';
+import { useQuery } from '@tanstack/react-query';
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export default function AssetDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const { data: a, isLoading: loading, error } = useQuery({
+    queryKey: [`/assets/${id}/`],
+    queryFn: () => apiGet(`/assets/${id}/`),
+  });
+
+  if (loading) return <Layout><div className="flex justify-center p-8"><Spinner /></div></Layout>;
+  if (error) return <Layout><div className="p-6 text-red-400 text-sm">Error: {error?.message ?? String(error)}</div></Layout>;
+
+  const findings = a?.findings ?? [];
+  const timeline = a?.seen_in_scans ?? [];
+  const extra = a?.extra ?? {};
+
+  return (
+    <Layout>
+      <div className="space-y-5">
+        <button onClick={() => navigate('/assets')} className="text-dim text-sm hover:text-body">← Assets</button>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <Badge value={a.kind} />
+          <h1 className="text-lit text-xl font-bold font-mono break-all">{a.key}</h1>
+          <Badge value={a.status} />
+        </div>
+
+        <Card>
+          <CardContent className="grid grid-cols-2 gap-x-8 gap-y-2 p-5 text-sm md:grid-cols-4">
+            <div><div className="text-dim text-xs uppercase">Domain</div><div className="text-body">{a.domain}</div></div>
+            <div><div className="text-dim text-xs uppercase">First seen</div><div className="text-body">{fmtDate(a.first_seen)}</div></div>
+            <div><div className="text-dim text-xs uppercase">Last seen</div><div className="text-body">{fmtDate(a.last_seen)}</div></div>
+            <div><div className="text-dim text-xs uppercase">Last scan</div>
+              <div className="text-body">
+                {a.last_scan ? <button className="text-green-400 hover:underline font-mono text-xs" onClick={() => navigate(`/scans/${a.last_scan}`)}>{a.last_scan.slice(0, 8)}</button> : '—'}
+              </div>
+            </div>
+            {Object.entries(extra).filter(([, v]) => v !== '' && v !== null && v !== undefined).map(([k, v]) => (
+              <div key={k}><div className="text-dim text-xs uppercase">{k.replace(/_/g, ' ')}</div>
+                <div className="text-body break-all">{Array.isArray(v) ? (v.join(', ') || '—') : String(v)}</div></div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="overflow-hidden">
+          <CardHeader className="px-5 pt-4 pb-0"><CardTitle className="text-base">Findings ({findings.length})</CardTitle></CardHeader>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {['Severity', 'Title', 'Source', 'Status', 'Scan'].map(h => (
+                    <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim">{h}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {findings.length === 0 ? (
+                  <TableRow><TableCell colSpan={5} className="px-4 py-8 text-center text-dim">No findings linked to this asset.</TableCell></TableRow>
+                ) : findings.map(f => (
+                  <TableRow key={f.id} className="hover:bg-hover transition-colors">
+                    <TableCell className="px-4 py-3"><Badge value={f.severity} /></TableCell>
+                    <TableCell className="px-4 py-3 text-body max-w-md truncate">{f.title}</TableCell>
+                    <TableCell className="px-4 py-3 text-dim text-xs">{f.source}</TableCell>
+                    <TableCell className="px-4 py-3"><Badge value={f.status || 'open'} /></TableCell>
+                    <TableCell className="px-4 py-3">
+                      {f.session_uuid ? <button className="text-green-400 hover:underline font-mono text-xs" onClick={() => navigate(`/scans/${f.session_uuid}`)}>{f.session_uuid.slice(0, 8)}</button> : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </Card>
+
+        <Card className="overflow-hidden">
+          <CardHeader className="px-5 pt-4 pb-0"><CardTitle className="text-base">Seen in scans ({timeline.length})</CardTitle></CardHeader>
+          <CardContent className="p-5 space-y-2">
+            {timeline.length === 0 ? <div className="text-dim text-sm">No scan history.</div>
+            : timeline.map(t => (
+              <div key={t.uuid} className="flex items-center gap-3 text-sm">
+                <button className="text-green-400 hover:underline font-mono text-xs" onClick={() => navigate(`/scans/${t.uuid}`)}>{t.uuid.slice(0, 8)}</button>
+                <Badge value={t.status} />
+                <span className="text-dim text-xs">{fmtDate(t.at)}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/AssetsPage.jsx
+++ b/frontend/src/pages/AssetsPage.jsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Layout } from '../components/Layout.jsx';
+import { Badge } from '../components/Badge.jsx';
+import { Spinner } from '../components/Spinner.jsx';
+import { Pagination } from '../components/Pagination.jsx';
+import { Card } from '../components/ui/card.jsx';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
+import { apiGet } from '../api/client.js';
+import { useQuery } from '@tanstack/react-query';
+
+const KINDS    = ['subdomain', 'ip', 'port', 'url'];
+const STATUSES = ['active', 'gone'];
+const SEV      = ['critical', 'high', 'medium', 'low', 'info'];
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Compact per-severity finding counts — only render the non-zero buckets.
+export function SeverityChips({ counts }) {
+  const shown = SEV.filter(s => (counts?.[s] ?? 0) > 0);
+  if (shown.length === 0) return <span className="text-dim text-xs">—</span>;
+  return (
+    <span className="inline-flex gap-1">
+      {shown.map(s => <Badge key={s} value={s} label={`${counts[s]} ${s}`} />)}
+    </span>
+  );
+}
+
+export default function AssetsPage() {
+  const navigate = useNavigate();
+  const [kind,   setKind]   = useState('');
+  const [status, setStatus] = useState('');
+  const [domain, setDomain] = useState('');
+  const [q,      setQ]      = useState('');
+  const [page,   setPage]   = useState(1);
+
+  const { data: domainsData } = useQuery({
+    queryKey: ['/domains/'],
+    queryFn: () => apiGet('/domains/'),
+  });
+  const { data, isLoading: loading, error } = useQuery({
+    queryKey: ['/assets/', kind, status, domain, q, page],
+    queryFn: () => apiGet(`/assets/?kind=${kind}&status=${status}&domain=${domain}&q=${encodeURIComponent(q)}&page=${page}`),
+  });
+
+  const assets  = data?.assets ?? [];
+  const domains = domainsData || [];
+
+  return (
+    <Layout>
+      <div className="space-y-5">
+        <div>
+          <h1 className="text-lit text-xl font-bold">Assets</h1>
+          <p className="text-dim text-sm mt-0.5">Everything discovered across all scans — your attack surface over time</p>
+        </div>
+
+        <div className="flex gap-3 flex-wrap">
+          <select value={kind} onChange={e => { setKind(e.target.value); setPage(1); }} className="field w-36">
+            <option value="">All kinds</option>
+            {KINDS.map(k => <option key={k} value={k}>{k}</option>)}
+          </select>
+          <select value={status} onChange={e => { setStatus(e.target.value); setPage(1); }} className="field w-32">
+            <option value="">Any status</option>
+            {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <select value={domain} onChange={e => { setDomain(e.target.value); setPage(1); }} className="field w-52">
+            <option value="">All domains</option>
+            {domains.map(d => <option key={d.id} value={d.name}>{d.name}</option>)}
+          </select>
+          <input value={q} onChange={e => { setQ(e.target.value); setPage(1); }}
+            placeholder="Search key…" className="field w-52" />
+        </div>
+
+        <Card className="overflow-hidden">
+          {loading ? <div className="flex justify-center p-8"><Spinner /></div>
+          : error   ? <div className="p-6 text-red-400 text-sm">Error: {error?.message ?? String(error)}</div>
+          : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      {['Kind', 'Asset', 'Domain', 'Status', 'Open findings', 'First seen', 'Last seen'].map(h => (
+                        <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim whitespace-nowrap">{h}</TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {assets.length === 0 ? (
+                      <TableRow><TableCell colSpan={7} className="px-4 py-10 text-center text-dim">No assets.</TableCell></TableRow>
+                    ) : assets.map(a => (
+                      <TableRow key={a.id} onClick={() => navigate(`/assets/${a.id}`)}
+                        className="hover:bg-hover transition-colors cursor-pointer">
+                        <TableCell className="px-4 py-3"><Badge value={a.kind} /></TableCell>
+                        <TableCell className="px-4 py-3 font-mono text-body text-xs max-w-xs truncate">{a.key}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{a.domain}</TableCell>
+                        <TableCell className="px-4 py-3"><Badge value={a.status} /></TableCell>
+                        <TableCell className="px-4 py-3"><SeverityChips counts={a.findings} /></TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{fmtDate(a.first_seen)}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{fmtDate(a.last_seen)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+              {data?.total_pages > 1 && (
+                <div className="px-4 py-3 border-t border-border">
+                  <Pagination page={page} totalPages={data.total_pages} onPage={setPage} />
+                </div>
+              )}
+            </>
+          )}
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/AssetsPage.test.jsx
+++ b/frontend/src/pages/AssetsPage.test.jsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SeverityChips } from './AssetsPage.jsx';
+
+describe('SeverityChips', () => {
+  it('renders a chip only for non-zero severities', () => {
+    render(<SeverityChips counts={{ critical: 2, high: 0, medium: 1, low: 0, info: 0 }} />);
+    expect(screen.getByText('2 critical')).toBeInTheDocument();
+    expect(screen.getByText('1 medium')).toBeInTheDocument();
+    expect(screen.queryByText(/high/)).not.toBeInTheDocument();
+  });
+
+  it('renders an em dash when there are no findings', () => {
+    render(<SeverityChips counts={{ critical: 0, high: 0, medium: 0, low: 0, info: 0 }} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('handles a missing counts object', () => {
+    render(<SeverityChips counts={undefined} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -17,6 +17,8 @@ import ReportsPage from './pages/ReportsPage.jsx';
 import NotificationsPage from './pages/NotificationsPage.jsx';
 import AiPage from './pages/AiPage.jsx';
 import CredentialsPage from './pages/CredentialsPage.jsx';
+import AssetsPage from './pages/AssetsPage.jsx';
+import AssetDetailPage from './pages/AssetDetailPage.jsx';
 
 function NotFound() {
   return <div className="p-8 text-body">404 - Page not found</div>;
@@ -39,6 +41,8 @@ export const router = createBrowserRouter([
       { path: '/scans', element: <ScansPage /> },
       { path: '/scans/start', element: <ScanStartPage /> },
       { path: '/scans/:uuid', element: <ScanDetailPage /> },
+      { path: '/assets', element: <AssetsPage /> },
+      { path: '/assets/:id', element: <AssetDetailPage /> },
       { path: '/workflows', element: <WorkflowsPage /> },
       { path: '/workflows/:id', element: <WorkflowDetailPage /> },
       { path: '/insights', element: <InsightsPage /> },

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.15.0"
+version = "2.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
**Step 1** of moving the console to **finding-centric grounded on asset-centric** — see the new `docs/specs/2026-09-12-finding-centric-ui-direction.md`, which **explicitly supersedes #406** ("make the UI strictly scan-centric").

## Context
#406 deliberately removed the Assets inventory pages (list + detail) and the global Findings page to go strictly scan-centric, moving triage into the Scan-Detail modal — but **that triage is scan-scoped and doesn't persist** (a false-positive dismissal is lost on the next scan; the amnic.com false positives would re-appear every run). #406 left the `/api/assets/` layer + `asset_inventory` data intact, so restoring the surface is **UI wiring only**.

## This PR (asset-centric grounding)
- **Assets list** (`/assets`) — restored from git (pre-#406) and adapted: filters (kind / status / domain / search), pagination, per-asset open-finding **severity chips**; rows link to detail.
- **Asset detail** (`/assets/:id`) — metadata, findings, scan timeline.
- Nav entry + routes; `SeverityChips` component + its test restored.
- Spec doc recording the #406 reversal, its rationale, the **make-or-break prerequisite** (a persistent `Issue` register so triage sticks across scans — PR2), and the phased plan (PR2 identity → PR3 Findings register → PR4 dashboard/delta).
- Syncs `uv.lock` `openeasd 2.15.0 → 2.15.1` (missed in the release PR — `pyproject` was bumped, the lock wasn't).

## Not in this PR (by design)
The Findings register as the *primary* surface is **PR3**, gated on **PR2** (persistent finding identity). Shipping a finding-centric view on today's per-scan findings would re-noise triage every scan — so the asset grounding lands first.

## Test
Frontend **build OK**, **35 vitest pass** (`AssetsPage.test` restored). No backend change (API + data layer already present and tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)