### PR TITLE
ci: auto-create the GitHub Release on a v* tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,3 +232,32 @@ jobs:
           # SBOM lists every package in the image; provenance attests the build.
           sbom: true
           provenance: mode=max
+
+  # Create (or update) the GitHub Release for a v* tag, with notes from the
+  # matching CHANGELOG section. Runs only on tag pushes, after images publish,
+  # so a `git tag vX.Y.Z && push` now yields both the images AND the Release —
+  # previously the Release was a manual step that drifted (see the v2.11.0→v2.16.0
+  # gap that had to be backfilled).
+  release:
+    name: GitHub Release
+    runs-on: ubuntu-24.04
+    needs: [publish]
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write   # create / edit GitHub Releases
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - name: Create or update the Release from CHANGELOG
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"   # e.g. v2.16.0
+          # Extract this version's CHANGELOG section (between its header and the next).
+          awk -v h="## [$TAG]" 'index($0,h)==1{f=1;next} /^## \[/{if(f)exit} f' CHANGELOG.md > notes.md
+          if [ -s notes.md ]; then NOTES_ARG=(--notes-file notes.md); else
+            echo "No CHANGELOG section for $TAG — auto-generating notes."; NOTES_ARG=(--generate-notes); fi
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --title "$TAG" "${NOTES_ARG[@]}"
+          else
+            gh release create "$TAG" --title "$TAG" --verify-tag "${NOTES_ARG[@]}"
+          fi


### PR DESCRIPTION
## Why
The `publish` job builds & pushes images on a `v*` tag, but **never created the GitHub Release object** — so the `/releases` page was a manual step that drifted: Releases stopped at **v2.11.0** while tags/images reached **v2.16.0**. (Just backfilled the 7-version gap by hand.)

## Change
Adds a **`release`** job that runs on a `v*` tag, after `publish`:
- extracts the tag's section from `CHANGELOG.md` into the release notes,
- `gh release create` (or `gh release edit` if it already exists — **idempotent** for re-runs),
- `permissions: contents: write` scoped to the job; uses `${{ github.token }}`.

So `git tag vX.Y.Z && git push origin vX.Y.Z` now yields **images *and* the GitHub Release** — no manual step, no more drift.

## Validation
`ci.yml` parses (jobs: test, frontend, docker, publish, **release**). Notes-extraction uses the same awk pattern used to backfill the 7 historical releases; falls back to `--generate-notes` if a tag has no CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)