### PR TITLE
docs: add H8–H10 resilience track to queue-consumer hardening plan

### DIFF
--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -11,6 +11,12 @@ pattern — **at-least-once side-effects, low observability, and an unbounded
 result store** — to make it correct, observable, and bounded. It does **not**
 change the architecture or remove features.
 
+A later **resilience track (H8–H10)** extends the plan with fixes for a
+*demonstrated* failure mode — the 2026-09-12 preprod queue-jam, where a worker
+rollout during active scans stranded in-flight workflows on the old app-version
+and permanently saturated the `concurrency=2` queue. These are deploy-safety and
+state-consistency hardening, same additive-and-safe discipline.
+
 **Owner:** OpenEASD core. **Depends on:** nothing external.
 
 ---
@@ -251,6 +257,128 @@ suppresses scans.
 **Effort:** ~1 PR (cleanest **after** H6, so scheduled rows dispatch through the
 adapter). **Priority:** medium — operator-experience win.
 
+## 5f. Phase H8 — drain / quiesce the queue before a worker rollout (deploy safety)
+
+> **Origin:** a real 2026-09-12 preprod incident. The v2.16.0 rollout landed
+> **while scans were running**. DBOS pins an in-flight workflow to the code's
+> **app-version hash**; the new worker computed a different hash, so it could
+> **not recover** the two `PENDING` `run_scan` workflows left mid-flight by the
+> replaced worker. Because the `scans` queue is `concurrency=2`, those two
+> un-recoverable `PENDING` rows **occupied both slots permanently** → every scan
+> enqueued afterward (3 of them) sat `pending` indefinitely. Recovery required
+> manually cancelling the orphans via `DBOSClient.cancel_workflow`. Memory:
+> `project_dbos_rollout_queue_jam.md`.
+
+**Problem:** a worker rollout (k8s `apply -k` / `rollout restart`, or any image
+bump) during active scans strands the in-flight workflows on the **old**
+app-version. With a small `concurrency` (2), a handful of stranded `PENDING`
+workflows is enough to **saturate the queue forever** — a self-inflicted full
+stall with no automatic recovery. This is distinct from a clean crash (where the
+*same-version* worker resumes): the version **changes** across a deploy, which is
+precisely when resume does not apply.
+
+**Change (options, combine 1 + one of a/b):**
+1. **Document + script a pre-rollout drain** (smallest, do first): a
+   `just drain-scans` / runbook step that refuses (or waits) to roll the worker
+   while `ScanSession.objects.filter(status__in=["running","pending"])` is
+   non-empty — or scales the worker to 0, lets in-flight scans finish, then rolls.
+   Pair with the existing `SCHEDULED_SCANS_ENABLED=false` to stop *new* enqueues
+   during a maintenance window.
+2. Pick one automatic backstop so a drain that was skipped still recovers:
+   - **(a)** A startup **version-orphan reaper** in the worker entrypoint / a DBOS
+     `@scheduled` sweep: on launch, find `run_scan` workflows in `ENQUEUED`/`PENDING`
+     whose `application_version` ≠ the current worker's, and **cancel** them (their
+     `ScanSession` is re-enqueued fresh under the new version if still wanted).
+     This is the programmatic form of the manual fix from the incident.
+   - **(b)** Raise/curb reliance on a fixed `concurrency` so a couple of stranded
+     rows can't wholesale-block — e.g. a dedicated higher-concurrency lane for
+     quick passive scans (relates to the route-by-resource idea deliberately not
+     adopted for the general case; here it's a safety valve, not choreography).
+Recommend **1 + 2(a)**: a drain runbook to *prevent* it, plus a version-orphan
+reaper to *auto-heal* it. (a) must use the DBOS client API
+(`cancel_workflow`) — never a raw `UPDATE dbos.workflow_status` (the latter
+corrupts queue accounting and is blocked by tooling safety classifiers anyway).
+
+**Tests:** simulate a stranded `PENDING` with a mismatched `application_version`
+→ the reaper cancels it and frees the slot; a same-version `PENDING` (legit
+resume) is **never** touched; drain refuses to roll while scans are in-flight.
+
+**Effort:** ~1 PR (drain runbook + reaper). **Priority:** **high** — this failure
+has *already occurred* and fully stalls the scan subsystem with no auto-recovery.
+
+## 5g. Phase H9 — reconcile phantom `PENDING` workflows with terminal sessions
+
+> **Origin:** same 2026-09-12 incident. Observed `scan-25` (raga.ai) with
+> `ScanSession.status = "failed"` **but** its DBOS workflow still `PENDING`,
+> `executor=local` — a "phantom" holding a `concurrency` slot with no live
+> session behind it. The two sources of truth (Django `ScanSession` and
+> `dbos.workflow_status`) had **diverged**, and nothing reconciles them.
+
+**Problem:** `ScanSession.status` (domain truth) and the DBOS workflow status
+(engine truth) are separate records that can drift — a session reaped to
+`failed`/`cancelled` while its DBOS workflow lingers `PENDING`/`ENQUEUED`. A
+phantom `PENDING` silently consumes a scarce `concurrency` slot indefinitely, and
+nothing detects or clears it. This is the **inverse** of H4 (which stops the
+watchdog reaping a *live* scan): H9 cleans up an *orphaned engine workflow whose
+session is already terminal*.
+
+**Change:** add a lightweight **reconciliation sweep** (DBOS `@scheduled`, or fold
+into the H4/watchdog pass): for each non-terminal `run_scan` DBOS workflow
+(`ENQUEUED`/`PENDING`), look up its `ScanSession` (via the `deduplication_id`
+`scan-{id}` ↔ session id mapping observed in the incident); if the session is
+**terminal** (`completed`/`failed`/`partial`/`cancelled`), **cancel the workflow**
+(`cancel_workflow`) to free the slot. Emit a log/metric so a recurring divergence
+is visible (it signals a bug upstream, e.g. the watchdog reaping without
+cancelling the workflow — which H4 should also fix at the source).
+
+**Relationship to H4:** H4 makes the watchdog *not* reap sessions with a live DBOS
+workflow; H9 makes a separate pass *clean up* DBOS workflows whose session is
+already dead. Ideally H4 also **cancels the DBOS workflow when it reaps a session**
+(fixing the divergence at the source), leaving H9 as the periodic safety net.
+Do H9 **with or right after H4**.
+
+**Tests:** a `PENDING` workflow whose session is `failed` → reconciler cancels it
+and frees the slot; a `PENDING` workflow with a `running` session (legit
+in-flight) is untouched; reconciler is idempotent (re-running cancels nothing new).
+
+**Effort:** ~1 PR (shares the session↔workflow lookup with H4/H8). **Priority:**
+**medium-high** — a single undetected phantom halves a `concurrency=2` queue.
+
+## 5h. Phase H10 — short "no-progress" liveness watchdog (distinct from the 24h cap)
+
+> **Origin:** same incident exposed the gap. `SCAN_TASK_TIMEOUT` / the watchdog
+> cutoff is ~**24h** (deliberately high so a healthy long scan is never flipped
+> mid-run, per H4). But that means a **genuinely wedged** scan — or a phantom
+> holding a slot — can sit for **up to a day** before anything reaps it. On a
+> `concurrency=2` queue, two wedged slots = a **24h total stall**.
+
+**Problem:** there is exactly one timeout (the 24h hard cap), serving two
+conflicting goals: (i) *don't kill healthy long scans* (wants a **high** cutoff)
+and (ii) *free a wedged slot quickly* (wants a **low** cutoff). A single value
+can't do both, so today it's tuned for (i) and (ii) is unprotected.
+
+**Change:** add a **liveness / no-progress** signal separate from total runtime.
+- Have the runner stamp a **heartbeat** on the `ScanSession` (e.g.
+  `last_progress_at`) whenever it completes a phase-group step or writes a batch of
+  rows (the instrumentation point H2 already adds).
+- A **short** watchdog (`SCAN_NO_PROGRESS_MINUTES`, e.g. 30–60m, ≪ the 24h cap)
+  reaps a `running` scan whose `last_progress_at` is stale **and** whose DBOS
+  workflow is not actively advancing (compose with H4's live-workflow check and
+  H9's reconcile) — freeing the slot in minutes, not a day, **without** killing a
+  scan that is slow-but-progressing (its heartbeat keeps moving).
+- Keep the 24h hard cap as the absolute ceiling for a scan that *is* progressing
+  but has simply run too long.
+
+**Tests:** a scan emitting heartbeats past `SCAN_NO_PROGRESS_MINUTES` is **not**
+reaped (slow-but-alive); a scan with a stale heartbeat past the cutoff **is**
+reaped and its slot freed; the 24h cap still applies to a heartbeating-but-
+overlong scan.
+
+**Effort:** ~1 PR (the heartbeat stamp rides on H2's instrumentation; the watchdog
+extends the existing reaper). **Priority:** **medium-high** — directly bounds the
+blast radius of H8/H9 failures on the small-concurrency queue. Implements pipeline
+principle #12 (per-stage safety net) at a useful granularity.
+
 ## 6. Non-goals / explicitly out of scope
 
 - **Do NOT make the pattern "textbook pure."** The multi-producer (API +
@@ -276,6 +404,20 @@ adapter). **Priority:** medium — operator-experience win.
    (principle #8); operator-experience win.
 7. **H4 — watchdog ↔ DBOS-resume reconcile** (1 PR) — closes the recovery-path
    overlap. Lowest priority (narrow race, high timeout); do last.
+
+**Resilience track (H8–H10) — surfaced by the 2026-09-12 preprod queue-jam
+incident, not the original audit.** These address a *demonstrated* full-stall
+failure mode, so they jump ahead of the lower-priority cleanup items:
+
+8. **H8 — drain/quiesce before worker rollout + version-orphan reaper** (1 PR) —
+   **highest resilience priority**; the failure has already happened and fully
+   stalls scans with no auto-recovery. Do alongside or before H2.
+9. **H9 — reconcile phantom `PENDING` workflows with terminal sessions** (1 PR) —
+   do **with or right after H4** (shares the session↔workflow lookup; ideally H4
+   cancels the workflow at reap time and H9 is the periodic safety net).
+10. **H10 — short no-progress liveness watchdog** (1 PR) — bounds the blast radius
+    of H8/H9 on the `concurrency=2` queue; rides on H2's heartbeat instrumentation,
+    so sequence it **after/with H2**, composing with H4 + H9.
 
 **Reference implementation:** H2 (metrics), H6 (`@durable_task`), and H7
 (`ScheduledJob`) are all **proven in the sibling `cybersecify/backend` repo**
@@ -308,5 +450,15 @@ DESIGN.md "Workflow vs. Pipeline". Those are not tracked as gaps.
   enqueues; dedup preserved; scan/agent flows unchanged.
 - H7: a disabled `ScheduledJob` row never fires; an edited cron takes effect with
   no deploy; `SCHEDULED_SCANS_ENABLED=false` still suppresses scans.
+- H8: a stranded `PENDING` `run_scan` with a mismatched `application_version` is
+  cancelled by the version-orphan reaper and its slot freed; a same-version
+  `PENDING` (legit resume) is never touched; drain refuses to roll the worker
+  while scans are in-flight.
+- H9: a `PENDING` workflow whose `ScanSession` is terminal (`failed`/`cancelled`)
+  is cancelled and its slot freed; a `PENDING` with a `running` session is
+  untouched; the reconciler is idempotent.
+- H10: a scan emitting heartbeats past `SCAN_NO_PROGRESS_MINUTES` is NOT reaped
+  (slow-but-alive); a scan with a stale heartbeat past the cutoff IS reaped and
+  its slot freed; the 24h hard cap still applies to a heartbeating-but-overlong run.
 - Whole: with every feature unused/disabled, a scan is byte-identical to today
   (additive-safety check).


### PR DESCRIPTION
## What

Adds three new phases (**H8–H10**) to \`docs/specs/2026-09-07-producer-queue-consumer-hardening.md\`, a **resilience track** for deploy-safety and queue/state consistency.

## Why

Surfaced by a **real 2026-09-12 preprod incident**: the v2.16.0 worker rollout landed *while scans were running*. DBOS pins an in-flight workflow to the code's **app-version hash**, so the new worker couldn't recover the two \`PENDING\` \`run_scan\` workflows left mid-flight — and with \`Queue("scans", concurrency=2)\` those two un-recoverable rows **saturated both slots permanently**. Every subsequently enqueued scan sat \`pending\` forever; recovery needed a manual \`DBOSClient.cancel_workflow\`. (Captured in memory as \`project_dbos_rollout_queue_jam.md\`.)

## The three phases

- **H8 — drain/quiesce before a worker rollout + version-orphan reaper.** Prevent the jam (drain runbook; \`SCHEDULED_SCANS_ENABLED=false\` during maintenance) *and* auto-heal it (a reaper that cancels workflows pinned to a stale \`application_version\`, via the DBOS client API — never raw SQL). **High priority — demonstrated full stall, no auto-recovery.**
- **H9 — reconcile phantom \`PENDING\` workflows with terminal sessions.** The inverse of H4: clean up a DBOS workflow still \`PENDING\` while its \`ScanSession\` is already \`failed\`/\`cancelled\` (observed on \`scan-25\`), so it stops holding a concurrency slot. Do with/after H4.
- **H10 — short no-progress liveness watchdog.** A heartbeat-based reaper distinct from the 24h hard cap, so a wedged slot frees in minutes not a day on the \`concurrency=2\` queue — without killing slow-but-progressing scans. Rides on H2's instrumentation; implements pipeline principle #12.

Also updates the Goal intro, the sequencing (§7), and the verification (§8) sections.

## Scope

Docs only — no code, no migration. Each phase remains an independently-shippable PR when implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)