### PR TITLE
fix: API security-review findings (webhook leak, XFF, report gate, token revoke)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,7 +419,7 @@ Per-module routers (each file exports a `router = Router(auth=JWTAuth())`):
 - Access token: short-lived, sent as `Authorization: Bearer <token>`
 - Refresh token: long-lived, sent in POST body to `/api/token/refresh`
 - Logout: blacklists refresh token via `/api/token/blacklist` (simplejwt OutstandingToken/BlacklistedToken)
-- **Brute-force rate limiting:** `LoginRateLimitMiddleware` (`apps/core/console/api/ratelimit.py`) locks out an IP after `LOGIN_RATELIMIT_MAX_FAILURES` (default 5) failed `POST /api/token/pair` attempts within the window, returning 429 + `Retry-After`. State is the DB-backed `LoginThrottle` model (shared across gunicorn workers, unlike the per-process LocMemCache). Only `/token/pair` is limited (not `/refresh`); a successful login clears the IP's counter. Per-IP via `X-Forwarded-For` when `LOGIN_RATELIMIT_TRUST_FORWARDED_FOR` is on (default, for the mandated proxy); off → falls back to the unspoofable `REMOTE_ADDR` so a bare deployment can't be evaded by rotating the header. Tunable/`LOGIN_RATELIMIT_ENABLED`-toggle via settings. Tests: `tests/unit/test_login_ratelimit.py`.
+- **Brute-force rate limiting:** `LoginRateLimitMiddleware` (`apps/core/console/api/ratelimit.py`) locks out an IP after `LOGIN_RATELIMIT_MAX_FAILURES` (default 5) failed `POST /api/token/pair` attempts within the window, returning 429 + `Retry-After`. State is the DB-backed `LoginThrottle` model (shared across gunicorn workers, unlike the per-process LocMemCache). Only `/token/pair` is limited (not `/refresh`); a successful login clears the IP's counter. Per-IP via `X-Forwarded-For` when `LOGIN_RATELIMIT_TRUST_FORWARDED_FOR` is on (default, for the mandated proxy) — keyed on the **rightmost** XFF entry (the hop the trusted proxy appended; the leftmost is client-forgeable, so keying on it would let an attacker rotate a spoofed header to evade the lockout — assumes a single trusted proxy); off → falls back to the unspoofable `REMOTE_ADDR`. Tunable/`LOGIN_RATELIMIT_ENABLED`-toggle via settings. Tests: `tests/unit/test_login_ratelimit.py`.
 
 **Adding a new API endpoint:**
 1. Add endpoint function to the relevant `apps/core/<module>/api.py` router
@@ -822,8 +822,8 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 ```
 
 ### Other routes
-- `/reports/<uuid>/csv/` → CSV export (**synchronous** Django view on the web tier, `_report_auth_required` — accepts session auth or `?token=<access_token>`)
-- `/reports/<uuid>/pdf/` → PDF export (**synchronous** Django view on the web tier, rendered with WeasyPrint, `_report_auth_required` — accepts session auth or `?token=<access_token>`)
+- `/reports/<uuid>/csv/` → CSV export (**synchronous** Django view on the web tier, `_report_auth_required` — accepts session auth or an `Authorization: Bearer` header; the old `?token=` query-param was removed in F-sec3, and the gate now also honors `must_change_password`)
+- `/reports/<uuid>/pdf/` → PDF export (**synchronous** Django view on the web tier, rendered with WeasyPrint, `_report_auth_required` — same auth as CSV: session or Bearer header, no `?token=`, `must_change_password` enforced)
 - **Reports UI:** the React SPA has a dedicated **Reports page** (`/reports`, nav item + `ReportsPage.jsx`) listing completed scans with per-scan CSV/PDF export + a `min_severity` filter (auth'd fetch+Blob, JWT in header); also still available as CSV/PDF buttons on the Scan Detail page. The SPA `/reports` route and the Django `/reports/<uuid>/{csv,pdf}/` endpoints coexist — Django's SPA catch-all serves bare `/reports`, and the Vite dev proxy uses a `^/reports/.+` regex so only the endpoints proxy to Django.
 - `/admin/` → Django admin
 - `/api/docs` → Django Ninja auto-generated OpenAPI docs
@@ -914,11 +914,12 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/integration/test_ai_flow.py` | 6 | AI end-to-end (only the Cloudflare HTTP edge + queue mocked): finalize → triage/summaries/agent/audit, report + alert carry output, subscan chain roundtrip, AI-off zero traces, Cloudflare-down scan still completes; plus an opt-in LIVE smoke test (runs only with real `CLOUDFLARE_*` env: `pytest tests/integration/test_ai_flow.py -k live`) |
 | `tests/test_api_endpoints.py` | 104 | Smoke tests for all API endpoints (auth + payload shape), incl. build-provenance `/health/` + `/api/version/` (+ `no-store`) + update-check `/api/version/latest/` |
 | `tests/unit/test_crypto.py` | 16 | At-rest secret encryption — Fernet roundtrip/non-determinism/legacy-plaintext tolerance, key derivation/override/rotation, DB-holds-ciphertext + ORM-returns-plaintext for AI/notifications/amass/subfinder |
