### PR TITLE
fix: default /metrics to off (opt-in) — M3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ web vulnerabilities using a dynamic workflow engine with auto-registered tools.
   [`docs/CODING_STANDARDS.md`](docs/CODING_STANDARDS.md) (conventions + open
   review findings), `docs/specs/` (feature specs + producer→queue→consumer
   hardening plan H1–H7). Release notes: `CHANGELOG.md`.
-- **Health**: `GET /health/` (unauth, K8s probes) · `GET /api/version/` · `GET /metrics/` (unauth Prometheus exporter, `METRICS_ENABLED`).
+- **Health**: `GET /health/` (unauth, K8s probes) · `GET /api/version/` · `GET /metrics/` (unauth Prometheus exporter — **opt-in, OFF by default**; enable `METRICS_ENABLED=true` only once network-restricted to your scraper — M3).
 
 ## GitHub Flow
 
@@ -878,7 +878,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_scheduled_jobs.py` | 7 | H7 ScheduledJob registry — `dispatch_scheduled` honours enabled toggle, stamps last_run_at, skips disabled (no stamp), fails open on missing row / lookup error; migration seeds the 6 system crons enabled |
 | `tests/unit/test_watchdog_reconcile.py` | 6 | H4/H9 watchdog↔DBOS reconcile — reap_stuck_scans cancels the reaped scan's DBOS workflow inline (`_cancel_workflows_for_sessions` matches `scan-{id}` dedup); empty no-op, list/cancel failures swallowed, reap-then-cancel end-to-end |
 | `tests/unit/test_no_progress_watchdog.py` | 5 | H10 no-progress watchdog — reap running scan on stale `last_progress_at` heartbeat (fresh → kept, stale → reaped, NULL+old → reaped, NULL+recent → kept, 24h hard cap still applies) |
-| `tests/unit/test_metrics.py` | 9 | H2 DB-backed Prometheus exporter — scans-by-status, queue depth, findings-by-severity, domains, journey latency, liveness staleness; `/metrics` endpoint (prometheus text, no-store, unauthenticated, `METRICS_ENABLED` 404 toggle); `last_progress_at` heartbeat stamped per step |
+| `tests/unit/test_metrics.py` | 10 | H2 DB-backed Prometheus exporter — scans-by-status, queue depth, findings-by-severity, domains, journey latency, liveness staleness; `/metrics` endpoint (prometheus text, no-store, unauthenticated, `METRICS_ENABLED` 404 toggle, **off by default** — M3); `last_progress_at` heartbeat stamped per step |
 | `tests/unit/test_orphan_reaper.py` | 9 | H8 orphaned-workflow reaper — cancels ENQUEUED/PENDING `run_scan` workflows whose `ScanSession` is terminal/missing (phantom queue-slot holders); keeps live (pending/running) sessions; dry-run; fail-graceful (list/cancel errors swallowed) |
 | `tests/unit/test_service_detection.py` | 64 | XML parsing, Port enrichment, is_web |
 | `tests/unit/test_ssh_checker.py` | 34 | SSH probe, host key, kex/cipher/MAC, auth, collector |
@@ -921,6 +921,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1894 tests** (1848 fast + 46 slow domain_security)
+**Total: 1895 tests** (1849 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
+++ b/docs/specs/2026-09-07-producer-queue-consumer-hardening.md
@@ -73,8 +73,10 @@ nothing; a first call with no prior `Alert` rows still sends.
 > **Status:** ✅ Shipped — as a **DB-backed exporter** (deliberate deviation from the
 > in-process-counter design below). `apps/core/console/observability/metrics.py`
 > `render_metrics()` queries Postgres on each scrape and emits Prometheus text;
-> `GET /metrics` (web tier, unauthenticated like `/health`, `METRICS_ENABLED`
-> toggle, `no-store`). Metrics: `openeasd_scans{status}`,
+> `GET /metrics` (web tier, unauthenticated, `no-store`; `METRICS_ENABLED` toggle —
+> **OFF by default / opt-in**, per M3 of the API security review: it's unauth so it
+> ships closed and is enabled only once network-restricted to the scraper).
+> Metrics: `openeasd_scans{status}`,
 > `openeasd_scan_queue_depth`, `openeasd_findings{severity}`, `openeasd_domains`,
 > `openeasd_scan_last_journey_seconds` (enqueue=start_time → finalize=end_time,
 > principle #13), and `openeasd_seconds_since_last_progress` (worker liveness).

--- a/openeasd/settings/base.py
+++ b/openeasd/settings/base.py
@@ -338,9 +338,12 @@ SCAN_RETENTION_ENABLED = config("SCAN_RETENTION_ENABLED", default=False, cast=bo
 SCAN_RETENTION_KEEP_PER_DOMAIN = config("SCAN_RETENTION_KEEP_PER_DOMAIN", default=30, cast=int)
 SCAN_RETENTION_MAX_AGE_DAYS = config("SCAN_RETENTION_MAX_AGE_DAYS", default=180, cast=int)
 
-# Prometheus metrics endpoint (H2). Unauthenticated GET /metrics (counts only, no
-# finding detail) — restrict at the network/proxy layer. Set False to 404 it.
-METRICS_ENABLED = config("METRICS_ENABLED", default=True, cast=bool)
+# Prometheus metrics endpoint (H2). GET /metrics is UNAUTHENTICATED (counts only,
+# no finding detail), so it is OPT-IN: OFF by default (404). Enable it deliberately
+# (METRICS_ENABLED=true) once the endpoint is network-restricted to your scraper —
+# leaving it public exposes aggregate posture (open-finding counts by severity, scan
+# activity) to any caller. (M3, API security review.)
+METRICS_ENABLED = config("METRICS_ENABLED", default=False, cast=bool)
 
 # Scanner timeouts (seconds) — override in .env if needed
 SCANNER_DNS_TIMEOUT = config("SCANNER_DNS_TIMEOUT", default=5, cast=int)

--- a/openeasd/urls.py
+++ b/openeasd/urls.py
@@ -11,10 +11,11 @@ from apps.core.console.api.ninja import api
 
 
 def metrics(request):
-    """Prometheus metrics (H2). Unauthenticated like /health (counts only, no
-    finding detail) — restrict at the network layer. Toggle via METRICS_ENABLED.
-    Served by the web tier but reflects worker state too (DB-backed exporter)."""
-    if not getattr(settings, "METRICS_ENABLED", True):
+    """Prometheus metrics (H2). Unauthenticated (counts only, no finding detail) and
+    therefore OPT-IN: OFF by default (M3) — enable METRICS_ENABLED only once the
+    endpoint is network-restricted to your scraper. Served by the web tier but
+    reflects worker state too (DB-backed exporter)."""
+    if not getattr(settings, "METRICS_ENABLED", False):
         return HttpResponse(status=404)
     from apps.core.console.observability.metrics import render_metrics
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -86,6 +86,10 @@ class TestMetricsEndpoint:
         settings.METRICS_ENABLED = False
         assert Client().get("/metrics/").status_code == 404
 
+    def test_endpoint_off_by_default(self):
+        # M3: /metrics is opt-in — OFF by default (no METRICS_ENABLED override).
+        assert Client().get("/metrics/").status_code == 404
+
 
 class TestHeartbeat:
     def test_step_stamps_last_progress_at(self, transactional_db):


### PR DESCRIPTION
## What
Resolves **M3** (the last open API-review finding). `/metrics` is unauthenticated (counts only), so it now ships **closed**: `METRICS_ENABLED` defaults to **False** → `/metrics` returns 404 unless explicitly enabled.

Enable it deliberately (`METRICS_ENABLED=true`) **only once the endpoint is network-restricted** to your Prometheus scraper — leaving it public exposes aggregate posture (open-finding counts by severity, scan activity, queue depth) to any anonymous caller.

## Deploy note
On preprod (running v2.17.1 with the old default-on), `/metrics` will go dark after the next release+deploy unless you set `METRICS_ENABLED=true` in the configmap. That's the intended secure default — set the env var only where you've locked the endpoint down.

## Tests
`test_metrics.py` (10): adds an off-by-default assertion; existing endpoint tests set the flag explicitly so they're unaffected. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)