### PR TITLE
chore: release v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.16.0] — 2026-09-12
+
 ### Added
 - **Dashboard cross-link cards (finding-centric PR4).** Two clickable summary
   cards on the dashboard: **Open Issues** (open/acknowledged/in-progress by
@@ -1730,7 +1732,8 @@ security learners. The pre-launch work below tightens the load-bearing
   limit would have shown Infra Scan at id=2 with `is_default=true`.)
 
 <!-- Version compare links (Keep a Changelog) -->
-[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.15.1...HEAD
+[Unreleased]: https://github.com/cybersecify/OpenEASD/compare/v2.16.0...HEAD
+[v2.16.0]: https://github.com/cybersecify/OpenEASD/compare/v2.15.1...v2.16.0
 [v2.15.1]: https://github.com/cybersecify/OpenEASD/compare/v2.15.0...v2.15.1
 [v2.15.0]: https://github.com/cybersecify/OpenEASD/compare/v2.14.2...v2.15.0
 [v2.14.2]: https://github.com/cybersecify/OpenEASD/compare/v2.14.1...v2.14.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,10 +3,10 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.15.1 — 2026-09-11)
+## Status (v2.16.0 — 2026-09-12)
 
-- **Released**: v2.15.1 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
-  `:v2.15.1` / `:v2.15` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
+- **Released**: v2.16.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
+  `:v2.16.0` / `:v2.16` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
 - **Scope**: 29 registered scan tools across 13 pipeline phases; single-user
   (one admin, no RBAC) by design.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.15.1"
+version = "2.16.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.15.1"
+version = "2.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Minor release — the finding-centric-grounded-on-asset-centric **UI direction** (PRs #460–#464), which supersedes #406's "strictly scan-centric" and adds the cross-scan triage persistence #406 lacked. Spec: `docs/specs/2026-09-12-finding-centric-ui-direction.md`.

## Included
- **PR1 (#460)** Assets inventory UI (list + detail).
- **PR2 (#461)** Persistent `Issue` register — cross-scan finding identity; triage status persists across scans. *Adds migration `0009_issue`.*
- **PR3 (#462)** Findings register UI over the Issue register (triage sticks).
- **PR5 (#463)** Changes feed (`/changes` + `/api/scans/deltas/`).
- **PR4 (#464)** Dashboard cross-link cards (Open Issues + Asset Inventory).

## Release mechanics
`pyproject` `2.15.1 → 2.16.0`; CHANGELOG `[Unreleased] → [v2.16.0]` + compare footer; CLAUDE.md status line; `uv.lock` synced.

## ⚠ Migration
Carries **`0009_issue`** (new `Issue` table). The web tier's entrypoint runs `migrate` on deploy — additive, no data change.

After merge: tag `v2.16.0`, push → publish `:v2.16.0` / `:v2.16` / `:latest`, then deploy to preprod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)