-| `tests/unit/test_login_ratelimit.py` | 13 | Login brute-force limiter — threshold lockout, window reset, success clears, X-Forwarded-For keying (+ untrusted-XFF fallback / spoof-evasion), middleware integration (per-IP isolation, disabled bypass, refresh endpoint unaffected) |
+| `tests/unit/test_login_ratelimit.py` | 14 | Login brute-force limiter — threshold lockout, window reset, success clears, **rightmost** X-Forwarded-For keying (leftmost is client-forgeable — spoofed-leftmost can't evade when trusted; untrusted-XFF fallback to REMOTE_ADDR), middleware integration (per-IP isolation, disabled bypass, refresh endpoint unaffected) |
+| `tests/unit/test_api_security_fixes.py` | 5 | API-review security fixes — webhook URL/secret not leaked in `/notifications/test/` error (H1); report download honours `must_change_password` gate via Bearer (M1); change-password blacklists outstanding refresh tokens (M2) + rejects >128-char password (M4) |
 
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1877 tests** (1831 fast + 46 slow domain_security)
+**Total: 1883 tests** (1837 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/console/api/ninja.py
+++ b/apps/core/console/api/ninja.py
@@ -146,6 +146,10 @@ def change_password(request, payload: ChangePasswordIn):
         raise HttpError(400, "Current password is incorrect")
     if len(payload.new_password) < 8:
         raise HttpError(400, "New password must be at least 8 characters")
+    # Cap length: set_password PBKDF2-hashes the raw string, so an unbounded
+    # password is an authenticated CPU-burn vector.
+    if len(payload.new_password) > 128:
+        raise HttpError(400, "New password must be at most 128 characters")
     if payload.new_password == payload.current_password:
         raise HttpError(400, "New password must differ from current password")
     u.set_password(payload.new_password)
@@ -155,6 +159,20 @@ def change_password(request, payload: ChangePasswordIn):
     if profile and profile.must_change_password:
         profile.must_change_password = False
         profile.save(update_fields=["must_change_password"])
+    # Revoke existing sessions: the API is stateless JWT, so without this a
+    # previously-issued (possibly stolen) refresh token keeps minting access
+    # tokens after the password change. Blacklist all of the user's outstanding
+    # refresh tokens so a password change actually ends other sessions. Access
+    # tokens are short-lived and expire on their own.
+    try:
+        from ninja_jwt.token_blacklist.models import BlacklistedToken, OutstandingToken
+        for ot in OutstandingToken.objects.filter(user=u):
+            BlacklistedToken.objects.get_or_create(token=ot)
+    except Exception:  # noqa: BLE001 — a blacklist hiccup must not fail the change
+        import logging
+        logging.getLogger(__name__).warning(
+            "[auth] could not blacklist outstanding tokens on password change", exc_info=True
+        )
     return {"ok": True}
 
 

--- a/apps/core/console/api/ratelimit.py
+++ b/apps/core/console/api/ratelimit.py
@@ -29,16 +29,24 @@ def _cfg(name, default):
 def client_ip(request) -> str:
     """Client IP the limiter keys on.
 
-    Behind the documented TLS reverse proxy, REMOTE_ADDR is the proxy, so the
-    leftmost X-Forwarded-For entry (set by that proxy) identifies the client —
-    used when LOGIN_RATELIMIT_TRUST_FORWARDED_FOR is on (the default). When it is
-    off (no trusted proxy), XFF is ignored and the unspoofable REMOTE_ADDR is
-    used, so an attacker cannot rotate the header to evade the limit.
+    Behind the documented single TLS reverse proxy, REMOTE_ADDR is the proxy and
+    the proxy APPENDS the real client IP to any inbound X-Forwarded-For. So the
+    trustworthy value is the **rightmost** (last) XFF entry — the hop the proxy
+    itself added — NOT the leftmost, which the client can forge. Taking the
+    leftmost would let an attacker rotate a spoofed `X-Forwarded-For: <random>`
+    per request to get a fresh throttle key every time and evade the lockout.
+    Used when LOGIN_RATELIMIT_TRUST_FORWARDED_FOR is on (the default). When off
+    (no trusted proxy), XFF is ignored and the unspoofable REMOTE_ADDR is used.
+
+    NB: this assumes exactly one trusted proxy in front. With N chained proxies
+    the trusted entry is the Nth-from-right; set LOGIN_RATELIMIT_TRUST_FORWARDED_FOR
+    off (or front with a single proxy) if that doesn't hold.
     """
     if _cfg("LOGIN_RATELIMIT_TRUST_FORWARDED_FOR", True):
         xff = request.META.get("HTTP_X_FORWARDED_FOR", "")
         if xff:
-            return xff.split(",")[0].strip()
+            # rightmost = the hop our own proxy appended (client can forge the rest)
+            return xff.split(",")[-1].strip()
     return request.META.get("REMOTE_ADDR") or "unknown"
 
 

--- a/apps/core/console/notifications/api.py
+++ b/apps/core/console/notifications/api.py
@@ -138,7 +138,13 @@ def test_notification(request, data: TestIn):
         resp.raise_for_status()
         return {"ok": True, "channel": channel}
     except Exception as e:
-        raise HttpError(502, f"Webhook delivery failed: {e}")
+        # Do NOT put `e` in the response: requests' exceptions embed the full
+        # webhook URL, whose path carries the Slack/Teams secret token. The URL is
+        # write-only everywhere else (never returned by GET), so leaking it here
+        # would let a client exfiltrate the secret by triggering a failed test.
+        # Log the detail server-side; return a generic message.
+        logger.warning("[notifications] %s webhook test delivery failed: %s", channel, e)
+        raise HttpError(502, "Webhook delivery failed — see server logs for detail.")
 
 
 @router.get("/alerts/")

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -264,9 +264,19 @@ def _report_auth_required(view_func):
     the Bearer header), so nothing depends on it — a token in the query string is
     now ignored.
     """
+    def _password_change_pending(user) -> bool:
+        # Mirror JWTAuth: a user still on the forced-change flag (e.g. default
+        # admin/admin) must not reach data endpoints. The Ninja API blocks them
+        # everywhere but /user/*; without this check the report views are a hole
+        # in that server-side enforcement.
+        profile = getattr(user, "profile", None)
+        return bool(profile is not None and profile.must_change_password)
+
     @functools.wraps(view_func)
     def wrapper(request, *args, **kwargs):
         if request.user.is_authenticated:
+            if _password_change_pending(request.user):
+                return HttpResponseRedirect('/change-password')
             return view_func(request, *args, **kwargs)
 
         auth_header = request.headers.get('Authorization', '')
@@ -277,7 +287,10 @@ def _report_auth_required(view_func):
                 from ninja_jwt.tokens import AccessToken
                 token_obj = AccessToken(token)
                 user_id = token_obj["user_id"]
-                request.user = User.objects.get(id=user_id, is_active=True)
+                user = User.objects.get(id=user_id, is_active=True)
+                if _password_change_pending(user):
+                    return HttpResponseRedirect('/change-password')
+                request.user = user
                 return view_func(request, *args, **kwargs)
             except Exception as exc:
                 logger.debug(f"Report token auth failed: {exc}")

--- a/tests/unit/test_api_security_fixes.py
+++ b/tests/unit/test_api_security_fixes.py
@@ -1,0 +1,111 @@
+"""Tests for the API security-review fixes (H1, M1, M2, M4).
+
+- H1: /notifications/test/ must not leak the webhook URL (secret) in its error.
+- M1: report downloads must honour the must_change_password gate.
+- M2: change-password must blacklist the user's outstanding refresh tokens.
+- M4: change-password must reject an over-long new password.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import requests
+from django.contrib.auth.models import User
+from django.test import Client
+from ninja_jwt.tokens import AccessToken, RefreshToken
+
+pytestmark = pytest.mark.django_db
+
+
+def _bearer(user):
+    return {"HTTP_AUTHORIZATION": f"Bearer {AccessToken.for_user(user)}"}
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="admin", password="longpass1")
+
+
+# --- H1: webhook secret not leaked in test-alert error -----------------------
+
+class TestWebhookSecretNotLeaked:
+    def test_failed_slack_test_does_not_leak_url(self, user):
+        from apps.core.console.notifications.models import NotificationConfig
+        secret_url = "https://hooks.slack.com/services/T000/B000/SUPERSECRETTOKEN"
+        cfg = NotificationConfig.objects.get_or_create(pk=1)[0]
+        cfg.slack_webhook_url = secret_url
+        cfg.save()
+
+        # requests raises with the full URL embedded — the classic leak vector.
+        boom = requests.exceptions.HTTPError(
+            f"404 Client Error: Not Found for url: {secret_url}"
+        )
+        # api.py does `import requests as req_lib` inside the view, so patch the
+        # real requests.post.
+        with patch("requests.post", side_effect=boom):
+            resp = Client().post(
+                "/api/notifications/test/",
+                data='{"channel":"slack"}',
+                content_type="application/json",
+                **_bearer(user),
+            )
+        assert resp.status_code == 502
+        body = resp.content.decode()
+        assert "SUPERSECRETTOKEN" not in body
+        assert "hooks.slack.com/services" not in body
+        assert "Webhook delivery failed" in body
+
+
+# --- M1: report download honours must_change_password ------------------------
+
+class TestReportPasswordGate:
+    def _session(self):
+        from apps.core.engine.scans.models import ScanSession
+        return ScanSession.objects.create(domain="ex.com", status="completed")
+
+    def _flag(self, user):
+        from apps.core.console.dashboard.models import UserProfile
+        p, _ = UserProfile.objects.get_or_create(user=user)
+        p.must_change_password = True
+        p.save()
+
+    def test_flagged_user_bearer_is_redirected_not_served(self, user):
+        s = self._session()
+        self._flag(user)
+        resp = Client().get(f"/reports/{s.uuid}/csv/", **_bearer(user))
+        assert resp.status_code in (301, 302)
+        assert "/change-password" in resp["Location"]
+
+    def test_unflagged_user_bearer_is_served(self, user):
+        s = self._session()
+        resp = Client().get(f"/reports/{s.uuid}/csv/", **_bearer(user))
+        assert resp.status_code == 200
+
+
+# --- M2 + M4: change-password token revocation + max length ------------------
+
+class TestChangePasswordHardening:
+    def test_revokes_outstanding_refresh_tokens(self, user):
+        from ninja_jwt.token_blacklist.models import BlacklistedToken
+        # Issuing a refresh token records an OutstandingToken row.
+        RefreshToken.for_user(user)
+        assert BlacklistedToken.objects.count() == 0
+        resp = Client().post(
+            "/api/user/change-password/",
+            data='{"current_password":"longpass1","new_password":"newlongpass9"}',
+            content_type="application/json",
+            **_bearer(user),
+        )
+        assert resp.status_code == 200
+        # The user's outstanding refresh token is now blacklisted.
+        assert BlacklistedToken.objects.count() >= 1
+
+    def test_rejects_overlong_new_password(self, user):
+        resp = Client().post(
+            "/api/user/change-password/",
+            data='{"current_password":"longpass1","new_password":"%s"}' % ("x" * 200),
+            content_type="application/json",
+            **_bearer(user),
+        )
+        assert resp.status_code == 400
+        assert "128" in resp.json()["error"]["message"]

