### PR TITLE
feat: opt-in scan retention / pruning (H3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -874,6 +874,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_coverage.py` | 6 | Scan coverage (spec C2) — endpoint counts, dominant vendor, report note wording |
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
 | `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, authorization gate, `SCHEDULED_SCANS_ENABLED` switch |
+| `tests/unit/test_scan_retention.py` | 7 | H3 scan pruning — opt-in (`SCAN_RETENTION_ENABLED`), keep newest-N per domain, max-age window, always keep latest, never delete pending/running, per-domain, cascade to findings |
 | `tests/unit/test_orphan_reaper.py` | 9 | H8 orphaned-workflow reaper — cancels ENQUEUED/PENDING `run_scan` workflows whose `ScanSession` is terminal/missing (phantom queue-slot holders); keeps live (pending/running) sessions; dry-run; fail-graceful (list/cancel errors swallowed) |
 | `tests/unit/test_service_detection.py` | 64 | XML parsing, Port enrichment, is_web |
 | `tests/unit/test_ssh_checker.py` | 34 | SSH probe, host key, kex/cipher/MAC, auth, collector |
@@ -914,6 +915,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1843 tests** (1797 fast + 46 slow domain_security)
+**Total: 1850 tests** (1804 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/engine/durable/workflows.py
+++ b/apps/core/engine/durable/workflows.py
@@ -203,3 +203,17 @@ def scheduled_token_purge(scheduled_time, actual_time) -> None:
     from apps.core.engine.scheduler.scheduler import purge_expired_blacklisted_tokens
 
     purge_expired_blacklisted_tokens()
+
+
+_SCAN_PRUNE_CRON = getattr(settings, "SCAN_PRUNE_CRON", "30 3 * * *")
+
+
+@DBOS.scheduled(_SCAN_PRUNE_CRON)
+@DBOS.workflow(name="scheduled_scan_prune")
+def scheduled_scan_prune(scheduled_time, actual_time) -> None:
+    """Prune old scan history (H3). A hygiene cron like token-purge — always
+    registered, but a no-op unless SCAN_RETENTION_ENABLED (the function self-gates),
+    so it is NOT tied to SCHEDULED_SCANS_ENABLED."""
+    from apps.core.engine.scheduler.scheduler import prune_old_scans
+
+    prune_old_scans()

--- a/apps/core/engine/scheduler/scheduler.py
+++ b/apps/core/engine/scheduler/scheduler.py
@@ -387,3 +387,74 @@ def purge_expired_blacklisted_tokens():
     if deleted:
         logger.info(f"[token_purge] Deleted {deleted} expired outstanding token(s)")
     return deleted
+
+
+# ---------------------------------------------------------------------------
+# Scan retention / pruning (H3 — bounded result store)
+# ---------------------------------------------------------------------------
+
+def prune_old_scans():
+    """Delete old scan history to bound DB growth — OPT-IN (no-op unless
+    SCAN_RETENTION_ENABLED). Per domain, keep the newest
+    SCAN_RETENTION_KEEP_PER_DOMAIN scans AND any newer than
+    SCAN_RETENTION_MAX_AGE_DAYS; delete the rest. Invariants:
+
+    - The single newest scan per domain is ALWAYS kept (a domain never ends up
+      with zero scans, even if its newest is older than MAX_AGE_DAYS).
+    - pending/running scans are NEVER deleted (they may be in-flight); only
+      terminal scans are deletion candidates.
+    - Deletion cascades to the scan's assets/findings (FK on_delete=CASCADE);
+      the persistent asset_inventory + Issue registers keep the long-term
+      surface history, so pruning raw scans doesn't lose the over-time story.
+
+    Returns the number of ScanSessions deleted.
+    """
+    from django.conf import settings
+
+    if not getattr(settings, "SCAN_RETENTION_ENABLED", False):
+        return 0
+
+    from apps.core.engine.scans.models import ScanSession
+
+    keep_n = getattr(settings, "SCAN_RETENTION_KEEP_PER_DOMAIN", 30)
+    max_age_days = getattr(settings, "SCAN_RETENTION_MAX_AGE_DAYS", 180)
+    age_cutoff = (
+        django_tz.now() - django_tz.timedelta(days=max_age_days)
+        if max_age_days and max_age_days > 0
+        else None
+    )
+    terminal = ["completed", "failed", "partial", "cancelled"]
+
+    # order_by() clears ScanSession.Meta.ordering — otherwise the ordering field
+    # is added to the SELECT and defeats DISTINCT (one row per scan, not per domain).
+    domains = list(
+        ScanSession.objects.order_by().values_list("domain", flat=True).distinct()
+    )
+    to_delete = []
+    for domain in domains:
+        # Newest-first; only terminal scans are candidates for deletion.
+        sessions = list(
+            ScanSession.objects.filter(domain=domain, status__in=terminal)
+            .order_by("-start_time")
+            .values_list("id", "start_time")
+        )
+        for idx, (sid, start_time) in enumerate(sessions):
+            if idx == 0:
+                continue  # always keep the newest terminal scan for the domain
+            if idx < keep_n:
+                continue  # within the keep-N window
+            if age_cutoff is not None and start_time >= age_cutoff:
+                continue  # within the max-age window
+            to_delete.append(sid)
+
+    if not to_delete:
+        return 0
+
+    deleted, _ = ScanSession.objects.filter(id__in=to_delete).delete()
+    # `deleted` counts cascaded rows too; report the ScanSession count explicitly.
+    session_count = len(to_delete)
+    logger.info(
+        "[retention] Pruned %d old scan(s) across %d domain(s) (keep=%d, max_age_days=%s)",
+        session_count, len(set(domains)), keep_n, max_age_days,
+    )
+    return session_count

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -109,6 +109,15 @@ auth behaviour.
 
 ## 5. Phase H3 — Bounded result store (retention / pruning)
 
+> **Status:** ✅ Shipped — `prune_old_scans()` (`scheduler.py`) + `scheduled_scan_prune`
+> (`@DBOS.scheduled`, `SCAN_PRUNE_CRON` default `30 3 * * *`). OFF by default
+> (`SCAN_RETENTION_ENABLED`); when on, keeps per domain the newest
+> `SCAN_RETENTION_KEEP_PER_DOMAIN` (30) scans + any within
+> `SCAN_RETENTION_MAX_AGE_DAYS` (180), always keeps the single newest, never deletes
+> pending/running, and cascades to assets/findings. Hygiene cron (self-gates on the
+> setting), so NOT tied to `SCHEDULED_SCANS_ENABLED`. Tests:
+> `tests/unit/test_scan_retention.py` (7). No migration.
+
 **Problem:** unbounded growth of scan history.
 
 **Change:**

--- a/openeasd/settings/base.py
+++ b/openeasd/settings/base.py
@@ -327,6 +327,17 @@ DBOS_APP_NAME = config("DBOS_APP_NAME", default="openeasd")
 DBOS_SCAN_CONCURRENCY = config("DBOS_SCAN_CONCURRENCY", default=2, cast=int)
 SCAN_STEP_TIMEOUT = config("SCAN_STEP_TIMEOUT", default=SCAN_TASK_TIMEOUT, cast=int)
 
+# Scan retention / pruning (H3 — bounded result store). OFF by default: pruning
+# deletes scan history (cascading to its assets/findings), so it is opt-in. When
+# enabled, prune_old_scans keeps, per domain, the newest KEEP_PER_DOMAIN scans AND
+# any scan newer than MAX_AGE_DAYS; older ones are deleted. The single latest scan
+# per domain is ALWAYS kept regardless. The persistent asset_inventory + Issue
+# registers preserve the long-term "surface over time" story, so pruning raw scan
+# rows does not lose it. Set MAX_AGE_DAYS=0 to disable the age rule (count only).
+SCAN_RETENTION_ENABLED = config("SCAN_RETENTION_ENABLED", default=False, cast=bool)
+SCAN_RETENTION_KEEP_PER_DOMAIN = config("SCAN_RETENTION_KEEP_PER_DOMAIN", default=30, cast=int)
+SCAN_RETENTION_MAX_AGE_DAYS = config("SCAN_RETENTION_MAX_AGE_DAYS", default=180, cast=int)
+
 # Scanner timeouts (seconds) — override in .env if needed
 SCANNER_DNS_TIMEOUT = config("SCANNER_DNS_TIMEOUT", default=5, cast=int)
 SCANNER_HTTP_TIMEOUT = config("SCANNER_HTTP_TIMEOUT", default=10, cast=int)

--- a/tests/unit/test_scan_retention.py
+++ b/tests/unit/test_scan_retention.py
@@ -1,0 +1,129 @@
+"""Tests for scan retention / pruning (H3 — bounded result store).
+
+prune_old_scans is OPT-IN (no-op unless SCAN_RETENTION_ENABLED). When enabled it
+keeps, per domain, the newest KEEP_PER_DOMAIN scans + any within MAX_AGE_DAYS,
+always keeps the single newest, never deletes pending/running, and cascades.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.core.data.findings.models import Finding
+from apps.core.engine.scans.models import ScanSession
+from apps.core.engine.scheduler.scheduler import prune_old_scans
+
+pytestmark = pytest.mark.django_db
+
+
+def _scan(domain, *, status="completed", age_days=0):
+    s = ScanSession.objects.create(domain=domain, status=status)
+    if age_days:
+        # start_time is auto_now_add; override via update to backdate.
+        ScanSession.objects.filter(id=s.id).update(
+            start_time=timezone.now() - timedelta(days=age_days)
+        )
+        s.refresh_from_db()
+    return s
+
+
+def test_noop_when_disabled(settings):
+    settings.SCAN_RETENTION_ENABLED = False
+    for i in range(5):
+        _scan("ex.com", age_days=i + 1)
+    assert prune_old_scans() == 0
+    assert ScanSession.objects.count() == 5
+
+
+def test_keeps_newest_n_per_domain(settings):
+    settings.SCAN_RETENTION_ENABLED = True
+    settings.SCAN_RETENTION_KEEP_PER_DOMAIN = 3
+    settings.SCAN_RETENTION_MAX_AGE_DAYS = 0  # disable age rule → count only
+    # 6 scans, ages 10..60 days so all are outside any age window.
+    for d in range(10, 70, 10):
+        _scan("ex.com", age_days=d)
+    deleted = prune_old_scans()
+    assert deleted == 3  # 6 - keep 3
+    assert ScanSession.objects.filter(domain="ex.com").count() == 3
+
+
+def test_max_age_keeps_recent_beyond_n(settings):
+    settings.SCAN_RETENTION_ENABLED = True
+    settings.SCAN_RETENTION_KEEP_PER_DOMAIN = 2
+    settings.SCAN_RETENTION_MAX_AGE_DAYS = 90
+    # 4 recent (within 90d) + 2 old (beyond 90d). Keep: newest 2 by count + all
+    # within-age → all 4 recent kept; the 2 old ones beyond both windows deleted.
+    for d in (5, 20, 40, 80):
+        _scan("ex.com", age_days=d)
+    for d in (120, 200):
+        _scan("ex.com", age_days=d)
+    deleted = prune_old_scans()
+    assert deleted == 2
+    remaining_ages_ok = ScanSession.objects.filter(domain="ex.com").count() == 4
+    assert remaining_ages_ok
+
+
+def test_always_keeps_newest_even_if_old(settings):
+    settings.SCAN_RETENTION_ENABLED = True
+    settings.SCAN_RETENTION_KEEP_PER_DOMAIN = 0  # count window keeps nothing
+    settings.SCAN_RETENTION_MAX_AGE_DAYS = 30
+    # single scan, very old → still kept (never leave a domain with zero scans)
+    _scan("ex.com", age_days=365)
+    deleted = prune_old_scans()
+    assert deleted == 0
+    assert ScanSession.objects.filter(domain="ex.com").count() == 1
+
+
+def test_never_deletes_pending_or_running(settings):
+    # NB: a partial unique constraint (uniq_active_scan_per_domain) allows at most
+    # one active (pending/running) scan per domain, so the running and pending
+    # cases use different domains.
+    settings.SCAN_RETENTION_ENABLED = True
+    settings.SCAN_RETENTION_KEEP_PER_DOMAIN = 1
+    settings.SCAN_RETENTION_MAX_AGE_DAYS = 0
+    # ex.com: newest terminal kept, old terminal deleted, running never deleted.
+    _scan("ex.com", status="completed", age_days=10)  # newest terminal (kept)
+    _scan("ex.com", status="completed", age_days=40)  # old terminal → deleted
+    _scan("ex.com", status="running", age_days=20)    # in-flight, never deleted
+    # ex2.com: a pending (active) scan + one terminal — pending never deleted.
+    _scan("ex2.com", status="pending", age_days=5)    # in-flight, never deleted
+    _scan("ex2.com", status="completed", age_days=30)  # only terminal → kept (newest)
+    deleted = prune_old_scans()
+    assert deleted == 1  # only ex.com's old completed scan
+    assert ScanSession.objects.filter(domain="ex.com", status="running").exists()
+    assert ScanSession.objects.filter(domain="ex2.com", status="pending").exists()
+
+
+def test_prune_is_per_domain(settings):
+    settings.SCAN_RETENTION_ENABLED = True
+    settings.SCAN_RETENTION_KEEP_PER_DOMAIN = 1
+    settings.SCAN_RETENTION_MAX_AGE_DAYS = 0
+    for d in (10, 20, 30):
+        _scan("a.com", age_days=d)
+    for d in (10, 20):
+        _scan("b.com", age_days=d)
+    deleted = prune_old_scans()
+    assert deleted == 3  # a.com: 3-1=2 ; b.com: 2-1=1
+    assert ScanSession.objects.filter(domain="a.com").count() == 1
+    assert ScanSession.objects.filter(domain="b.com").count() == 1
+
+
+def test_cascade_deletes_findings(settings):
+    settings.SCAN_RETENTION_ENABLED = True
+    settings.SCAN_RETENTION_KEEP_PER_DOMAIN = 1
+    settings.SCAN_RETENTION_MAX_AGE_DAYS = 0
+    newest = _scan("ex.com", age_days=5)
+    old = _scan("ex.com", age_days=50)
+    Finding.objects.create(
+        session=old, source="nmap", check_type="cve", severity="high",
+        title="old", description="d", remediation="r", target="t",
+    )
+    Finding.objects.create(
+        session=newest, source="nmap", check_type="cve", severity="high",
+        title="new", description="d", remediation="r", target="t",
+    )
+    prune_old_scans()
+    assert not ScanSession.objects.filter(id=old.id).exists()
+    assert Finding.objects.filter(session_id=old.id).count() == 0  # cascaded
+    assert Finding.objects.filter(session_id=newest.id).count() == 1


### PR DESCRIPTION
## What
Implements **H3** (bounded result store). `prune_old_scans()` + a `scheduled_scan_prune` `@DBOS.scheduled` hygiene cron.

- **OFF by default** (`SCAN_RETENTION_ENABLED=false`) — it deletes data, so opt-in.
- When on: per domain, keep the newest `SCAN_RETENTION_KEEP_PER_DOMAIN` (30) scans **plus** any within `SCAN_RETENTION_MAX_AGE_DAYS` (180 days); delete older **terminal** scans (cascades to their assets/findings).
- **Invariants:** always keep the single newest scan per domain (never leave a domain empty); never delete `pending`/`running` scans.
- The cron self-gates on the setting (like token-purge), so it is **not** tied to `SCHEDULED_SCANS_ENABLED`.

## Why
A monitored deployment grows `ScanSession`/`Finding`/asset rows without limit. The persistent `asset_inventory` + `Issue` registers preserve the long-term "surface over time" story, so pruning raw scan rows doesn't lose it.

## Notes
- Fixed a Django `distinct()`-vs-`Meta.ordering` gotcha in the per-domain query (`order_by()` to clear ordering before `distinct()`).
- Respects the existing `uniq_active_scan_per_domain` constraint (at most one active scan per domain).

## Tests
`tests/unit/test_scan_retention.py` (7): no-op when disabled, keep newest-N, max-age window, always-keep-latest, never-delete-active, per-domain, cascade-to-findings. Ruff + `manage.py check` clean; scheduler suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)