### PR TITLE
fix: API robustness findings — pagination clamp, auth_type 400, past schedule (L1/L2/L5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -916,10 +916,11 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_crypto.py` | 16 | At-rest secret encryption — Fernet roundtrip/non-determinism/legacy-plaintext tolerance, key derivation/override/rotation, DB-holds-ciphertext + ORM-returns-plaintext for AI/notifications/amass/subfinder |
 | `tests/unit/test_login_ratelimit.py` | 14 | Login brute-force limiter — threshold lockout, window reset, success clears, **rightmost** X-Forwarded-For keying (leftmost is client-forgeable — spoofed-leftmost can't evade when trusted; untrusted-XFF fallback to REMOTE_ADDR), middleware integration (per-IP isolation, disabled bypass, refresh endpoint unaffected) |
 | `tests/unit/test_api_security_fixes.py` | 5 | API-review security fixes — webhook URL/secret not leaked in `/notifications/test/` error (H1); report download honours `must_change_password` gate via Bearer (M1); change-password blacklists outstanding refresh tokens (M2) + rejects >128-char password (M4) |
+| `tests/unit/test_api_robustness_fixes.py` | 11 | API-review robustness fixes — pagination clamp (page≤0 / huge page_size → 200 not 500) on `/ai/audit` + `/notifications/alerts` (L1); `authorize_domain` rejects invalid `auth_type` with 400, omitted→owner (L2); `schedule_type=once` rejects a past `scheduled_at` (L5) |
 
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1883 tests** (1837 fast + 46 slow domain_security)
+**Total: 1894 tests** (1848 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/console/ai/api.py
+++ b/apps/core/console/ai/api.py
@@ -252,6 +252,10 @@ def list_audit(request, page: int = 1, page_size: int = 25):
 
     qs = AIInvocation.objects.select_related("session").order_by("-created_at")
     total = qs.count()
+    # Clamp: a negative/zero page produces a negative slice offset (ORM raises →
+    # unhandled 500 escaping the error envelope); cap page_size to bound the fetch.
+    page = max(1, page)
+    page_size = max(1, min(page_size, 100))
     offset = (page - 1) * page_size
     items = qs[offset:offset + page_size]
 

--- a/apps/core/console/notifications/api.py
+++ b/apps/core/console/notifications/api.py
@@ -153,6 +153,10 @@ def list_alerts(request, page: int = 1, page_size: int = 25):
 
     qs = Alert.objects.select_related("session").order_by("-sent_at")
     total = qs.count()
+    # Clamp: a negative/zero page produces a negative slice offset (ORM raises →
+    # unhandled 500 escaping the error envelope); cap page_size to bound the fetch.
+    page = max(1, page)
+    page_size = max(1, min(page_size, 100))
     offset = (page - 1) * page_size
     items = qs[offset:offset + page_size]
 

--- a/apps/core/data/domains/api.py
+++ b/apps/core/data/domains/api.py
@@ -160,7 +160,13 @@ def authorize_domain(request, pk: int, data: AuthorizeIn):
         raise HttpError(400, "Authorization attestation is required")
 
     valid_types = {choice[0] for choice in DomainAuthorization.AUTH_TYPES}
-    auth_type = data.auth_type if data.auth_type in valid_types else "owner"
+    # Reject an explicit bad value rather than silently coercing to "owner" — that
+    # would mis-attribute the scan-consent record's basis (e.g. record "owner" when
+    # the caller claimed written-authorization/bug-bounty). Omitted defaults to
+    # "owner" via the schema, which is valid and passes.
+    if data.auth_type not in valid_types:
+        raise HttpError(400, f"auth_type must be one of: {', '.join(sorted(valid_types))}")
+    auth_type = data.auth_type
 
     DomainAuthorization.objects.create(
         domain=domain,

--- a/apps/core/engine/scans/api.py
+++ b/apps/core/engine/scans/api.py
@@ -343,6 +343,10 @@ def start_scan(request, data: ScanStartRequest):
             raise HttpError(400, "Invalid ISO datetime format for scheduled_at")
         if scheduled_at.tzinfo is None:
             scheduled_at = timezone.make_aware(scheduled_at)
+        # Reject a past datetime — otherwise the next sweep fires it immediately,
+        # which is surprising for a "schedule for later" request.
+        if scheduled_at <= timezone.now():
+            raise HttpError(400, "scheduled_at must be in the future")
         _schedule_once(domain, scheduled_at)
         return Status(201, {"scheduled_at": scheduled_at.isoformat()})
 

--- a/tests/unit/test_api_robustness_fixes.py
+++ b/tests/unit/test_api_robustness_fixes.py
@@ -1,0 +1,96 @@
+"""Tests for the API-review robustness fixes (L1, L2, L5)."""
+
+import datetime
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from django.utils import timezone
+from ninja_jwt.tokens import AccessToken
+
+pytestmark = pytest.mark.django_db
+
+
+def _bearer(user):
+    return {"HTTP_AUTHORIZATION": f"Bearer {AccessToken.for_user(user)}"}
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="admin", password="longpass1")
+
+
+# --- L1: pagination clamp (no 500 on bad page) -------------------------------
+
+class TestPaginationClamp:
+    @pytest.mark.parametrize("path", ["/api/ai/audit/", "/api/notifications/alerts/"])
+    @pytest.mark.parametrize("qs", ["?page=0", "?page=-3", "?page=1&page_size=100000"])
+    def test_bad_pagination_returns_200_not_500(self, user, path, qs):
+        resp = Client().get(path + qs, **_bearer(user))
+        assert resp.status_code == 200  # clamped, not an unhandled negative-slice 500
+
+
+# --- L2: authorize_domain rejects invalid auth_type --------------------------
+
+class TestAuthorizeAuthType:
+    def _domain(self, name="ex.com"):
+        from apps.core.data.domains.models import Domain
+        return Domain.objects.create(name=name)
+
+    def _post(self, user, pk, body):
+        return Client().post(
+            f"/api/domains/{pk}/authorize/", data=body,
+            content_type="application/json", **_bearer(user),
+        )
+
+    def test_invalid_auth_type_rejected(self, user):
+        d = self._domain()
+        resp = self._post(user, d.pk, '{"attestation":true,"auth_type":"bogus"}')
+        assert resp.status_code == 400
+        assert "auth_type" in resp.json()["error"]["message"]
+
+    def test_valid_auth_type_accepted(self, user):
+        d = self._domain("ok.com")
+        resp = self._post(user, d.pk, '{"attestation":true,"auth_type":"bug_bounty"}')
+        assert resp.status_code == 200
+
+    def test_omitted_auth_type_defaults_to_owner(self, user):
+        d = self._domain("def.com")
+        resp = self._post(user, d.pk, '{"attestation":true}')
+        assert resp.status_code == 200
+        from apps.core.data.domains.models import DomainAuthorization
+        assert DomainAuthorization.objects.get(domain=d).auth_type == "owner"
+
+
+# --- L5: schedule_type=once rejects a past datetime --------------------------
+
+class TestScheduleOncePast:
+    def _authorized_domain(self, name="sch.com"):
+        from apps.core.data.domains.models import Domain, DomainAuthorization
+        d = Domain.objects.create(name=name)
+        DomainAuthorization.objects.create(
+            domain=d, auth_type="owner",
+            authorized_at=timezone.localdate(), authorized_by="admin",
+        )
+        return d
+
+    def test_past_scheduled_at_rejected(self, user):
+        self._authorized_domain()
+        past = (timezone.now() - datetime.timedelta(days=1)).isoformat()
+        resp = Client().post(
+            "/api/scans/start/",
+            data='{"domain":"sch.com","schedule_type":"once","scheduled_at":"%s"}' % past,
+            content_type="application/json", **_bearer(user),
+        )
+        assert resp.status_code == 400
+        assert "future" in resp.json()["error"]["message"].lower()
+
+    def test_future_scheduled_at_accepted(self, user):
+        self._authorized_domain("fut.com")
+        future = (timezone.now() + datetime.timedelta(days=1)).isoformat()
+        resp = Client().post(
+            "/api/scans/start/",
+            data='{"domain":"fut.com","schedule_type":"once","scheduled_at":"%s"}' % future,
+            content_type="application/json", **_bearer(user),
+        )
+        assert resp.status_code == 201


### PR DESCRIPTION
## What
Second (lower-severity) batch from the API review — the unambiguous robustness bugs.

- **L1** — `/ai/audit/` and `/notifications/alerts/` clamp `page≥1` and cap `page_size≤100`. A `page≤0` made a **negative slice offset** → ORM raised an **unhandled 500** that escaped the `{"error":{...}}` envelope; `page_size` was uncapped. (scans/assets/insights already use `Paginator.get_page`, so they were fine — this aligns the two manual-slicing endpoints.)
- **L2** — `authorize_domain` returns **400** on an invalid `auth_type` instead of silently coercing to `"owner"` (which mis-attributed the scan-consent basis, e.g. recording "owner" when the caller claimed written-consent/bug-bounty). Omitted still defaults to `"owner"`.
- **L5** — `schedule_type=once` rejects a **past** `scheduled_at` (400) instead of firing it near-immediately on the next sweep.

## Deliberately not changed (documented niceties — behavior-change risk > benefit)
- **L3** subscan-vs-start tool-validation source mismatch (changing validation could reject a legitimate `service_detection` subscan)
- **L4** reports 302-redirect vs 401 (the redirect is intentional for browser downloads)
- **L6** silent no-op on `stop`/`cancel` of an already-terminal/missing target (benign idempotency)

## Tests
`tests/unit/test_api_robustness_fixes.py` (11). Affected suites green (domains/scans/subscan/ai_api/notifications — 151 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)