### PR TITLE
chore: release v2.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.17.2] — 2026-09-13
+
+### Fixed
+- **`/metrics` is now opt-in, OFF by default (M3).** The Prometheus endpoint is
+  unauthenticated (counts only), so it ships closed: `METRICS_ENABLED` defaults to
+  `False` (404 unless explicitly enabled). Enable it only once the endpoint is
+  network-restricted to your scraper — leaving it public exposes aggregate posture
+  (open-finding counts by severity, scan activity) to any caller. Closes the last
+  open finding from the API security review.
+
+### Docs
+- Added the **D-017 flow diagram** to `docs/DESIGN.md` (write → execute → promote →
+  read path of the domain-centric architecture).
+
 ## [v2.17.1] — 2026-09-13
 
 Security + robustness fixes from a UI-independent API contract/security review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.17.1 — 2026-09-13)
+## Status (v2.17.2 — 2026-09-13)
 
 - **Released**: v2.16.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
   `:v2.16.0` / `:v2.16` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.17.1"
+version = "2.17.2"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.17.1"
+version = "2.17.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Release v2.17.2
Patch over v2.17.1 (no migrations):
- **`/metrics` opt-in, off by default (M3)** — the last open API-review finding.
- **D-017 flow diagram** docs.

Bumps `pyproject.toml` + `uv.lock` → 2.17.2, `[v2.17.2]` CHANGELOG, CLAUDE.md status. After merge: tag `v2.17.2` → GHCR + Release, then roll to preprod with `METRICS_ENABLED=true` (keeping /metrics enabled there, now that the default is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)