### PR TITLE
docs: add D-017 flow diagram to DESIGN.md

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -34,6 +34,58 @@ facts are presented.**
 Full rationale + the dev order (entities → pipeline → API+DBOS → normalize →
 vertical slices → UI last) in [DECISIONS.md §D-017](DECISIONS.md#d-017--architecture-north-star-domain-centric-api-driven-ui-agnostic).
 
+### Flow
+
+How a fact enters the system and comes back out. Execution, domain, and
+presentation run in their own lanes and meet only through stored facts.
+
+```
+ ① WRITE / TRIGGER                          ② EXECUTE (durable, resumable)
+ ┌─────────────────────────┐                ┌───────────────────────────────────────┐
+ │ producer:               │  create        │ DBOS run_scan workflow (worker tier)    │
+ │  • API POST /scans/start│  ScanSession   │   └─ Pipeline — 13 phases, fixed order  │
+ │  • scheduler cron       │ ─── + ────────►│        └─ Tools (per phase)             │
+ │  • AI agent             │  enqueue       │             normalize → write rows      │
+ └─────────────────────────┘  (returns 201) │             (never call each other)     │
+        ▲                                    └───────────────────┬─────────────────────┘
+        │                                                        │ writes
+        │                                                        ▼
+        │                                   ╔═════════════════════════════════════════╗
+        │                                   ║ RAW, SCAN-SCOPED LAYER                   ║
+        │                                   ║ per-scan Finding + Subdomain/IP/Port/URL ║
+        │                                   ║ "what this run saw" — provenance,        ║
+        │                                   ║ prunable (retention), idempotent (resume)║
+        │                                   ╚════════════════════╤════════════════════╝
+        │                                                        │ ③ PROMOTE (at _finalize_session)
+        │                                                        ▼  rollup + relationships
+        │                                   ╔═════════════════════════════════════════╗
+        │                                   ║ PERSISTENT, DOMAIN-CENTRIC FACT LAYER    ║
+        │                                   ║   Asset (inventory, deduped per domain)  ║
+        │                                   ║   Issue (triage persists across scans)   ║
+        │                                   ║ relationship graph (independent entities)║
+        │                                   ║   Scan ─discovers→ Asset                 ║
+        │                                   ║   Scan ─generates→ Finding               ║
+        │                                   ║   Finding ─affects→ Asset                ║
+        │                                   ║   Finding ─promoted to→ Issue            ║
+        │                                   ║ + deltas · exposure · AI triage · alerts ║
+        │                                   ╚════════════════════╤════════════════════╝
+        │                                                        │ ④ READ (traverse the graph)
+        │         the SAME backend, queried per perspective      ▼
+   ┌────┴───────────────── API (Django Ninja, flat JSON — the one contract) ──────────────────┐
+   │  /scans → scan-centric   /assets → asset-centric   /issues → finding/issue-centric   …    │
+   └────────────────────────────────────────────────┬──────────────────────────────────────────┘
+                                                     ▼
+                            UI decides PRESENTATION only (React SPA, or any client)
+                            new perspective = new read + view, NO schema change
+```
+
+**The rule the diagram encodes:** the backend stores **facts, relationships,
+execution state, and normalized results**; the UI decides **how they're presented**.
+Raw scan rows are execution/provenance; the domain-centric layer is the canonical
+cross-scan truth. ⑤ *Lifecycle:* triage lives on `Issue` so it survives scans;
+retention prunes the raw layer without losing the domain story; a new tool just
+writes normalized rows and the graph + every perspective pick it up for free.
+
 ---
 
 ## System Overview


### PR DESCRIPTION
## What
Adds a **Flow** diagram under the *North star (D-017)* section in `docs/DESIGN.md` — the end-to-end path a fact takes through the domain-centric architecture:

`① write/trigger (producer → ScanSession + enqueue) → ② execute (DBOS workflow → pipeline → tools normalize → write) → raw scan-scoped layer → ③ promote at finalize into the persistent domain-centric fact layer + relationship graph (Scan discovers Asset · Finding affects Asset · Finding promoted to Issue) → ④ read via the one API, per perspective → UI decides presentation only → ⑤ lifecycle (triage survives scans, raw layer prunable, new tool free).`

Makes the governing rule concrete: **backend stores facts/relationships/execution-state/normalized-results; UI decides presentation** — and shows why a new perspective needs no schema change.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)