### PR TITLE
feat: no-progress liveness watchdog (H10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,6 +875,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
 | `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, authorization gate, `SCHEDULED_SCANS_ENABLED` switch |
 | `tests/unit/test_scan_retention.py` | 7 | H3 scan pruning — opt-in (`SCAN_RETENTION_ENABLED`), keep newest-N per domain, max-age window, always keep latest, never delete pending/running, per-domain, cascade to findings |
+| `tests/unit/test_no_progress_watchdog.py` | 5 | H10 no-progress watchdog — reap running scan on stale `last_progress_at` heartbeat (fresh → kept, stale → reaped, NULL+old → reaped, NULL+recent → kept, 24h hard cap still applies) |
 | `tests/unit/test_metrics.py` | 9 | H2 DB-backed Prometheus exporter — scans-by-status, queue depth, findings-by-severity, domains, journey latency, liveness staleness; `/metrics` endpoint (prometheus text, no-store, unauthenticated, `METRICS_ENABLED` 404 toggle); `last_progress_at` heartbeat stamped per step |
 | `tests/unit/test_orphan_reaper.py` | 9 | H8 orphaned-workflow reaper — cancels ENQUEUED/PENDING `run_scan` workflows whose `ScanSession` is terminal/missing (phantom queue-slot holders); keeps live (pending/running) sessions; dry-run; fail-graceful (list/cancel errors swallowed) |
 | `tests/unit/test_service_detection.py` | 64 | XML parsing, Port enrichment, is_web |
@@ -916,6 +917,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1859 tests** (1813 fast + 46 slow domain_security)
+**Total: 1864 tests** (1818 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/engine/scheduler/scheduler.py
+++ b/apps/core/engine/scheduler/scheduler.py
@@ -32,6 +32,14 @@ SCAN_TIMEOUT_MINUTES = _config("SCAN_TIMEOUT_MINUTES", default=1440, cast=int)  
 # that legitimately queue scans for long stretches behind long-running ones.
 SCAN_PENDING_TIMEOUT_MINUTES = _config("SCAN_PENDING_TIMEOUT_MINUTES", default=60, cast=int)
 
+# H10 — no-progress watchdog. A running scan that has not completed a step (no
+# heartbeat on ScanSession.last_progress_at) for this many minutes is treated as
+# wedged and reaped, freeing its scarce concurrency slot in minutes rather than
+# waiting out the 24h hard cap (SCAN_TIMEOUT_MINUTES). Must stay COMFORTABLY above
+# the longest single-tool runtime (nuclei/amass can run tens of minutes and the
+# heartbeat only ticks between steps) so a slow-but-alive scan is never killed.
+SCAN_NO_PROGRESS_MINUTES = _config("SCAN_NO_PROGRESS_MINUTES", default=60, cast=int)
+
 
 # ---------------------------------------------------------------------------
 # Core schedule setup (legacy no-op — schedules are DBOS @scheduled workflows)
@@ -227,9 +235,23 @@ def reap_stuck_scans():
     now = django_tz.now()
     running_cutoff = now - django_tz.timedelta(minutes=SCAN_TIMEOUT_MINUTES)
     pending_cutoff = now - django_tz.timedelta(minutes=SCAN_PENDING_TIMEOUT_MINUTES)
+    no_progress_cutoff = now - django_tz.timedelta(minutes=SCAN_NO_PROGRESS_MINUTES)
+    # A running scan is stuck if EITHER it has exceeded the 24h hard cap
+    # (SCAN_TIMEOUT_MINUTES) OR it has made no progress for
+    # SCAN_NO_PROGRESS_MINUTES (H10). The heartbeat (ScanSession.last_progress_at,
+    # stamped on every step completion) is the liveness signal: a slow-but-alive
+    # scan keeps it fresh and is NOT reaped; a wedged scan goes stale and is freed
+    # in minutes instead of a day. NULL heartbeat (no step has finished yet) falls
+    # back to start_time, so a scan that never completes a first step is still
+    # reaped once it's stale. NO_PROGRESS must exceed the longest single-tool
+    # runtime (heartbeat is per-step), hence a generous default.
+    running_stuck = Q(status="running") & (
+        Q(start_time__lt=running_cutoff)
+        | Q(last_progress_at__lt=no_progress_cutoff)
+        | Q(last_progress_at__isnull=True, start_time__lt=no_progress_cutoff)
+    )
     stuck_qs = ScanSession.objects.filter(
-        Q(status="running", start_time__lt=running_cutoff)
-        | Q(status="pending", start_time__lt=pending_cutoff)
+        running_stuck | Q(status="pending", start_time__lt=pending_cutoff)
     ).select_related("workflow_run")
 
     reap_msg = "reaped by watchdog after timeout"

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -398,6 +398,17 @@ in-flight) is untouched; reconciler is idempotent (re-running cancels nothing ne
 
 ## 5h. Phase H10 — short "no-progress" liveness watchdog (distinct from the 24h cap)
 
+> **Status:** ✅ Shipped — `reap_stuck_scans` now reaps a `running` scan when its
+> `last_progress_at` heartbeat (H2) is older than `SCAN_NO_PROGRESS_MINUTES`
+> (default 60), in addition to the 24h `SCAN_TIMEOUT_MINUTES` hard cap. A
+> slow-but-alive scan keeps the heartbeat fresh (stamped per step completion) and
+> is not reaped; a NULL heartbeat falls back to `start_time`. The default stays
+> comfortably above the longest single-tool runtime (heartbeat only ticks between
+> steps). The existing orphan reaper wired after `reap_stuck_scans` then cancels the
+> reaped scan's DBOS workflow (frees the slot). Tests:
+> `tests/unit/test_no_progress_watchdog.py` (5) + updated `test_scheduler.py`
+> (live scans now carry a heartbeat). No migration (uses H2's field).
+
 > **Origin:** same incident exposed the gap. `SCAN_TASK_TIMEOUT` / the watchdog
 > cutoff is ~**24h** (deliberately high so a healthy long scan is never flipped
 > mid-run, per H4). But that means a **genuinely wedged** scan — or a phantom

--- a/tests/unit/test_no_progress_watchdog.py
+++ b/tests/unit/test_no_progress_watchdog.py
@@ -1,0 +1,77 @@
+"""Tests for the H10 no-progress watchdog (reap_stuck_scans heartbeat path).
+
+A running scan is reaped when its last_progress_at heartbeat is stale beyond
+SCAN_NO_PROGRESS_MINUTES, while a slow-but-heartbeating scan is left alone. The
+24h hard cap (SCAN_TIMEOUT_MINUTES) still applies to a heartbeating-but-overlong
+run.
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.core.engine.scans.models import ScanSession
+from apps.core.engine.scheduler.scheduler import reap_stuck_scans
+
+pytestmark = pytest.mark.django_db
+
+
+def _running(domain, *, started_min_ago, progress_min_ago=None):
+    s = ScanSession.objects.create(domain=domain, status="running")
+    fields = {"start_time": timezone.now() - timedelta(minutes=started_min_ago)}
+    if progress_min_ago is not None:
+        fields["last_progress_at"] = timezone.now() - timedelta(minutes=progress_min_ago)
+    ScanSession.objects.filter(id=s.id).update(**fields)
+    s.refresh_from_db()
+    return s
+
+
+def test_fresh_heartbeat_not_reaped(settings):
+    settings.SCAN_NO_PROGRESS_MINUTES = 60
+    settings.SCAN_TIMEOUT_MINUTES = 1440
+    # running 90 min but heartbeated 2 min ago → slow-but-alive → NOT reaped.
+    s = _running("a.com", started_min_ago=90, progress_min_ago=2)
+    reap_stuck_scans()
+    s.refresh_from_db()
+    assert s.status == "running"
+
+
+def test_stale_heartbeat_reaped(settings):
+    settings.SCAN_NO_PROGRESS_MINUTES = 60
+    settings.SCAN_TIMEOUT_MINUTES = 1440
+    # heartbeated 90 min ago (> 60) though well under the 24h cap → wedged → reaped.
+    s = _running("a.com", started_min_ago=120, progress_min_ago=90)
+    reap_stuck_scans()
+    s.refresh_from_db()
+    assert s.status in ("failed", "partial")
+
+
+def test_null_heartbeat_reaped_when_old(settings):
+    settings.SCAN_NO_PROGRESS_MINUTES = 60
+    settings.SCAN_TIMEOUT_MINUTES = 1440
+    # never completed a step (NULL heartbeat), started 90 min ago → reaped.
+    s = _running("a.com", started_min_ago=90, progress_min_ago=None)
+    reap_stuck_scans()
+    s.refresh_from_db()
+    assert s.status in ("failed", "partial")
+
+
+def test_null_heartbeat_recent_not_reaped(settings):
+    settings.SCAN_NO_PROGRESS_MINUTES = 60
+    settings.SCAN_TIMEOUT_MINUTES = 1440
+    # just started (5 min), no step finished yet → within grace → NOT reaped.
+    s = _running("a.com", started_min_ago=5, progress_min_ago=None)
+    reap_stuck_scans()
+    s.refresh_from_db()
+    assert s.status == "running"
+
+
+def test_hard_cap_still_reaps_heartbeating_overlong(settings):
+    settings.SCAN_NO_PROGRESS_MINUTES = 60
+    settings.SCAN_TIMEOUT_MINUTES = 1440  # 24h
+    # heartbeating (fresh) but running 25h → exceeds the hard cap → reaped.
+    s = _running("a.com", started_min_ago=1500, progress_min_ago=1)
+    reap_stuck_scans()
+    s.refresh_from_db()
+    assert s.status in ("failed", "partial")

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -23,15 +23,17 @@ from apps.core.engine.scheduler.scheduler import (
 # ---------------------------------------------------------------------------
 
 class TestReapStuckScans:
-    def _make_session(self, status, age_minutes, domain="example.com"):
+    def _make_session(self, status, age_minutes, domain="example.com", progress_minutes_ago=None):
         from apps.core.engine.scans.models import ScanSession
         session = ScanSession.objects.create(
             domain=domain, scan_type="full", status=status,
         )
-        # Backdate start_time
-        ScanSession.objects.filter(pk=session.pk).update(
-            start_time=timezone.now() - timedelta(minutes=age_minutes)
-        )
+        # Backdate start_time; optionally set a liveness heartbeat (H10). Without
+        # a heartbeat a running scan is eligible for the no-progress reap.
+        fields = {"start_time": timezone.now() - timedelta(minutes=age_minutes)}
+        if progress_minutes_ago is not None:
+            fields["last_progress_at"] = timezone.now() - timedelta(minutes=progress_minutes_ago)
+        ScanSession.objects.filter(pk=session.pk).update(**fields)
         session.refresh_from_db()
         return session
 
@@ -86,16 +88,22 @@ class TestReapStuckScans:
         assert session.status == "pending"
 
     def test_running_scan_keeps_longer_timeout(self, db):
-        """A running scan older than the pending cutoff but under the running
-        timeout is NOT reaped — running scans keep the full SCAN_TIMEOUT budget."""
-        session = self._make_session("running", SCAN_PENDING_TIMEOUT_MINUTES + 5)
+        """A LIVE running scan (fresh heartbeat) older than the pending cutoff but
+        under the running timeout is NOT reaped — running scans keep the full
+        SCAN_TIMEOUT budget as long as they keep making progress (H10)."""
+        session = self._make_session(
+            "running", SCAN_PENDING_TIMEOUT_MINUTES + 5, progress_minutes_ago=1
+        )
         count = reap_stuck_scans()
         assert count == 0
         session.refresh_from_db()
         assert session.status == "running"
 
     def test_does_not_reap_recent_running_scan(self, db):
-        session = self._make_session("running", SCAN_TIMEOUT_MINUTES - 1)
+        # Live scan (fresh heartbeat) just under the 24h hard cap → kept.
+        session = self._make_session(
+            "running", SCAN_TIMEOUT_MINUTES - 1, progress_minutes_ago=1
+        )
         count = reap_stuck_scans()
         assert count == 0
         session.refresh_from_db()
@@ -116,7 +124,8 @@ class TestReapStuckScans:
     def test_reaps_multiple_stuck_scans(self, db):
         self._make_session("running", SCAN_TIMEOUT_MINUTES + 5, "a.com")
         self._make_session("pending", SCAN_TIMEOUT_MINUTES + 5, "b.com")
-        self._make_session("running", SCAN_TIMEOUT_MINUTES - 1, "c.com")  # recent — skip
+        # Live scan just under the hard cap (fresh heartbeat) — skipped.
+        self._make_session("running", SCAN_TIMEOUT_MINUTES - 1, "c.com", progress_minutes_ago=1)
         count = reap_stuck_scans()
         assert count == 2
 


### PR DESCRIPTION
## What
Implements **H10**, closing the running-session orphan gap H8 left open. `reap_stuck_scans` now reaps a `running` scan whose `last_progress_at` heartbeat (from H2) is stale beyond `SCAN_NO_PROGRESS_MINUTES` (default 60), **in addition to** the 24h `SCAN_TIMEOUT_MINUTES` hard cap.

- A slow-but-alive scan keeps its heartbeat fresh (stamped per step completion) → **not** reaped.
- A `NULL` heartbeat (no step finished yet) falls back to `start_time` → a scan that never completes a first step is still reaped once stale.
- The 24h hard cap still bounds a heartbeating-but-overlong run.
- The orphan reaper already wired after `reap_stuck_scans` (H8) then cancels the reaped scan's DBOS workflow, freeing the slot.

## Why
Before, a wedged `running` scan held a scarce `concurrency=2` slot for up to **24h**. H10 frees it in ~minutes using the real liveness signal, without false-killing long-but-progressing scans. `SCAN_NO_PROGRESS_MINUTES` must exceed the longest single-tool runtime (heartbeat only ticks between steps) — hence the generous default.

## Tests
`tests/unit/test_no_progress_watchdog.py` (5): fresh→kept, stale→reaped, NULL+old→reaped, NULL+recent→kept, 24h cap still applies. Updated `test_scheduler.py` so "live" running scans carry a heartbeat (being merely old no longer keeps a scan alive — the intended behavior change). Ruff + scheduler/orphan suites green (48 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)