--- a/tests/unit/test_login_ratelimit.py
+++ b/tests/unit/test_login_ratelimit.py
@@ -55,10 +55,23 @@ class TestHelpers:
         row.refresh_from_db()
         assert row.failures == 1  # counter reset for the new window
 
-    def test_client_ip_prefers_forwarded_for(self):
+    def test_client_ip_uses_rightmost_forwarded_for(self):
+        # The trusted proxy APPENDS the real client IP, so the rightmost XFF
+        # entry is trustworthy; the leftmost ("5.5.5.5") is client-forgeable and
+        # must NOT be used (keying on it would let a spoofed header evade the limit).
         req = type("R", (), {"META": {
             "HTTP_X_FORWARDED_FOR": "5.5.5.5, 10.0.0.1", "REMOTE_ADDR": "10.0.0.1"}})()
-        assert ratelimit.client_ip(req) == "5.5.5.5"
+        assert ratelimit.client_ip(req) == "10.0.0.1"
+
+    def test_spoofed_leftmost_forwarded_for_cannot_evade_when_trusted(self, settings):
+        # Even with XFF trusted, a client rotating the LEFTMOST (forged) entry
+        # keys on the same rightmost proxy-added IP every time → no evasion.
+        settings.LOGIN_RATELIMIT_TRUST_FORWARDED_FOR = True
+        ip1 = ratelimit.client_ip(type("R", (), {"META": {
+            "HTTP_X_FORWARDED_FOR": "1.1.1.1, 10.0.0.9", "REMOTE_ADDR": "10.0.0.9"}})())
+        ip2 = ratelimit.client_ip(type("R", (), {"META": {
+            "HTTP_X_FORWARDED_FOR": "2.2.2.2, 10.0.0.9", "REMOTE_ADDR": "10.0.0.9"}})())
+        assert ip1 == ip2 == "10.0.0.9"
 
     def test_client_ip_falls_back_to_remote_addr(self):
         req = type("R", (), {"META": {"REMOTE_ADDR": "6.6.6.6"}})()


