### PR TITLE
feat: dashboard cross-link cards — Open Issues + Asset Inventory (finding-centric PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ commits to recover the reasoning.
 ## [Unreleased]
 
 ### Added
+- **Dashboard cross-link cards (finding-centric PR4).** Two clickable summary
+  cards on the dashboard: **Open Issues** (open/acknowledged/in-progress by
+  severity, from `/issues/summary/`) linking to the Findings register, and
+  **Asset Inventory** (active / gone / total, from `/assets/summary/`) linking to
+  Assets. Restores the cross-scan posture cards #406 removed and completes the
+  finding-centric-grounded-on-asset-centric UI direction
+  (`docs/specs/2026-09-12-finding-centric-ui-direction.md`). Frontend-only —
+  reuses existing summary endpoints.
 - **Changes feed — "what changed since last scan" (finding-centric PR5).** New
   **Changes** page (nav + `/changes`) and `/api/scans/deltas/` endpoint over the
   existing `ScanDelta` records: a recency-ordered feed of **new / removed**

--- a/docs/specs/2026-09-12-finding-centric-ui-direction.md
+++ b/docs/specs/2026-09-12-finding-centric-ui-direction.md
@@ -1,6 +1,7 @@
 # Finding-Centric UI, Grounded on Asset-Centric — Direction Spec
 
-> **Status:** 🚧 In progress.
+> **Status:** ✅ Implemented (PR1–PR5). The console is finding-centric grounded
+> on asset-centric; scans are the activity/history layer.
 > - PR1 — restore the **Assets inventory UI** (list + detail), nav + routes (the
 >   asset-centric grounding). *This PR.* The `/api/assets/` layer was never
 >   removed, so this is UI wiring only.
@@ -10,8 +11,8 @@
 > - PR3 — ✅ **Findings/Issues register UI** as the primary triage surface
 >   (`/findings` + `/api/issues/`; triage patches `Issue.status`, so it persists).
 > - PR5 — ✅ **"changes since last scan" feed** (`/changes` + `/api/scans/deltas/`).
-> - PR4 — dashboard cross-link cards (Open-Issues + Asset-inventory) — *deferred*
->   (the delta feed was prioritised as PR5).
+> - PR4 — ✅ dashboard cross-link cards (Open-Issues + Asset-inventory). All
+>   phases now shipped — the console is finding-centric grounded on asset-centric.
 >
 > **This decision supersedes #406** ("make the UI strictly scan-centric"), which
 > had removed the global Findings page and the Assets inventory pages. See

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -34,6 +34,14 @@ export default function DashboardPage() {
     queryKey: ['/dashboard/'],
     queryFn: () => apiGet('/dashboard/'),
   });
+  const { data: issuesSummary } = useQuery({
+    queryKey: ['/issues/summary/'],
+    queryFn: () => apiGet('/issues/summary/'),
+  });
+  const { data: assetsSummary } = useQuery({
+    queryKey: ['/assets/summary/'],
+    queryFn: () => apiGet('/assets/summary/'),
+  });
 
   if (loading) return <Layout><div className="flex justify-center items-center h-64"><Spinner size={40} /></div></Layout>;
   if (error)   return <Layout><div className="text-red-400 p-4">Error: {error?.message ?? String(error)}</div></Layout>;
@@ -65,6 +73,37 @@ export default function DashboardPage() {
           <AssetCard label="IPs"        value={kpi_ips} />
           <AssetCard label="Ports"      value={kpi_ports} />
           <AssetCard label="URLs"       value={kpi_urls} />
+        </div>
+
+        {/* Cross-links into the persistent finding-centric surfaces. */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <button onClick={() => navigate('/findings')}
+            className="text-left bg-card border border-rim rounded-xl p-4 hover:bg-hover transition-colors">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-semibold text-lit">Open Issues</span>
+              <span className="text-xs text-brand">View all →</span>
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {['critical', 'high', 'medium', 'low', 'info'].map(s => (
+                <Badge key={s} value={s} label={`${issuesSummary?.open_by_severity?.[s] ?? 0} ${s}`} />
+              ))}
+            </div>
+            <p className="text-xs text-dim mt-2">Persistent register — triage sticks across scans.</p>
+          </button>
+
+          <button onClick={() => navigate('/assets')}
+            className="text-left bg-card border border-rim rounded-xl p-4 hover:bg-hover transition-colors">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-semibold text-lit">Asset Inventory</span>
+              <span className="text-xs text-brand">View all →</span>
+            </div>
+            <div className="flex gap-5">
+              <div><span className="text-2xl font-bold text-lit">{assetsSummary?.active ?? 0}</span> <span className="text-xs text-dim">active</span></div>
+              <div><span className="text-2xl font-bold text-dim">{assetsSummary?.gone ?? 0}</span> <span className="text-xs text-dim">gone</span></div>
+              <div><span className="text-2xl font-bold text-lit">{assetsSummary?.total ?? 0}</span> <span className="text-xs text-dim">total</span></div>
+            </div>
+            <p className="text-xs text-dim mt-2">Persistent attack surface across scans.</p>
+          </button>
         </div>
 
         <Card className="overflow-hidden">


### PR DESCRIPTION
**PR4** — the final piece of the finding-centric-grounded-on-asset-centric direction. Spec: `docs/specs/2026-09-12-finding-centric-ui-direction.md` (now marked ✅ Implemented).

## Change
Two clickable dashboard summary cards, restoring the cross-scan posture cards #406 removed:
- **Open Issues** — open/acknowledged/in-progress counts by severity (`/issues/summary/`) → links to the **Findings** register.
- **Asset Inventory** — active / gone / total (`/assets/summary/`) → links to **Assets**.

Frontend-only — reuses the existing summary endpoints (no backend change).

## Direction complete
PR1 (assets grounding) + PR2 (persistent Issue identity) + PR3 (Findings register) + PR5 (Changes feed) + **PR4 (this — dashboard cross-links)**. The console is now finding-centric grounded on asset-centric, with scans as the activity/history layer — reversing #406's "strictly scan-centric" *and* adding the cross-scan triage persistence #406 never had.

## Test
Frontend **build OK**, **35 vitest pass**. No backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)