### PR TITLE
fix: watchdog ↔ DBOS reconcile — cancel reaped scans' workflows inline (H4 + H9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,6 +875,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_scans.py` | 30 | ScanSession, scheduling, scan_start views |
 | `tests/unit/test_scheduler.py` | 33 | reap_stuck_scans, token purge, daily_scan, authorization gate, `SCHEDULED_SCANS_ENABLED` switch |
 | `tests/unit/test_scan_retention.py` | 7 | H3 scan pruning — opt-in (`SCAN_RETENTION_ENABLED`), keep newest-N per domain, max-age window, always keep latest, never delete pending/running, per-domain, cascade to findings |
+| `tests/unit/test_watchdog_reconcile.py` | 6 | H4/H9 watchdog↔DBOS reconcile — reap_stuck_scans cancels the reaped scan's DBOS workflow inline (`_cancel_workflows_for_sessions` matches `scan-{id}` dedup); empty no-op, list/cancel failures swallowed, reap-then-cancel end-to-end |
 | `tests/unit/test_no_progress_watchdog.py` | 5 | H10 no-progress watchdog — reap running scan on stale `last_progress_at` heartbeat (fresh → kept, stale → reaped, NULL+old → reaped, NULL+recent → kept, 24h hard cap still applies) |
 | `tests/unit/test_metrics.py` | 9 | H2 DB-backed Prometheus exporter — scans-by-status, queue depth, findings-by-severity, domains, journey latency, liveness staleness; `/metrics` endpoint (prometheus text, no-store, unauthenticated, `METRICS_ENABLED` 404 toggle); `last_progress_at` heartbeat stamped per step |
 | `tests/unit/test_orphan_reaper.py` | 9 | H8 orphaned-workflow reaper — cancels ENQUEUED/PENDING `run_scan` workflows whose `ScanSession` is terminal/missing (phantom queue-slot holders); keeps live (pending/running) sessions; dry-run; fail-graceful (list/cancel errors swallowed) |
@@ -917,6 +918,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1864 tests** (1818 fast + 46 slow domain_security)
+**Total: 1870 tests** (1824 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/engine/scheduler/scheduler.py
+++ b/apps/core/engine/scheduler/scheduler.py
@@ -257,8 +257,10 @@ def reap_stuck_scans():
     reap_msg = "reaped by watchdog after timeout"
     partial_count = 0
     failed_count = 0
+    reaped_ids = []
 
     for session in stuck_qs:
+        reaped_ids.append(session.id)
         run = getattr(session, "workflow_run", None)
         completed_step = False
         if run is not None:
@@ -300,7 +302,55 @@ def reap_stuck_scans():
             f"[watchdog] Reaped {total} stuck scan(s) — "
             f"{partial_count} as partial (kept findings), {failed_count} as failed"
         )
+    # H4/H9 reconcile (source-fix): a scan we just reaped to terminal leaves its
+    # DBOS run_scan workflow still ENQUEUED/PENDING — a phantom that holds a
+    # scans-queue concurrency slot. Cancel those workflows inline, in the SAME
+    # pass that reaped the sessions, so a phantom never outlives its scan
+    # (rather than depending on reap_orphaned_scan_workflows running afterwards —
+    # that remains the periodic safety net for anything missed). The heartbeat
+    # reap (H10) is the liveness signal that keeps us from reaping a scan DBOS is
+    # legitimately still advancing, which is H4's "don't fight DBOS resume" goal.
+    _cancel_workflows_for_sessions(reaped_ids)
     return total
