### PR TITLE
feat: Changes feed — 'what changed since last scan' (finding-centric PR5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **Changes feed — "what changed since last scan" (finding-centric PR5).** New
+  **Changes** page (nav + `/changes`) and `/api/scans/deltas/` endpoint over the
+  existing `ScanDelta` records: a recency-ordered feed of **new / removed**
+  findings across scans, filterable by domain and change type, each row linking
+  to its scan. The delta-detection identity key (`source:check_type:title`) is
+  parsed for display (colons in titles preserved). The delta/change-centric entry
+  point for the finding-centric UI (asset grounding = PR1, persistent issues =
+  PR2, register = PR3). Dashboard cross-link cards remain deferred.
 - **Findings register UI — the finding-centric primary surface (PR3).** New
   **Findings** page (nav + `/findings`) and `/api/issues/` API (list ranked by
   severity, `summary`, and a `status` endpoint) over the persistent `Issue`

--- a/apps/core/engine/scans/api.py
+++ b/apps/core/engine/scans/api.py
@@ -508,6 +508,48 @@ def update_finding_status(request, finding_id: int, data: FindingStatusRequest):
     return _serialize_finding(finding)
 
 
+def _delta_row(d) -> dict:
+    # item_identifier is "source:check_type:title" (the delta-detection key).
+    # Split on the first two ":" so a title containing ":" stays intact.
+    parts = (d.item_identifier or "").split(":", 2)
+    source, check_type, title = (parts + ["", "", ""])[:3]
+    return {
+        "id": d.id,
+        "change_type": d.change_type,       # "new" | "removed"
+        "category": d.change_category,       # "finding"
+        "source": source,
+        "check_type": check_type,
+        "title": title,
+        "domain": d.session.domain,
+        "scan_uuid": str(d.session.uuid),
+        "created_at": d.created_at.isoformat(),
+    }
+
+
+@router.get("/deltas/")
+def list_deltas(request, domain: str = "", change_type: str = "", page: int = 1):
+    """Recent scan-to-scan changes (new / removed findings), newest first — the
+    'changes since last scan' feed. Filter by domain / change_type."""
+    from apps.core.engine.scans.models import ScanDelta
+
+    qs = ScanDelta.objects.select_related("session").order_by("-created_at")
+    if domain:
+        qs = qs.filter(session__domain__icontains=domain)
+    if change_type:
+        qs = qs.filter(change_type=change_type)
+
+    paginator = Paginator(qs, 30)
+    p = paginator.get_page(page)
+    return {
+        "deltas": [_delta_row(d) for d in p],
+        "total": paginator.count,
+        "page": p.number,
+        "total_pages": paginator.num_pages,
+        "has_next": p.has_next(),
+        "has_previous": p.has_previous(),
+    }
+
+
 @router.get("/{session_uuid}/")
 def scan_detail(request, session_uuid: uuid.UUID):
     from apps.core.data.assets.models import IPAddress, Port, Subdomain

--- a/docs/specs/2026-09-12-finding-centric-ui-direction.md
+++ b/docs/specs/2026-09-12-finding-centric-ui-direction.md
@@ -9,7 +9,9 @@
 >   status now persists across scans, dismissals stick.
 > - PR3 — ✅ **Findings/Issues register UI** as the primary triage surface
 >   (`/findings` + `/api/issues/`; triage patches `Issue.status`, so it persists).
-> - PR4 — dashboard cross-links + a "changes since last scan" feed.
+> - PR5 — ✅ **"changes since last scan" feed** (`/changes` + `/api/scans/deltas/`).
+> - PR4 — dashboard cross-link cards (Open-Issues + Asset-inventory) — *deferred*
+>   (the delta feed was prioritised as PR5).
 >
 > **This decision supersedes #406** ("make the UI strictly scan-centric"), which
 > had removed the global Findings page and the Assets inventory pages. See

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -8,6 +8,7 @@ import BuildInfo from './BuildInfo.jsx';
 const NAV = [
   { label: 'Dashboard',      path: '/' },
   { label: 'Findings',       path: '/findings' },
+  { label: 'Changes',        path: '/changes' },
   { label: 'Assets',         path: '/assets' },
   { label: 'Domains',        path: '/domains' },
   { label: 'Scans',          path: '/scans' },

--- a/frontend/src/pages/ChangesPage.jsx
+++ b/frontend/src/pages/ChangesPage.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Layout } from '../components/Layout.jsx';
+import { Badge } from '../components/Badge.jsx';
+import { Spinner } from '../components/Spinner.jsx';
+import { Pagination } from '../components/Pagination.jsx';
+import { Card } from '../components/ui/card.jsx';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table.jsx';
+import { apiGet } from '../api/client.js';
+import { useQuery } from '@tanstack/react-query';
+
+function fmtWhen(iso) {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+export default function ChangesPage() {
+  const navigate = useNavigate();
+  const [changeType, setChangeType] = useState('');
+  const [domain,     setDomain]     = useState('');
+  const [page,       setPage]       = useState(1);
+
+  const { data, isLoading: loading, error } = useQuery({
+    queryKey: ['/scans/deltas/', changeType, domain, page],
+    queryFn: () => apiGet(`/scans/deltas/?change_type=${changeType}`
+      + `&domain=${encodeURIComponent(domain)}&page=${page}`),
+  });
+
+  const deltas     = data?.deltas ?? [];
+  const totalPages = data ? data.total_pages : 1;
+  const reset = (fn) => (v) => { fn(v); setPage(1); };
+
+  return (
+    <Layout>
+      <div className="space-y-5">
+        <div>
+          <h1 className="text-lit text-xl font-bold">Changes</h1>
+          <p className="text-dim text-sm mt-0.5">
+            What appeared and disappeared between scans — newest first. New findings are worth a look; removed ones may be fixed or a coverage gap.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <select value={changeType} onChange={e => reset(setChangeType)(e.target.value)} className="field w-40">
+            <option value="">All changes</option>
+            <option value="new">New</option>
+            <option value="removed">Removed</option>
+          </select>
+          <input value={domain} onChange={e => reset(setDomain)(e.target.value)}
+            placeholder="Filter by domain…" className="field flex-1 min-w-[180px]" />
+        </div>
+
+        <Card className="overflow-hidden">
+          {loading ? (
+            <div className="flex justify-center p-8"><Spinner /></div>
+          ) : error ? (
+            <div className="p-6 text-red-400 text-sm">Error: {error?.message ?? String(error)}</div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      {['Change', 'Finding', 'Source', 'Domain', 'When', ''].map((h, idx) => (
+                        <TableHead key={idx} className="px-4 py-3 text-xs font-semibold uppercase tracking-wider text-dim whitespace-nowrap">{h}</TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {deltas.length === 0 ? (
+                      <TableRow><TableCell colSpan={6} className="px-4 py-10 text-center text-dim">
+                        No changes recorded yet — deltas appear after a domain's second scan.
+                      </TableCell></TableRow>
+                    ) : deltas.map(d => (
+                      <TableRow key={d.id} className="hover:bg-hover transition-colors">
+                        <TableCell className="px-4 py-3">
+                          <Badge value={d.change_type === 'new' ? 'open' : 'resolved'}
+                            label={d.change_type === 'new' ? 'new' : 'removed'} />
+                        </TableCell>
+                        <TableCell className="px-4 py-3 text-body font-medium max-w-md truncate" title={d.title}>{d.title || '—'}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs">{d.source}{d.check_type ? ` / ${d.check_type}` : ''}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim font-mono text-xs">{d.domain}</TableCell>
+                        <TableCell className="px-4 py-3 text-dim text-xs whitespace-nowrap">{fmtWhen(d.created_at)}</TableCell>
+                        <TableCell className="px-4 py-3">
+                          <button onClick={() => navigate(`/scans/${d.scan_uuid}`)} className="text-brand hover:underline text-xs">scan →</button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+              {totalPages > 1 && (
+                <div className="px-4 py-3 border-t border-border">
+                  <Pagination page={page} totalPages={totalPages} onPage={setPage} />
+                </div>
+              )}
+            </>
+          )}
+        </Card>
+      </div>
+    </Layout>
+  );
+}

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -20,6 +20,7 @@ import CredentialsPage from './pages/CredentialsPage.jsx';
 import AssetsPage from './pages/AssetsPage.jsx';
 import AssetDetailPage from './pages/AssetDetailPage.jsx';
 import FindingsPage from './pages/FindingsPage.jsx';
+import ChangesPage from './pages/ChangesPage.jsx';
 
 function NotFound() {
   return <div className="p-8 text-body">404 - Page not found</div>;
@@ -43,6 +44,7 @@ export const router = createBrowserRouter([
       { path: '/scans/start', element: <ScanStartPage /> },
       { path: '/scans/:uuid', element: <ScanDetailPage /> },
       { path: '/findings', element: <FindingsPage /> },
+      { path: '/changes', element: <ChangesPage /> },
       { path: '/assets', element: <AssetsPage /> },
       { path: '/assets/:id', element: <AssetDetailPage /> },
       { path: '/workflows', element: <WorkflowsPage /> },

--- a/tests/unit/test_deltas_api.py
+++ b/tests/unit/test_deltas_api.py
@@ -1,0 +1,55 @@
+"""/api/scans/deltas/ — the 'changes since last scan' feed (PR5)."""
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestDeltasAPI:
+    def _session(self, domain="example.com"):
+        from apps.core.engine.scans.models import ScanSession
+        return ScanSession.objects.create(domain=domain, scan_type="full", status="completed")
+
+    def _delta(self, sess, change_type="new", ident="web_checker:missing_header:Missing CSP"):
+        from apps.core.engine.scans.models import ScanDelta
+        return ScanDelta.objects.create(
+            session=sess, change_type=change_type, change_category="finding",
+            item_identifier=ident,
+        )
+
+    def test_requires_auth(self, client):
+        assert client.get("/api/scans/deltas/").status_code == 401
+
+    def test_list_shape_and_key_parse(self, auth_client):
+        s = self._session()
+        self._delta(s, "new", "web_checker:missing_header:Missing CSP header")
+        body = auth_client.get("/api/scans/deltas/").json()
+        assert body["total"] == 1 and "page" in body and "total_pages" in body
+        row = body["deltas"][0]
+        assert row["change_type"] == "new"
+        assert row["source"] == "web_checker" and row["check_type"] == "missing_header"
+        assert row["title"] == "Missing CSP header"
+        assert row["domain"] == "example.com" and row["scan_uuid"]
+
+    def test_title_with_colon_is_preserved(self, auth_client):
+        # split(":", 2) keeps colons in the title intact.
+        s = self._session()
+        self._delta(s, "new", "nmap:cve:CVE-2024-1: RCE in service X")
+        row = auth_client.get("/api/scans/deltas/").json()["deltas"][0]
+        assert row["source"] == "nmap" and row["check_type"] == "cve"
+        assert row["title"] == "CVE-2024-1: RCE in service X"
+
+    def test_filter_change_type(self, auth_client):
+        s = self._session()
+        self._delta(s, "new", "a:b:c")
+        self._delta(s, "removed", "d:e:f")
+        assert auth_client.get("/api/scans/deltas/?change_type=new").json()["total"] == 1
+        assert auth_client.get("/api/scans/deltas/?change_type=removed").json()["total"] == 1
+
+    def test_filter_domain(self, auth_client):
+        self._delta(self._session("alpha.com"), ident="a:b:c")
+        self._delta(self._session("beta.com"), ident="d:e:f")
+        assert auth_client.get("/api/scans/deltas/?domain=alpha.com").json()["total"] == 1
+
+    def test_route_not_shadowed_by_uuid_detail(self, auth_client):
+        # /deltas/ must resolve to the feed, not be parsed as a scan UUID (200, not 404/422).
+        assert auth_client.get("/api/scans/deltas/").status_code == 200


### PR DESCRIPTION
**PR5** — the delta/change-centric entry point of the finding-centric UI. Spec: `docs/specs/2026-09-12-finding-centric-ui-direction.md`.

## Change
- **`/api/scans/deltas/`** (scans router): recency-ordered feed of `ScanDelta` records (**new / removed** findings), filter by `domain` + `change_type`, paginated. Parses the delta identity key `source:check_type:title` for display (`split(":", 2)` — colons in titles preserved). Placed **before** `/{session_uuid}/` so `deltas` isn't coerced as a UUID.
- **Changes page** (`/changes`) + nav: new-vs-removed badges, each row links to its scan, domain/type filters. Empty state notes deltas appear after a domain's *second* scan.

## Where this lands the direction
PR1 (assets grounding) + PR2 (persistent Issue identity) + PR3 (register) + **PR5 (this — changes feed)** complete the finding-centric-grounded-on-asset-centric console. The dashboard cross-link cards (**PR4**) remain deferred (you prioritised the feed).

## Test
`test_deltas_api.py` (6): auth (401), list shape + key parse, **colon-in-title preserved**, `change_type`/`domain` filters, route-not-shadowed-by-`{uuid}`. `test_scans` + deltas: **41 passed**. Frontend **build OK**, **35 vitest pass**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)