### PR TITLE
fix: idempotent crash-resume for Findings (H5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -890,7 +890,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_exposure_score.py` | 38 | Exposure Score — formula (clean=0, weights, saturation cap), grade bands, trend delta (up/down/flat/no-baseline), builder populates ScanSummary, insights + dashboard API fields, PDF report exposure block |
 | `tests/unit/test_web_checker.py` | 58 | Headers, cookies, CORS, disclosure, collector; security.txt (RFC 9116) — expires parsing, SPA-catch-all guard, missing=info/expired=low findings, reachable-vs-absent (unreachable ⇒ no false "missing"), apex-only collection + fail-graceful |
 | `tests/unit/test_passive_scan.py` | 27 | registry `active` classification (domain_security passive / domain_probe active), `is_passive_tool_set`, Credential Exposure grouping, Passive Scan workflow all-passive invariant, passive-scan auth-gate bypass + active-scan gate, subscan gate |
-| `tests/unit/test_workflow_runner.py` | 35 | run_workflow, naabu-gated service_detection injection, step failure, cancellation, phase parallelism (concurrent same-phase; LOW_MEMORY serialises heavy phases but light phase-1 tools still parallel) |
+| `tests/unit/test_workflow_runner.py` | 38 | run_workflow, naabu-gated service_detection injection, step failure, cancellation, phase parallelism (concurrent same-phase; LOW_MEMORY serialises heavy phases but light phase-1 tools still parallel); **H5 resume idempotency** (crash-resume re-run deletes the tool's stale Findings first → no duplicates; completed tool not re-run; first run normal) |
 | `tests/unit/test_default_workflow.py` | 5 | Full Scan is the default workflow with the complete 18-tool set (migration 0021), idempotent gap-fill |
 | `tests/integration/test_scan_flow.py` | 12 | Full pipeline (mocked) + delete cascade |
 | `tests/unit/test_update_check.py` | 22 | Update-available check — version parse/compare, cached GitHub fetch, fail-graceful on timeout/HTTP-error/bad-payload, endpoint shape |
@@ -914,6 +914,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1840 tests** (1794 fast + 46 slow domain_security)
+**Total: 1843 tests** (1797 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/engine/workflows/runner.py
+++ b/apps/core/engine/workflows/runner.py
@@ -82,6 +82,21 @@ def _run_single_step(run, session, tool: str, order: int) -> None:
         step_result.save(update_fields=[
             "order", "status", "started_at", "finished_at", "error", "findings_count",
         ])
+        # Idempotency (H5, pipeline principle #4): a non-terminal existing row means
+        # this tool was interrupted mid-run (worker crash), so it is about to be
+        # RE-executed. Finding writes use bulk_create (append, no unique constraint),
+        # so any Findings the tool wrote before the crash would be DUPLICATED by the
+        # re-run. Delete this tool's prior Findings for the session first, so the
+        # re-run converges to the same state (delete-then-insert). source == the
+        # registry tool key. Assets need no cleanup — they are (session, …)-unique
+        # and written with ignore_conflicts=True, so re-writes are already idempotent.
+        from apps.core.data.findings.models import Finding
+        deleted, _ = Finding.objects.filter(session=session, source=tool).delete()
+        if deleted:
+            logger.info(
+                "[workflow:%s] resume: cleared %d stale %s finding(s) before re-run",
+                run.id, deleted, tool,
+            )
     else:
         step_result = WorkflowStepResult.objects.create(
             run=run,

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -164,6 +164,17 @@ terminal/absent DBOS workflow past cutoff is reaped as today.
 
 ## 5c. Phase H5 — idempotent phase-group steps (pipeline principle #4)
 
+> **Status:** ✅ Shipped — implemented at **per-tool** granularity (finer than the
+> per-group option A), in `runner.py::_run_single_step`. The existing F1b resume
+> guard already skips tools that reached a terminal state and re-runs only a tool
+> left non-terminal by a crash; in exactly that re-run branch we now
+> **delete the tool's prior `Finding` rows for the session** (`source == tool`)
+> before re-executing, so Finding writes (bulk_create, no unique constraint)
+> converge instead of duplicating. Assets need no cleanup — they are
+> `(session, …)`-unique and written with `ignore_conflicts=True`, so re-writes are
+> already idempotent. Tests: `test_workflow_runner.py::TestResumeIdempotencyH5`
+> (3: crash-resume no-dup, completed-tool-not-rerun, first-run-normal). No migration.
+
 **Problem:** `_run_phase_group` is a `@DBOS.step` that runs *all* tools in a phase.
 DBOS skips a step that **completed**, but a step that **crashes mid-run** re-runs
 the whole group on resume — so a tool that already wrote its rows before the crash

--- a/tests/unit/test_workflow_runner.py
+++ b/tests/unit/test_workflow_runner.py
@@ -725,3 +725,80 @@ class TestPhaseParallelExecution:
         assert WorkflowStepResult.objects.get(run=run, tool="tls_checker").status == "completed"
         # Phase-10 tool was skipped
         assert WorkflowStepResult.objects.get(run=run, tool="nuclei").status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# H5 — idempotent re-run of a crash-interrupted tool (no duplicate Findings)
+# ---------------------------------------------------------------------------
+
+class TestResumeIdempotencyH5:
+    """_run_single_step must delete a tool's prior Findings before re-running it
+    on a crash-resume (non-terminal step row), so Finding writes converge instead
+    of duplicating (bulk_create has no unique constraint)."""
+
+    def _finding_runner(self, n):
+        """A runner that writes n Findings for the session (like a real tool)."""
+        def _run(session):
+            from apps.core.data.findings.models import Finding
+            objs = [
+                Finding(
+                    session=session, source="nmap", check_type="cve",
+                    severity="high", title=f"CVE-{i}", description="d",
+                    remediation="r", target="1.2.3.4:22",
+                )
+                for i in range(n)
+            ]
+            Finding.objects.bulk_create(objs)
+            return objs
+        return _run
+
+    def test_crash_resume_does_not_duplicate_findings(self, transactional_db, run):
+        from apps.core.data.findings.models import Finding
+        from apps.core.engine.workflows.runner import _run_single_step
+
+        # Simulate a crash mid-run: a non-terminal step row + 2 partially-written findings.
+        WorkflowStepResult.objects.create(
+            run=run, tool="nmap", order=1, status="running",
+            started_at=timezone.now(),
+        )
+        self._finding_runner(2)(run.session)
+        assert Finding.objects.filter(session=run.session, source="nmap").count() == 2
+
+        # Resume: re-run writes 3 findings. Old 2 must be cleared first → exactly 3.
+        with _patch_get_runner({"nmap": self._finding_runner(3)}):
+            _run_single_step(run, run.session, "nmap", order=1)
+
+        assert Finding.objects.filter(session=run.session, source="nmap").count() == 3
+        assert WorkflowStepResult.objects.get(run=run, tool="nmap").status == "completed"
+
+    def test_completed_tool_is_not_rerun_and_findings_kept(self, transactional_db, run):
+        from apps.core.data.findings.models import Finding
+        from apps.core.engine.workflows.runner import _run_single_step
+
+        # A tool that already COMPLETED this run: its row is terminal, findings stay.
+        WorkflowStepResult.objects.create(
+            run=run, tool="nmap", order=1, status="completed",
+            started_at=timezone.now(), finished_at=timezone.now(),
+        )
+        self._finding_runner(2)(run.session)
+
+        called = {"n": 0}
+        def _should_not_run(session):
+            called["n"] += 1
+            return []
+        with _patch_get_runner({"nmap": _should_not_run}):
+            _run_single_step(run, run.session, "nmap", order=1)
+
+        assert called["n"] == 0  # early-return: tool not re-executed
+        assert Finding.objects.filter(session=run.session, source="nmap").count() == 2
+
+    def test_first_run_writes_findings_normally(self, transactional_db, run):
+        from apps.core.data.findings.models import Finding
+        from apps.core.engine.workflows.runner import _run_single_step
+
+        # No prior step row → fresh run, nothing to delete, findings written once.
+        with _patch_get_runner({"nmap": self._finding_runner(2)}):
+            _run_single_step(run, run.session, "nmap", order=1)
+
+        assert Finding.objects.filter(session=run.session, source="nmap").count() == 2
+        assert WorkflowStepResult.objects.get(run=run, tool="nmap").status == "completed"


### PR DESCRIPTION
## What
Implements **H5** (pipeline principle #4 — idempotent steps) at per-tool granularity in `runner.py::_run_single_step`.

When the phase-group DBOS step re-runs a tool that a worker crash left **non-terminal** (the existing F1b resume path), we now **delete that tool's prior `Finding` rows for the session** (`source == tool`) before re-executing — so Finding writes (which use `bulk_create`, no unique constraint → append) **converge** instead of duplicating.

## Why
It's the one remaining *correctness* gap in the "durable" claim after H1 (alerts): a tool that wrote some findings before the crash would have them duplicated on resume. Confirmed: all 19 finding-producing tools use `bulk_create`. Assets need no change — they're `(session, …)`-unique and written with `ignore_conflicts=True`, so re-writes are already idempotent.

## Scope / safety
- Only the **crash-resume re-run** branch deletes (a tool left `running`/`pending`). Completed tools still early-return (findings preserved); first runs are untouched.
- The Issue register + asset-inventory rollups run at **finalize**, after all phases, so mid-run delete/re-insert doesn't affect them.

## Tests
`test_workflow_runner.py::TestResumeIdempotencyH5` (3): crash-resume → no duplicate findings; completed tool not re-run (findings kept); first run normal. Full runner suite green (40 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)