+
+
+def _cancel_workflows_for_sessions(session_ids) -> int:
+    """Cancel the ENQUEUED/PENDING run_scan DBOS workflows for the given sessions
+    (matched by deduplication_id ``scan-{id}``). Fail-graceful — logs and returns
+    0 on any error so it never aborts the watchdog sweep. Idempotent: cancelling
+    an already-terminal workflow is a no-op."""
+    if not session_ids:
+        return 0
+    try:
+        from apps.core.engine.durable.client import get_client
+        from apps.core.engine.durable.constants import QUEUE_NAME
+
+        client = get_client()
+        workflows = client.list_workflows(
+            name="run_scan",
+            status=["ENQUEUED", "PENDING"],
+            queue_name=QUEUE_NAME,
+            load_input=False,
+            load_output=False,
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("[watchdog] could not list run_scan workflows to cancel", exc_info=True)
+        return 0
+
+    wanted = {f"scan-{sid}" for sid in session_ids}
+    cancelled = 0
+    for wf in workflows:
+        if (getattr(wf, "deduplication_id", None) or "") in wanted:
+            try:
+                client.cancel_workflow(wf.workflow_id)
+                cancelled += 1
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "[watchdog] failed to cancel workflow %s", wf.workflow_id, exc_info=True
+                )
+    if cancelled:
+        logger.info("[watchdog] cancelled %d DBOS workflow(s) for reaped scan(s)", cancelled)
+    return cancelled
 
 
 # ---------------------------------------------------------------------------

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -156,6 +156,16 @@ no-op when disabled.
 
 ## 5b. Phase H4 — reconcile the watchdog with DBOS resume (design smell)
 
+> **Status:** ✅ Resolved via the heartbeat, not the spec's "query DBOS liveness"
+> option. H10's `last_progress_at` heartbeat IS the liveness signal: the watchdog
+> only reaps a `running` scan that has made **no progress** for
+> `SCAN_NO_PROGRESS_MINUTES` (or exceeded the 24h cap), so a scan DBOS is
+> legitimately resuming/advancing keeps its heartbeat fresh and is never reaped —
+> which is exactly H4's "don't fight DBOS resume" goal, achieved without querying
+> the DBOS workflow store on every sweep. Paired with H9 (below), the reap now also
+> cancels the scan's DBOS workflow inline. Tests: `test_no_progress_watchdog.py` +
+> `test_watchdog_reconcile.py`.
+
 **Problem:** `reap_stuck_scans` (the `scheduled_watchdog` cron) and DBOS's own
 crash-resume are **two uncoordinated recovery mechanisms** for the same scans.
 The watchdog reaps a `running` scan by `start_time` age → marks it `failed`/
@@ -359,6 +369,14 @@ resume) is **never** touched; drain refuses to roll while scans are in-flight.
 has *already occurred* and fully stalls the scan subsystem with no auto-recovery.
 
 ## 5g. Phase H9 — reconcile phantom `PENDING` workflows with terminal sessions
+
+> **Status:** ✅ Shipped — two complementary mechanisms. **Source-fix:**
+> `reap_stuck_scans` now cancels each reaped scan's DBOS workflow inline
+> (`_cancel_workflows_for_sessions`, matched by `scan-{id}` dedup), so a phantom
+> never outlives its scan. **Periodic safety net:** `reap_orphaned_scan_workflows`
+> (H8), wired after `reap_stuck_scans` in the watchdog, still sweeps any
+> non-terminal workflow whose session is already terminal. Both are fail-graceful
+> and idempotent. Tests: `test_watchdog_reconcile.py` (6) + `test_orphan_reaper.py`.
 
 > **Origin:** same 2026-09-12 incident. Observed `scan-25` (raga.ai) with
 > `ScanSession.status = "failed"` **but** its DBOS workflow still `PENDING`,