### PR DESCRIPTION
## What
Fixes the confirmed findings from a UI-independent API contract/security review (the active-scan **authorization gate was traced end-to-end and holds** — no change there).

| | Severity | Fix |
|---|---|---|
| **H1** | HIGH | `/notifications/test/` no longer leaks the webhook URL (its path carries the Slack/Teams **secret**) via the `requests` exception in the 502 body — an authenticated client could exfiltrate the write-only webhook by triggering a failed test. Log detail, return generic message. |
| **H2** | HIGH | Login rate-limiter keys on the **rightmost** `X-Forwarded-For` entry (the proxy-appended hop), not the client-forgeable leftmost — closes brute-force evasion via a rotated spoofed XFF header. |
| **M1** | MED | Report CSV/PDF downloads now honour `must_change_password` (like `JWTAuth`) — a default `admin/admin` holder can no longer pull reports via a Bearer token while locked out of the rest of the API. |
| **M2** | MED | Change-password blacklists the user's outstanding refresh tokens, so the change actually ends other (possibly stolen) sessions. |
| **M4** | MED | Change-password rejects a >128-char new password (`set_password` PBKDF2-hashes the raw string → unbounded CPU-burn). |

Also corrects **CLAUDE.md doc-drift**: the stale `?token=` report-auth description (removed in F-sec3) and the XFF keying note.

## Not included
- **M3** (`/metrics` unauthenticated + default-on): a conscious design decision (mirrors unauth `/health`, counts-only) — left for you to decide (default-off vs token-gate), not auto-changed.
- LOW robustness items (negative-page 500 on `/ai/audit`+`/notifications/alerts`, silent `auth_type` coercion, tool-validation source mismatch) — will follow in a separate robustness PR.

## Tests
`tests/unit/test_api_security_fixes.py` (5: H1 no-leak, M1 gate via Bearer ×2, M2 token revoke, M4 max-length) + updated `test_login_ratelimit.py` (rightmost XFF + spoofed-leftmost-can't-evade). Affected suites green (260 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)