### PR TITLE
feat: reap phantom run_scan workflows holding scans-queue slots (H8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,6 +874,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
 | `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, authorization gate, `SCHEDULED_SCANS_ENABLED` switch |
+| `tests/unit/test_orphan_reaper.py` | 9 | H8 orphaned-workflow reaper — cancels ENQUEUED/PENDING `run_scan` workflows whose `ScanSession` is terminal/missing (phantom queue-slot holders); keeps live (pending/running) sessions; dry-run; fail-graceful (list/cancel errors swallowed) |
 | `tests/unit/test_service_detection.py` | 64 | XML parsing, Port enrichment, is_web |
 | `tests/unit/test_ssh_checker.py` | 34 | SSH probe, host key, kex/cipher/MAC, auth, collector |
 | `tests/unit/test_subfinder.py` | 10 | JSON parser, dedup, hostname normalization |
@@ -913,6 +914,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1831 tests** (1785 fast + 46 slow domain_security)
+**Total: 1840 tests** (1794 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/engine/durable/management/commands/reap_orphan_scans.py
+++ b/apps/core/engine/durable/management/commands/reap_orphan_scans.py
@@ -1,0 +1,41 @@
+"""Cancel phantom `run_scan` DBOS workflows holding `scans`-queue slots (H8).
+
+A phantom is a workflow still ENQUEUED/PENDING while its ScanSession is terminal
+(or gone) — it occupies a scarce concurrency slot with no live work behind it.
+A couple of phantoms can permanently jam the (concurrency=2) queue so no new scan
+dequeues. This is the operator-invoked form of the periodic reaper the watchdog
+runs; use it to clear a jam immediately after a worker rollout.
+
+    uv run manage.py reap_orphan_scans            # cancel phantoms now
+    uv run manage.py reap_orphan_scans --dry-run  # list them, cancel nothing
+"""
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Cancel phantom run_scan workflows holding scans-queue slots (terminal/missing session)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List the phantom workflows that would be cancelled, but cancel nothing.",
+        )
+
+    def handle(self, *args, **options):
+        from apps.core.engine.scheduler.scheduler import reap_orphaned_scan_workflows
+
+        apply = not options["dry_run"]
+        reaped = reap_orphaned_scan_workflows(apply=apply)
+
+        if not reaped:
+            self.stdout.write(self.style.SUCCESS("No phantom run_scan workflows found — queue is clean."))
+            return
+
+        verb = "Cancelled" if apply else "Would cancel (dry-run)"
+        self.stdout.write(self.style.WARNING(f"{verb} {len(reaped)} phantom workflow(s):"))
+        for workflow_id, dedup, status in reaped:
+            self.stdout.write(f"  {dedup:<14} session={status:<10} {workflow_id}")
+        if not apply:
+            self.stdout.write("Re-run without --dry-run to cancel them.")

--- a/apps/core/engine/durable/workflows.py
+++ b/apps/core/engine/durable/workflows.py
@@ -185,9 +185,16 @@ def scheduled_user_scans_sweep(scheduled_time, actual_time) -> None:
 @DBOS.scheduled(_WATCHDOG_CRON)
 @DBOS.workflow(name="scheduled_watchdog")
 def scheduled_watchdog(scheduled_time, actual_time) -> None:
-    from apps.core.engine.scheduler.scheduler import reap_stuck_scans
+    from apps.core.engine.scheduler.scheduler import (
+        reap_orphaned_scan_workflows,
+        reap_stuck_scans,
+    )
 
+    # Order matters: reap_stuck_scans first flips stale pending/running sessions
+    # to terminal (failed/partial), then reap_orphaned_scan_workflows cancels the
+    # now-phantom DBOS workflows still holding a `scans`-queue concurrency slot.
     reap_stuck_scans()
+    reap_orphaned_scan_workflows()
 
 
 @DBOS.scheduled(_TOKEN_PURGE_CRON)

--- a/apps/core/engine/scheduler/scheduler.py
+++ b/apps/core/engine/scheduler/scheduler.py
@@ -282,6 +282,99 @@ def reap_stuck_scans():
 
 
 # ---------------------------------------------------------------------------
+# Orphaned-workflow reaper (H8 — free jammed `scans`-queue concurrency slots)
+# ---------------------------------------------------------------------------
+
+# A ScanSession is "live" only while it is pending or running; any other status
+# is terminal. A DBOS run_scan workflow that is still ENQUEUED/PENDING while its
+# ScanSession is terminal (or gone) is a *phantom*: it occupies a scarce
+# `scans`-queue concurrency slot but has no live work behind it. With
+# concurrency=2, a couple of phantoms permanently jam the queue so no new scan
+# dequeues (observed 2026-09-12: a worker rollout orphaned in-flight run_scan
+# workflows pinned to the old app-version; their sessions were later reaped to
+# `failed` by reap_stuck_scans, but the DBOS workflows stayed PENDING and held
+# both slots). This reaper cancels those phantoms so the slots free.
+#
+# It only ever cancels a workflow whose session is NOT live, so it can never kill
+# a legitimately in-flight scan — making it safe to run unattended from the
+# watchdog cron (no app-version guessing, no rolling-deploy race). Pending/running
+# version-orphans are first flipped to terminal by reap_stuck_scans (pending after
+# SCAN_PENDING_TIMEOUT_MINUTES), after which this reaper clears their workflows.
+_SCAN_ACTIVE_STATUSES = {"pending", "running"}
+
+
+def reap_orphaned_scan_workflows(apply: bool = True):
+    """Cancel ENQUEUED/PENDING `run_scan` DBOS workflows whose ScanSession is
+    terminal or missing (phantoms holding a `scans`-queue concurrency slot).
+
+    Returns a list of ``(workflow_id, deduplication_id, session_status)`` tuples
+    that were (or, when ``apply=False``, would be) cancelled. Fail-graceful: any
+    error is logged and an empty list returned — it runs inside the watchdog cron
+    and must never abort the sweep.
+    """
+    try:
+        from apps.core.engine.durable.client import get_client
+        from apps.core.engine.durable.constants import QUEUE_NAME
+        from apps.core.engine.scans.models import ScanSession
+
+        client = get_client()
+        workflows = client.list_workflows(
+            name="run_scan",
+            status=["ENQUEUED", "PENDING"],
+            queue_name=QUEUE_NAME,
+            load_input=False,
+            load_output=False,
+        )
+    except Exception:  # noqa: BLE001 — never abort the watchdog sweep
+        logger.warning("[orphan-reaper] could not list run_scan workflows", exc_info=True)
+        return []
+
+    reaped = []
+    for wf in workflows:
+        dedup = getattr(wf, "deduplication_id", None) or ""
+        # enqueue_scan() always sets deduplication_id="scan-{session_id}".
+        session_id = None
+        if dedup.startswith("scan-"):
+            try:
+                session_id = int(dedup[len("scan-"):])
+            except ValueError:
+                session_id = None
+
+        if session_id is None:
+            # No resolvable session handle — leave it; we only reap workflows we
+            # can prove are orphaned (don't guess about un-mappable ones).
+            continue
+
+        status = (
+            ScanSession.objects.filter(id=session_id)
+            .values_list("status", flat=True)
+            .first()
+        )
+        session_is_live = status in _SCAN_ACTIVE_STATUSES
+        if session_is_live:
+            continue  # a pending/running session may still be legitimate work
+
+        # status is None (session deleted) or terminal → phantom slot holder.
+        reaped.append((wf.workflow_id, dedup, status or "missing"))
+        if apply:
+            try:
+                client.cancel_workflow(wf.workflow_id)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "[orphan-reaper] failed to cancel workflow %s (%s)",
+                    wf.workflow_id, dedup, exc_info=True,
+                )
+
+    if reaped:
+        verb = "Cancelled" if apply else "Would cancel"
+        logger.warning(
+            "[orphan-reaper] %s %d phantom run_scan workflow(s) holding a queue slot: %s",
+            verb, len(reaped), ", ".join(f"{d}({s})" for _, d, s in reaped),
+        )
+    return reaped
+
+
+# ---------------------------------------------------------------------------
 # JWT token cleanup
 # ---------------------------------------------------------------------------
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -177,6 +177,24 @@ version and re-apply. Because tags are immutable, this is deterministic — the
 > deploy that includes a migration, verify it applied:
 > `kubectl exec deploy/openeasd-web -c web -- python manage.py showmigrations`.
 
+> ⚠️ **Drain scans before rolling the worker, or the queue can jam.** A worker
+> rollout that lands **while scans are running** orphans the in-flight `run_scan`
+> DBOS workflows: the new worker's code hash differs from the old one's, so it
+> **cannot recover** them, and — because the `scans` queue is `concurrency=2` —
+> a couple of stranded `PENDING` workflows **occupy both slots permanently** →
+> every new scan sits `pending` forever (observed 2026-09-12; see the
+> producer→queue→consumer hardening plan, **H8**). Safe rollout:
+> 1. Quiesce new enqueues during the window: `SCHEDULED_SCANS_ENABLED=false`.
+> 2. Wait for in-flight scans to finish (the Scans page, or check for
+>    `running`/`pending` sessions) before rolling the worker.
+> 3. After the rollout, clear any phantom slot-holders immediately:
+>    `kubectl exec deploy/openeasd-web -c web -- python manage.py reap_orphan_scans`
+>    (add `--dry-run` to preview). It cancels only `run_scan` workflows whose
+>    `ScanSession` is already terminal, so it can never kill a live scan. The
+>    `scheduled_watchdog` cron also runs this reaper automatically every cycle, so
+>    a skipped drain self-heals within ~`SCAN_PENDING_TIMEOUT_MINUTES` + one
+>    watchdog interval — the manual command just makes it instant.
+
 ## Where things live
 
 | Concern | File |

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -259,6 +259,21 @@ adapter). **Priority:** medium — operator-experience win.
 
 ## 5f. Phase H8 — drain / quiesce the queue before a worker rollout (deploy safety)
 
+> **Status:** ✅ Slice 1 shipped — the **safe, race-free** core. A
+> `reap_orphaned_scan_workflows()` reaper (`scheduler.py`) cancels ENQUEUED/PENDING
+> `run_scan` workflows whose `ScanSession` is terminal/missing (phantoms holding a
+> `scans`-queue slot); it runs automatically in the `scheduled_watchdog` cron
+> (after `reap_stuck_scans` flips stale sessions terminal) and on demand via
+> `manage.py reap_orphan_scans [--dry-run]`. Drain runbook added to
+> `docs/DEVELOPMENT.md` (`SCHEDULED_SCANS_ENABLED=false` + wait + post-rollout
+> reap). Tests: `tests/unit/test_orphan_reaper.py` (9). **Deferred:** the
+> *auto version-orphan reaper on worker startup* (option 2a) — it has a
+> rolling-deploy race (a still-live old-version worker's in-flight scans) and
+> needs `DBOS__APPVERSION` pinning we don't have; the terminal-session reaper
+> subsumes its practical need (a pending version-orphan is reaped to terminal by
+> `reap_stuck_scans` after `SCAN_PENDING_TIMEOUT_MINUTES`, then cancelled here).
+> The *running*-session version-orphan (held up to the 24h cap) is **H10's** gap.
+
 > **Origin:** a real 2026-09-12 preprod incident. The v2.16.0 rollout landed
 > **while scans were running**. DBOS pins an in-flight workflow to the code's
 > **app-version hash**; the new worker computed a different hash, so it could

--- a/tests/unit/test_orphan_reaper.py
+++ b/tests/unit/test_orphan_reaper.py
@@ -1,0 +1,110 @@
+"""Tests for the orphaned-workflow reaper (H8).
+
+reap_orphaned_scan_workflows cancels ENQUEUED/PENDING run_scan DBOS workflows
+whose ScanSession is terminal or missing (phantoms holding a scans-queue slot),
+and never touches a workflow whose session is still pending/running.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.core.engine.scans.models import ScanSession
+from apps.core.engine.scheduler.scheduler import reap_orphaned_scan_workflows
+
+pytestmark = pytest.mark.django_db
+
+
+def _wf(workflow_id, dedup):
+    """A minimal stand-in for a DBOS WorkflowStatus."""
+    return SimpleNamespace(workflow_id=workflow_id, deduplication_id=dedup)
+
+
+def _fake_client(workflows):
+    client = MagicMock()
+    client.list_workflows.return_value = workflows
+    return client
+
+
+def _patch_client(client):
+    # reap_orphaned_scan_workflows imports get_client from this module at call time.
+    return patch("apps.core.engine.durable.client.get_client", return_value=client)
+
+
+def test_terminal_session_workflow_is_cancelled():
+    s = ScanSession.objects.create(domain="ex.com", status="failed")
+    client = _fake_client([_wf("wf-1", f"scan-{s.id}")])
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows()
+    assert [r[0] for r in reaped] == ["wf-1"]
+    client.cancel_workflow.assert_called_once_with("wf-1")
+
+
+@pytest.mark.parametrize("status", ["pending", "running"])
+def test_live_session_workflow_is_kept(status):
+    s = ScanSession.objects.create(domain="ex.com", status=status)
+    client = _fake_client([_wf("wf-live", f"scan-{s.id}")])
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows()
+    assert reaped == []
+    client.cancel_workflow.assert_not_called()
+
+
+def test_missing_session_workflow_is_cancelled():
+    # dedup points at a session id that does not exist → orphan.
+    client = _fake_client([_wf("wf-gone", "scan-999999")])
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows()
+    assert reaped == [("wf-gone", "scan-999999", "missing")]
+    client.cancel_workflow.assert_called_once_with("wf-gone")
+
+
+def test_unmappable_dedup_is_left_alone():
+    client = _fake_client([_wf("wf-x", "not-a-scan-handle")])
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows()
+    assert reaped == []
+    client.cancel_workflow.assert_not_called()
+
+
+def test_dry_run_lists_but_cancels_nothing():
+    s = ScanSession.objects.create(domain="ex.com", status="cancelled")
+    client = _fake_client([_wf("wf-2", f"scan-{s.id}")])
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows(apply=False)
+    assert [r[0] for r in reaped] == ["wf-2"]
+    client.cancel_workflow.assert_not_called()
+
+
+def test_mixed_batch_only_terminal_cancelled():
+    live = ScanSession.objects.create(domain="ex.com", status="running")
+    dead = ScanSession.objects.create(domain="ex.com", status="completed")
+    client = _fake_client([
+        _wf("wf-live", f"scan-{live.id}"),
+        _wf("wf-dead", f"scan-{dead.id}"),
+    ])
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows()
+    assert [r[0] for r in reaped] == ["wf-dead"]
+    client.cancel_workflow.assert_called_once_with("wf-dead")
+
+
+def test_list_failure_is_swallowed():
+    client = MagicMock()
+    client.list_workflows.side_effect = RuntimeError("dbos down")
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows()
+    assert reaped == []  # fail-graceful — never raises inside the watchdog
+
+
+def test_cancel_failure_does_not_abort_batch():
+    s1 = ScanSession.objects.create(domain="a.com", status="failed")
+    s2 = ScanSession.objects.create(domain="b.com", status="failed")
+    client = _fake_client([_wf("wf-a", f"scan-{s1.id}"), _wf("wf-b", f"scan-{s2.id}")])
+    client.cancel_workflow.side_effect = [RuntimeError("boom"), None]
+    with _patch_client(client):
+        reaped = reap_orphaned_scan_workflows()
+    # both are reported as phantoms; the first cancel failing doesn't stop the second
+    assert {r[0] for r in reaped} == {"wf-a", "wf-b"}
+    assert client.cancel_workflow.call_count == 2


### PR DESCRIPTION
## What

Implements **H8 slice 1** from the producer→queue→consumer hardening plan — the safe, race-free core that auto-heals the queue jam.

- **`reap_orphaned_scan_workflows()`** (`scheduler.py`) cancels `ENQUEUED`/`PENDING` `run_scan` DBOS workflows whose `ScanSession` is **terminal or missing** (phantoms holding a `scans`-queue concurrency slot), via the DBOS client API — no raw SQL. It **never** touches a `pending`/`running` session, so it cannot kill a live scan. Fail-graceful (list/cancel errors logged, never raised).
- Wired into the **`scheduled_watchdog`** cron, after `reap_stuck_scans` (which flips stale sessions terminal first, so pending version-orphans are cleared a cycle later).
- **`manage.py reap_orphan_scans [--dry-run]`** for immediate post-rollout cleanup.
- **`docs/DEVELOPMENT.md`**: drain-before-rollout runbook (`SCHEDULED_SCANS_ENABLED=false` + wait + reap).

## Why

2026-09-12 preprod incident: the v2.16.0 worker rollout landed while scans were running. DBOS pins in-flight workflows to the code's app-version hash, so the new worker couldn't recover the two `PENDING` `run_scan` workflows the replaced worker left behind — and with `Queue("scans", concurrency=2)` those two un-recoverable rows **saturated both slots permanently**. Every new scan sat `pending`; recovery needed a manual `cancel_workflow`. This reaper programmatizes that fix, safely and automatically. (Memory: \`project_dbos_rollout_queue_jam.md\`.)

## Scope / deferred

Slice 1 is the **terminal-session** reaper (unambiguously safe). Explicitly deferred, documented in the spec's H8 status note:
- The **auto version-orphan reaper on worker startup** (option 2a) — rolling-deploy race (a still-live old-version worker's in-flight scans) + needs `DBOS__APPVERSION` pinning we don't have. The terminal-session reaper subsumes its practical need (a pending version-orphan → reaped terminal by `reap_stuck_scans` after `SCAN_PENDING_TIMEOUT_MINUTES` → cancelled here).
- The **running-session version-orphan** (held up to the 24h cap) is **H10's** no-progress gap.

## Tests

\`tests/unit/test_orphan_reaper.py\` (9): terminal-session → cancelled; live (pending/running) → kept; missing session → cancelled; un-mappable dedup → left alone; dry-run lists but cancels nothing; mixed batch; list-failure swallowed; cancel-failure doesn't abort the batch. Ruff + \`manage.py check\` clean; related scheduler/runner suites green (80 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)