### PR TITLE
feat: Findings register UI over the persistent Issue register (finding-centric PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **Findings register UI — the finding-centric primary surface (PR3).** New
+  **Findings** page (nav + `/findings`) and `/api/issues/` API (list ranked by
+  severity, `summary`, and a `status` endpoint) over the persistent `Issue`
+  register. It's a cross-scan issue list — filter by status/severity/domain/
+  search — where inline triage **patches `Issue.status`, so a dismissal persists
+  across scans** (the whole point of PR2). Targets link to their asset; the
+  empty state and header explicitly note "empty ≠ clean — check Scans for
+  coverage." This is the visible finding-centric turn, grounded on the asset
+  layer (PR1) and the persistent identity (PR2).
 - **Persistent Issue register — cross-scan finding identity (finding-centric PR2).**
   New `findings.Issue` model (mirrors `asset_inventory`): one row per
   `(domain, source, check_type, title, target)`, carrying `first_seen`/`last_seen`

--- a/apps/core/console/api/ninja.py
+++ b/apps/core/console/api/ninja.py
@@ -186,5 +186,8 @@ api.add_router("/credentials", credentials_router)
 from apps.core.console.ai.api import router as ai_router
 api.add_router("/ai", ai_router)
 
+from apps.core.data.findings.api import router as issues_router
+api.add_router("/issues", issues_router)
+
 from apps.core.data.asset_inventory.api import router as assets_router
 api.add_router("/assets", assets_router)

--- a/apps/core/data/findings/api.py
+++ b/apps/core/data/findings/api.py
@@ -1,0 +1,119 @@
+"""Issues API — ``/api/issues/`` : the persistent, cross-scan finding register.
+
+Reads and triages the ``Issue`` register (``apps/core/data/findings/models.Issue``).
+A status change here **persists across scans** (unlike per-scan
+``Finding.status``) — that is the point of the finding-centric UI: dismiss a false
+positive once and it stays dismissed. Spec:
+docs/specs/2026-09-12-finding-centric-ui-direction.md (PR3).
+"""
+
+import logging
+
+from django.core.paginator import Paginator
+from django.db.models import Case, Count, IntegerField, Value, When
+from django.shortcuts import get_object_or_404
+from ninja import Router, Schema
+from ninja.errors import HttpError
+
+from apps.core.console.api.auth import JWTAuth
+from apps.core.constants import SEVERITY_RANK
+
+from .models import STATUS_CHOICES, Issue
+
+logger = logging.getLogger(__name__)
+router = Router(auth=JWTAuth())
+
+_VALID_STATUSES = {s for s, _ in STATUS_CHOICES}
+# Issues that still need attention (drives the default view + the severity summary).
+_ACTIONABLE = ("open", "acknowledged", "in_progress")
+
+
+class StatusIn(Schema):
+    status: str
+
+
+def _row(i) -> dict:
+    return {
+        "id": i.id,
+        "domain": i.domain.name,
+        "source": i.source,
+        "check_type": i.check_type,
+        "title": i.title,
+        "target": i.target,
+        "severity": i.severity,
+        "status": i.status,
+        "first_seen": i.first_seen.isoformat(),
+        "last_seen": i.last_seen.isoformat(),
+        "asset_id": i.asset_id,
+    }
+
+
+def _ranked(qs):
+    """Order most-severe-first, then most-recent — using the shared SEVERITY_RANK
+    so the register's ranking can't drift from the rest of the app."""
+    whens = [When(severity=s, then=Value(r)) for s, r in SEVERITY_RANK.items()]
+    return qs.annotate(
+        sev_rank=Case(*whens, default=Value(-1), output_field=IntegerField())
+    ).order_by("-sev_rank", "-last_seen")
+
+
+@router.get("/")
+def list_issues(request, domain: str = "", status: str = "", severity: str = "",
+                source: str = "", q: str = "", page: int = 1):
+    qs = Issue.objects.select_related("domain")
+    if domain:
+        qs = qs.filter(domain__name__icontains=domain)
+    if status:
+        qs = qs.filter(status=status)
+    if severity:
+        qs = qs.filter(severity=severity)
+    if source:
+        qs = qs.filter(source=source)
+    if q:
+        qs = qs.filter(title__icontains=q)
+
+    paginator = Paginator(_ranked(qs), 25)
+    p = paginator.get_page(page)
+    return {
+        "issues": [_row(i) for i in p],
+        "total": paginator.count,
+        "page": p.number,
+        "total_pages": paginator.num_pages,
+        "has_next": p.has_next(),
+        "has_previous": p.has_previous(),
+    }
+
+
+@router.get("/summary/")
+def issues_summary(request, domain: str = ""):
+    qs = Issue.objects.all()
+    if domain:
+        qs = qs.filter(domain__name__icontains=domain)
+
+    by_status = {s: 0 for s, _ in STATUS_CHOICES}
+    for row in qs.values("status").annotate(n=Count("id")):
+        by_status[row["status"]] = row["n"]
+
+    # Severity breakdown of the still-actionable issues (open/ack/in-progress) —
+    # what actually needs work, excluding resolved / dismissed.
+    open_by_severity: dict[str, int] = {}
+    for row in (qs.filter(status__in=_ACTIONABLE)
+                  .values("severity").annotate(n=Count("id"))):
+        open_by_severity[row["severity"]] = row["n"]
+
+    return {
+        "total": qs.count(),
+        "by_status": by_status,
+        "open_by_severity": open_by_severity,
+    }
+
+
+@router.post("/{issue_id}/status/")
+def set_issue_status(request, issue_id: int, data: StatusIn):
+    if data.status not in _VALID_STATUSES:
+        raise HttpError(400, f"status must be one of {sorted(_VALID_STATUSES)}")
+    issue = get_object_or_404(Issue, id=issue_id)
+    issue.status = data.status
+    issue.save(update_fields=["status"])
+    logger.info("[issues] %s → %s", issue_id, data.status)
+    return _row(issue)

--- a/docs/specs/2026-09-12-finding-centric-ui-direction.md
+++ b/docs/specs/2026-09-12-finding-centric-ui-direction.md
@@ -7,7 +7,8 @@
 > - PR2 — ✅ **persistent finding identity** (cross-scan `Issue` register +
 >   finalize rollup). *The make-or-break prerequisite for finding-centric* — done:
 >   status now persists across scans, dismissals stick.
-> - PR3 — **Findings/Issues register UI** as the primary triage surface.
+> - PR3 — ✅ **Findings/Issues register UI** as the primary triage surface
+>   (`/findings` + `/api/issues/`; triage patches `Issue.status`, so it persists).
 > - PR4 — dashboard cross-links + a "changes since last scan" feed.
 >
 > **This decision supersedes #406** ("make the UI strictly scan-centric"), which

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -7,9 +7,10 @@ import BuildInfo from './BuildInfo.jsx';
 
 const NAV = [
   { label: 'Dashboard',      path: '/' },
+  { label: 'Findings',       path: '/findings' },
+  { label: 'Assets',         path: '/assets' },
   { label: 'Domains',        path: '/domains' },
   { label: 'Scans',          path: '/scans' },
-  { label: 'Assets',         path: '/assets' },
   { label: 'Workflows',      path: '/workflows' },
   { label: 'Insights',       path: '/insights' },
   { label: 'Reports',        path: '/reports' },

--- a/frontend/src/pages/FindingsPage.jsx
+++ b/frontend/src/pages/FindingsPage.jsx
@@ -4,7 +4,7 @@ import { Layout } from '../components/Layout.jsx';
 import { Badge } from '../components/Badge.jsx';
 import { Spinner } from '../components/Spinner.jsx';
 import { Pagination } from '../components/Pagination.jsx';
-import { Card, CardContent } from '../components/ui/card.jsx';
+import { Card } from '../components/ui/card.jsx';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
 import { toast } from '../components/Notification.jsx';
 import { apiGet, apiPost } from '../api/client.js';

--- a/frontend/src/pages/FindingsPage.jsx
+++ b/frontend/src/pages/FindingsPage.jsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Layout } from '../components/Layout.jsx';
+import { Badge } from '../components/Badge.jsx';
+import { Spinner } from '../components/Spinner.jsx';
+import { Pagination } from '../components/Pagination.jsx';
+import { Card, CardContent } from '../components/ui/card.jsx';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
+import { toast } from '../components/Notification.jsx';
+import { apiGet, apiPost } from '../api/client.js';
+import { useQuery } from '@tanstack/react-query';
+
+const SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'];
+const STATUSES   = ['open', 'acknowledged', 'in_progress', 'resolved', 'false_positive'];
+
+function fmtDate(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// Inline triage editor — persists to the Issue (survives future scans), unlike
+// the old per-scan finding status.
+function StatusEditor({ issueId, current, onUpdated }) {
+  const [saving, setSaving] = useState(false);
+  async function handleChange(e) {
+    const status = e.target.value;
+    setSaving(true);
+    try {
+      await apiPost(`/issues/${issueId}/status/`, { status });
+      toast.success(`Marked ${status.replace(/_/g, ' ')} (persists across scans)`);
+      onUpdated();
+    } catch (err) {
+      toast.error(err.message || 'Failed to update status.');
+    } finally {
+      setSaving(false);
+    }
+  }
+  return (
+    <select value={current} onChange={handleChange} disabled={saving}
+      className="field text-xs py-0.5 px-1 w-36">
+      {STATUSES.map(s => <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>)}
+    </select>
+  );
+}
+
+export default function FindingsPage() {
+  const navigate = useNavigate();
+  const [status,   setStatus]   = useState('open');   // default to the actionable set
+  const [severity, setSeverity] = useState('');
+  const [domain,   setDomain]   = useState('');
+  const [q,        setQ]        = useState('');
+  const [page,     setPage]     = useState(1);
+
+  const { data: summary } = useQuery({
+    queryKey: ['/issues/summary/', domain],
+    queryFn: () => apiGet(`/issues/summary/?domain=${encodeURIComponent(domain)}`),
+  });
+  const { data, isLoading: loading, error, refetch } = useQuery({
+    queryKey: ['/issues/', status, severity, domain, q, page],
+    queryFn: () => apiGet(`/issues/?status=${status}&severity=${severity}`
+      + `&domain=${encodeURIComponent(domain)}&q=${encodeURIComponent(q)}&page=${page}`),
+  });
+
+  const issues     = data?.issues ?? [];
+  const totalPages = data ? data.total_pages : 1;
+  const openSev    = summary?.open_by_severity ?? {};
+
+  const reset = (fn) => (v) => { fn(v); setPage(1); };
+
+  return (
+    <Layout>
+      <div className="space-y-5">
+        <div>
+          <h1 className="text-lit text-xl font-bold">Findings</h1>
+          <p className="text-dim text-sm mt-0.5">
+            Persistent issue register — one row per distinct finding across scans; triage sticks.
+          </p>
+        </div>
+
+        {/* Actionable-severity summary. NOTE: an empty list means "nothing open
+            in the register", NOT necessarily "surface is clean" — check Scans for
+            coverage / partial runs. */}
+        <div className="flex flex-wrap gap-2">
+          {SEVERITIES.map(s => (
+            <Badge key={s} value={s} label={`${openSev[s] ?? 0} ${s}`} />
+          ))}
+          <span className="text-dim text-xs self-center ml-1">open/acknowledged/in-progress</span>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-wrap gap-2">
+          <select value={status} onChange={e => reset(setStatus)(e.target.value)} className="field w-40">
+            <option value="">All statuses</option>
+            {STATUSES.map(s => <option key={s} value={s}>{s.replace(/_/g, ' ')}</option>)}
+          </select>
+          <select value={severity} onChange={e => reset(setSeverity)(e.target.value)} className="field w-36">
+            <option value="">All severities</option>
+            {SEVERITIES.map(s => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <input value={domain} onChange={e => reset(setDomain)(e.target.value)}
+            placeholder="Filter by domain…" className="field w-48" />
+          <input value={q} onChange={e => reset(setQ)(e.target.value)}
+            placeholder="Search title…" className="field flex-1 min-w-[180px]" />
+        </div>
+
+        <Card className="overflow-hidden">
+          {loading ? (
+            <div className="flex justify-center p-8"><Spinner /></div>
+          ) : error ? (
+            <div className="p-6 text-red-400 text-sm">Error: {error?.message ?? String(error)}</div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      {['Severity', 'Finding', 'Source', 'Target', 'Domain', 'Last seen', 'Status'].map(h => (
+                        <TableHead key={h} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim whitespace-nowrap">{h}</TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {issues.length === 0 ? (
+                      <TableRow><TableCell colSpan={7} className="px-4 py-10 text-center text-dim">
+                        No issues match. (Empty ≠ clean — check Scans for coverage.)
+                      </TableCell></TableRow>
+                    ) : issues.map(i => (
+                      <TableRow key={i.id} className="hover:bg-hover transition-colors">
+                        <TableCell className="px-4 py-3"><Badge value={i.severity} /></TableCell>
+                        <TableCell className="px-4 py-3 text-body font-medium max-w-md truncate" title={i.title}>{i.title}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{i.source}{i.check_type ? ` / ${i.check_type}` : ''}</TableCell>
+                        <TableCell className="px-4 py-3 font-mono text-xs">
+                          {i.asset_id ? (
+                            <button onClick={() => navigate(`/assets/${i.asset_id}`)} className="text-brand hover:underline">{i.target || '—'}</button>
+                          ) : (i.target || '—')}
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-dim font-mono text-xs">{i.domain}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs whitespace-nowrap">{fmtDate(i.last_seen)}</TableCell>
+                        <TableCell className="px-4 py-3"><StatusEditor issueId={i.id} current={i.status} onUpdated={refetch} /></TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+              {totalPages > 1 && (
+                <div className="px-4 py-3 border-t border-border">
+                  <Pagination page={page} totalPages={totalPages} onPage={setPage} />
+                </div>
+              )}
+            </>
+          )}
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -19,6 +19,7 @@ import AiPage from './pages/AiPage.jsx';
 import CredentialsPage from './pages/CredentialsPage.jsx';
 import AssetsPage from './pages/AssetsPage.jsx';
 import AssetDetailPage from './pages/AssetDetailPage.jsx';
+import FindingsPage from './pages/FindingsPage.jsx';
 
 function NotFound() {
   return <div className="p-8 text-body">404 - Page not found</div>;
@@ -41,6 +42,7 @@ export const router = createBrowserRouter([
       { path: '/scans', element: <ScansPage /> },
       { path: '/scans/start', element: <ScanStartPage /> },
       { path: '/scans/:uuid', element: <ScanDetailPage /> },
+      { path: '/findings', element: <FindingsPage /> },
       { path: '/assets', element: <AssetsPage /> },
       { path: '/assets/:id', element: <AssetDetailPage /> },
       { path: '/workflows', element: <WorkflowsPage /> },

--- a/tests/unit/test_issues_api.py
+++ b/tests/unit/test_issues_api.py
@@ -1,0 +1,86 @@
+"""/api/issues/ — the persistent finding register API (PR3)."""
+
+import pytest
+from django.utils import timezone
+
+
+def _issue(domain, **kw):
+    from apps.core.data.findings.models import Issue, issue_key
+    now = timezone.now()
+    defaults = dict(
+        source="web_checker", check_type="missing_header", title="Missing CSP",
+        target="example.com", severity="medium", status="open",
+        first_seen=now, last_seen=now,
+    )
+    defaults.update(kw)
+    defaults["key"] = issue_key(defaults["source"], defaults["check_type"],
+                                defaults["title"], defaults["target"])
+    return Issue.objects.create(domain=domain, **defaults)
+
+
+@pytest.mark.django_db
+class TestIssuesAPI:
+    def _domain(self, name="example.com"):
+        from apps.core.data.domains.models import Domain
+        d, _ = Domain.objects.get_or_create(name=name)
+        return d
+
+    def test_requires_auth(self, client):
+        assert client.get("/api/issues/").status_code == 401
+
+    def test_list_ranked_and_shaped(self, auth_client):
+        dom = self._domain()
+        _issue(dom, title="low one", severity="low")
+        _issue(dom, title="crit one", severity="critical", check_type="rce")
+        res = auth_client.get("/api/issues/?status=")  # all statuses
+        assert res.status_code == 200
+        body = res.json()
+        assert body["total"] == 2 and "page" in body and "total_pages" in body
+        # Ranked most-severe first.
+        assert body["issues"][0]["severity"] == "critical"
+        assert {"id", "title", "severity", "status", "domain", "last_seen"} <= set(body["issues"][0])
+
+    def test_filter_by_status_and_severity(self, auth_client):
+        dom = self._domain()
+        _issue(dom, title="open med", severity="medium", status="open")
+        _issue(dom, title="fp high", severity="high", status="false_positive", check_type="x")
+        assert auth_client.get("/api/issues/?status=open").json()["total"] == 1
+        assert auth_client.get("/api/issues/?severity=high").json()["total"] == 1
+        assert auth_client.get("/api/issues/?status=false_positive").json()["issues"][0]["title"] == "fp high"
+
+    def test_summary(self, auth_client):
+        dom = self._domain()
+        _issue(dom, title="a", severity="high", status="open")
+        _issue(dom, title="b", severity="high", status="open", check_type="y")
+        _issue(dom, title="c", severity="low", status="false_positive", check_type="z")
+        s = auth_client.get("/api/issues/summary/").json()
+        assert s["total"] == 3
+        assert s["by_status"]["open"] == 2 and s["by_status"]["false_positive"] == 1
+        # open_by_severity counts only actionable issues.
+        assert s["open_by_severity"].get("high") == 2
+        assert "low" not in s["open_by_severity"]  # the low one is dismissed
+
+    def test_status_update_persists(self, auth_client):
+        dom = self._domain()
+        i = _issue(dom, status="open")
+        res = auth_client.post(f"/api/issues/{i.id}/status/",
+                               data={"status": "false_positive"},
+                               content_type="application/json")
+        assert res.status_code == 200
+        assert res.json()["status"] == "false_positive"
+        i.refresh_from_db()
+        assert i.status == "false_positive"
+
+    def test_status_update_rejects_bad_value(self, auth_client):
+        dom = self._domain()
+        i = _issue(dom)
+        res = auth_client.post(f"/api/issues/{i.id}/status/",
+                               data={"status": "bogus"},
+                               content_type="application/json")
+        assert res.status_code == 400
+
+    def test_status_update_404(self, auth_client):
+        res = auth_client.post("/api/issues/999999/status/",
+                               data={"status": "open"},
+                               content_type="application/json")
+        assert res.status_code == 404


### PR DESCRIPTION
**PR3** — the visible **finding-centric** turn, grounded on PR1 (assets) + PR2 (persistent `Issue` identity). Spec: `docs/specs/2026-09-12-finding-centric-ui-direction.md`.

## Change
- **`/api/issues/` router** (`apps/core/data/findings/api.py`, registered in `ninja.py`):
  - `GET /` — list, **ranked most-severe-first** (shared `SEVERITY_RANK`), filter by status/severity/domain/`q`, paginated.
  - `GET /summary/` — `by_status` + **actionable `open_by_severity`** (excludes resolved/dismissed).
  - `POST /{id}/status/` — validate + **persist `Issue.status`**.
- **Findings page** (`/findings`) + nav entry placed high (the finding-centric primary): a **cross-scan issue register** with inline triage that patches `Issue.status`, so a `false_positive`/`acknowledged` dismissal **sticks across scans** (unlike the old per-scan modal). Targets link to their asset detail.
- **Never-fake-clean guard:** the header + empty state say *"empty ≠ clean — check Scans for coverage."*

## Test
`test_issues_api.py` (7): auth (401), ranked list + shape, status/severity filters, summary (actionable `open_by_severity` excludes dismissed), status update persists + 400 on bad value + 404. Frontend **build OK**, **35 vitest pass**. ruff clean.

## Where this lands the direction
PR1 (asset grounding) + PR2 (persistent identity) + **PR3 (this — the register UI)** = the console is now finding-centric grounded on asset-centric. **PR4** (dashboard cross-links + "changes since last scan" feed) is the remaining polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)