--- a/tests/unit/test_watchdog_reconcile.py
+++ b/tests/unit/test_watchdog_reconcile.py
@@ -1,0 +1,90 @@
+"""Tests for the H4/H9 watchdog↔DBOS reconcile — reap_stuck_scans cancels the
+reaped scan's DBOS workflow inline, and the helper is safe/idempotent."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.utils import timezone
+
+from apps.core.engine.scans.models import ScanSession
+from apps.core.engine.scheduler.scheduler import (
+    SCAN_TIMEOUT_MINUTES,
+    _cancel_workflows_for_sessions,
+    reap_stuck_scans,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _wf(workflow_id, dedup):
+    return SimpleNamespace(workflow_id=workflow_id, deduplication_id=dedup)
+
+
+def _fake_client(workflows):
+    c = MagicMock()
+    c.list_workflows.return_value = workflows
+    return c
+
+
+def _patch_client(client):
+    return patch("apps.core.engine.durable.client.get_client", return_value=client)
+
+
+def _stuck_running(domain):
+    s = ScanSession.objects.create(domain=domain, status="running")
+    ScanSession.objects.filter(id=s.id).update(
+        start_time=timezone.now() - timedelta(minutes=SCAN_TIMEOUT_MINUTES + 10)
+    )
+    return s
+
+
+class TestCancelHelper:
+    def test_cancels_only_matching_sessions(self):
+        client = _fake_client([_wf("wf-1", "scan-1"), _wf("wf-2", "scan-2"), _wf("wf-3", "scan-3")])
+        with _patch_client(client):
+            n = _cancel_workflows_for_sessions([1, 3])
+        assert n == 2
+        called = {c.args[0] for c in client.cancel_workflow.call_args_list}
+        assert called == {"wf-1", "wf-3"}
+
+    def test_empty_is_noop(self):
+        client = _fake_client([])
+        with _patch_client(client):
+            assert _cancel_workflows_for_sessions([]) == 0
+        client.list_workflows.assert_not_called()
+
+    def test_list_failure_swallowed(self):
+        client = MagicMock()
+        client.list_workflows.side_effect = RuntimeError("dbos down")
+        with _patch_client(client):
+            assert _cancel_workflows_for_sessions([1]) == 0
+
+    def test_cancel_failure_does_not_abort(self):
+        client = _fake_client([_wf("wf-1", "scan-1"), _wf("wf-2", "scan-2")])
+        client.cancel_workflow.side_effect = [RuntimeError("boom"), None]
+        with _patch_client(client):
+            n = _cancel_workflows_for_sessions([1, 2])
+        assert n == 1
+        assert client.cancel_workflow.call_count == 2
+
+
+class TestReapCancelsWorkflow:
+    def test_reaping_cancels_the_scans_workflow(self):
+        s = _stuck_running("ex.com")
+        client = _fake_client([_wf("wf-x", f"scan-{s.id}")])
+        with _patch_client(client):
+            reaped = reap_stuck_scans()
+        assert reaped == 1
+        s.refresh_from_db()
+        assert s.status in ("failed", "partial")
+        client.cancel_workflow.assert_called_once_with("wf-x")
+
+    def test_reap_with_no_matching_workflow_is_fine(self):
+        _stuck_running("ex.com")
+        client = _fake_client([_wf("wf-other", "scan-999")])  # unrelated
+        with _patch_client(client):
+            reaped = reap_stuck_scans()
+        assert reaped == 1
+        client.cancel_workflow.assert_not_called()


### PR DESCRIPTION
## What
Closes **H9** and **H4**.

- **H9 (source-fix):** `reap_stuck_scans` now cancels each reaped scan's DBOS `run_scan` workflow **inline** (`_cancel_workflows_for_sessions`, matched by `scan-{id}` dedup) — so a phantom `PENDING` workflow never outlives its scan and can't keep holding a `scans`-queue concurrency slot. The H8 orphan reaper (wired after `reap_stuck_scans`) stays as the periodic safety net.
- **H4 (resolved via the heartbeat):** rather than the spec's "query DBOS workflow liveness each sweep" option, H10's `last_progress_at` heartbeat is the liveness signal — the watchdog only reaps a `running` scan with **no progress** (stale heartbeat) or past the 24h cap, so a scan DBOS is legitimately resuming keeps its heartbeat fresh and is never reaped. That's H4's "don't fight DBOS resume" goal, simpler and without extra DBOS queries.

Both paths are fail-graceful (list/cancel errors logged, never abort the sweep) and idempotent (cancelling a terminal workflow is a no-op).

## Tests
`tests/unit/test_watchdog_reconcile.py` (6): helper cancels only matching sessions, empty no-op, list-failure swallowed, cancel-failure doesn't abort, reap-then-cancel end-to-end, reap with no matching workflow is fine. Scheduler + H10 suites green (45 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)