### PR TITLE
refactor: relocate 4 endpoints to perspective namespaces (D-017)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,9 +790,6 @@ GET  /api/scans/<uuid>/status/            — lightweight status (React polls ev
 POST /api/scans/<uuid>/stop/              — cancel running scan
 POST /api/scans/<uuid>/delete/            — delete scan session
 POST /api/scans/<uuid>/subscan/           — re-run a single tool / subset against an existing scan
-GET  /api/scans/urls/                     — paginated web-asset URLs (?domain=&page=)
-GET  /api/scans/findings/                 — paginated findings (?severity=&domain=&status=&source=)
-POST /api/scans/findings/<id>/status/     — update finding lifecycle status
 GET  /api/scheduled/                      — scheduled jobs list
 POST /api/scheduled/<job_id>/cancel/      — cancel scheduled job
 GET  /api/workflows/                      — list workflows
@@ -806,6 +803,10 @@ POST /api/workflows/<pk>/steps/<tool>/toggle/ — toggle single tool step
 GET  /api/assets/                         — persistent asset inventory (paginated; ?domain=&kind=&status=&q=), each row with per-severity open-finding counts
 GET  /api/assets/summary/                 — inventory totals by kind + active/gone
 GET  /api/assets/<id>/                     — asset detail: metadata + extra, findings, scan timeline (seen_in_scans)
+GET  /api/assets/urls/                     — paginated web-asset URLs (relocated from /api/scans/urls/ — D-017; ?domain=&session_uuid=&scheme=&status_code=&page=)
+GET  /api/findings/                        — paginated raw findings (relocated from /api/scans/findings/ — D-017; ?severity=&domain=&status=&source=&session_uuid=&page=)
+POST /api/findings/<id>/status/            — update finding lifecycle status (relocated from /api/scans/findings/<id>/status/ — D-017)
+GET  /api/changes/                         — scan-to-scan delta feed (relocated from /api/scans/deltas/ — D-017; ?domain=&change_type=&page=)
 GET  /api/insights/                       — trends, top hosts, asset growth, KPIs, Exposure Score + trend (per-scan exposure_score/grade + top-level exposure block)
 GET  /api/notifications/config/           — get Slack/Teams notification config
 POST /api/notifications/config/           — update notification config

--- a/apps/core/console/api/ninja.py
+++ b/apps/core/console/api/ninja.py
@@ -185,9 +185,10 @@ api.add_router("/dashboard", dashboard_router)
 from apps.core.data.domains.api import router as domains_router
 api.add_router("/domains", domains_router)
 
-from apps.core.engine.scans.api import router as scans_router, scheduled_router
+from apps.core.engine.scans.api import router as scans_router, scheduled_router, changes_router
 api.add_router("/scans", scans_router)
 api.add_router("/scheduled", scheduled_router)
+api.add_router("/changes", changes_router)
 
 from apps.core.engine.workflows.api import router as workflows_router
 api.add_router("/workflows", workflows_router)
@@ -204,8 +205,9 @@ api.add_router("/credentials", credentials_router)
 from apps.core.console.ai.api import router as ai_router
 api.add_router("/ai", ai_router)
 
-from apps.core.data.findings.api import router as issues_router
+from apps.core.data.findings.api import router as issues_router, findings_router
 api.add_router("/issues", issues_router)
+api.add_router("/findings", findings_router)
 
 from apps.core.data.asset_inventory.api import router as assets_router
 api.add_router("/assets", assets_router)

--- a/apps/core/data/asset_inventory/api.py
+++ b/apps/core/data/asset_inventory/api.py
@@ -5,6 +5,7 @@ rollup. Flat JSON, JWT-authed, same shape/pagination as the rest of the API.
 """
 
 import logging
+import uuid
 
 from django.core.paginator import Paginator
 from django.db.models import Count, Q
@@ -142,6 +143,73 @@ def assets_summary(request, domain: str = ""):
         "gone": qs.filter(status="gone").count(),
         "by_kind": by_kind,
     }
+
+
+# ---------------------------------------------------------------------------
+# Web-asset URLs — /api/assets/urls/ (asset-centric). Relocated from
+# /api/scans/urls/ (D-017: URLs are web assets, not a scan concern).
+# ---------------------------------------------------------------------------
+
+def _serialize_url(url) -> dict:
+    return {
+        "id": url.id,
+        "url": url.url,
+        "scheme": url.scheme,
+        "host": url.host,
+        "port_number": url.port_number,
+        "status_code": url.status_code,
+        "title": url.title,
+        "web_server": url.web_server,
+        "content_length": url.content_length,
+        "technologies": url.technologies or [],
+        "source": url.source,
+        "discovered_at": url.discovered_at.isoformat(),
+    }
+
+
+@router.get("/urls/")
+def list_urls(
+    request,
+    domain: str = "",
+    session_uuid: uuid.UUID | None = None,
+    scheme: str = "",
+    status_code: str = "",
+    page: int = 1,
+):
+    from apps.core.data.web_assets.models import URL
+    from apps.core.engine.scans.models import ScanSession
+    from apps.core.queries import latest_session_ids
+
+    if session_uuid is not None:
+        session = get_object_or_404(ScanSession, uuid=str(session_uuid))
+        qs = URL.objects.filter(session=session)
+    else:
+        latest_ids = latest_session_ids()
+        qs = URL.objects.filter(session_id__in=latest_ids)
+        if domain:
+            qs = qs.filter(session__domain__icontains=domain)
+
+    if scheme:
+        qs = qs.filter(scheme=scheme)
+    if status_code:
+        try:
+            qs = qs.filter(status_code=int(status_code))
+        except ValueError:
+            pass
+
+    qs = qs.select_related("port", "subdomain").order_by("url")
+    paginator = Paginator(qs, 50)
+    p = paginator.get_page(page)
+
+    return {
+        "results": [_serialize_url(u) for u in p],
+        "total": paginator.count,
+        "page": p.number,
+        "total_pages": paginator.num_pages,
+        "has_next": p.has_next(),
+        "has_previous": p.has_previous(),
+    }
+
 
 
 @router.get("/{asset_id}/")

--- a/apps/core/data/asset_inventory/api.py
+++ b/apps/core/data/asset_inventory/api.py
@@ -195,6 +195,8 @@ def list_urls(
         try:
             qs = qs.filter(status_code=int(status_code))
         except ValueError:
+            # Non-numeric status_code filter → ignore it (return unfiltered by code)
+            # rather than 400; a bad query param shouldn't error the listing.
             pass
 
     qs = qs.select_related("port", "subdomain").order_by("url")

--- a/apps/core/data/findings/api.py
+++ b/apps/core/data/findings/api.py
@@ -8,6 +8,7 @@ docs/specs/2026-09-12-finding-centric-ui-direction.md (PR3).
 """
 
 import logging
+import uuid
 
 from django.core.paginator import Paginator
 from django.db.models import Case, Count, IntegerField, Value, When
@@ -117,3 +118,145 @@ def set_issue_status(request, issue_id: int, data: StatusIn):
     issue.save(update_fields=["status"])
     logger.info("[issues] %s → %s", issue_id, data.status)
     return _row(issue)
+
+
+# ---------------------------------------------------------------------------
+# Raw findings — /api/findings/ : per-scan Finding instances (finding-centric).
+# Relocated from /api/scans/findings/ (D-017: findings belong in the findings
+# namespace, not under /scans). Distinct from the /api/issues/ register above —
+# these are raw per-scan Finding rows with per-scan lifecycle status; Issues are
+# the deduped, cross-scan promotion of them.
+# ---------------------------------------------------------------------------
+
+findings_router = Router(auth=JWTAuth())
+
+
+def _serialize_finding(finding) -> dict:
+    return {
+        "id": finding.id,
+        "session_id": finding.session_id,
+        "session_uuid": str(finding.session.uuid) if finding.session else None,
+        "source": finding.source,
+        "check_type": finding.check_type,
+        "severity": finding.severity,
+        "title": finding.title,
+        "description": finding.description,
+        "remediation": finding.remediation,
+        "target": finding.target,
+        "asset_id": finding.asset_id,
+        "asset_key": finding.asset.key if finding.asset_id else None,
+        "asset_kind": finding.asset.kind if finding.asset_id else None,
+        "extra": finding.extra,
+        "discovered_at": finding.discovered_at.isoformat(),
+        "status": finding.status,
+        "assigned_to": finding.assigned_to,
+        "resolved_at": finding.resolved_at.isoformat() if finding.resolved_at else None,
+        "resolution_note": finding.resolution_note,
+    }
+
+
+class FindingStatusRequest(Schema):
+    status: str
+    assigned_to: str | None = None
+    resolution_note: str | None = None
+
+
+@findings_router.get("/")
+def list_findings(
+    request,
+    severity: str = "",
+    domain: str = "",
+    status: str = "",
+    source: str = "",
+    session_id: int = 0,
+    session_uuid: uuid.UUID | None = None,
+    page: int = 1,
+):
+    from apps.core.data.findings.models import Finding
+    from apps.core.engine.scans.models import ScanSession
+    from apps.core.queries import latest_session_ids
+
+    if session_uuid is not None and not session_id:
+        session = get_object_or_404(ScanSession, uuid=str(session_uuid))
+        session_id = session.id
+
+    latest_ids = latest_session_ids()
+    base_qs = Finding.objects.select_related("session", "asset")
+    if not session_id:
+        base_qs = base_qs.filter(session_id__in=latest_ids)
+
+    if session_id:
+        count_base = Finding.objects.filter(session_id=session_id, status="open")
+    else:
+        count_base = Finding.objects.filter(session_id__in=latest_ids, status="open")
+    count_open_critical = count_base.filter(severity="critical").count()
+    count_open_high     = count_base.filter(severity="high").count()
+    count_open_medium   = count_base.filter(severity="medium").count()
+    count_open_low      = count_base.filter(severity="low").count()
+
+    qs = base_qs.order_by(
+        Case(
+            When(severity="critical", then=0),
+            When(severity="high", then=1),
+            When(severity="medium", then=2),
+            When(severity="low", then=3),
+            default=4,
+            output_field=IntegerField(),
+        ),
+        "-discovered_at",
+    )
+
+    if severity:
+        qs = qs.filter(severity=severity)
+    if session_id:
+        qs = qs.filter(session_id=session_id)
+    if domain:
+        qs = qs.filter(session__domain__icontains=domain)
+    if status:
+        qs = qs.filter(status=status)
+    if source:
+        qs = qs.filter(source=source)
+
+    paginator = Paginator(qs, 25)
+    p = paginator.get_page(page)
+
+    return {
+        "findings": [_serialize_finding(f) for f in p],
+        "counts": {
+            "open_critical": count_open_critical,
+            "open_high": count_open_high,
+            "open_medium": count_open_medium,
+            "open_low": count_open_low,
+        },
+        "total": paginator.count,
+        "page": p.number,
+        "total_pages": paginator.num_pages,
+        "has_next": p.has_next(),
+        "has_previous": p.has_previous(),
+    }
+
+
+@findings_router.post("/{finding_id}/status/")
+def update_finding_status(request, finding_id: int, data: FindingStatusRequest):
+    from django.utils import timezone
+
+    from apps.core.data.findings.models import Finding
+
+    finding = get_object_or_404(Finding, id=finding_id)
+
+    if data.status not in _VALID_STATUSES:
+        raise HttpError(400, f"status must be one of: {', '.join(sorted(_VALID_STATUSES))}")
+
+    finding.status = data.status
+    if data.status == "resolved" and not finding.resolved_at:
+        finding.resolved_at = timezone.now()
+    elif data.status != "resolved":
+        finding.resolved_at = None
+
+    if data.assigned_to is not None:
+        finding.assigned_to = str(data.assigned_to)[:150]
+    if data.resolution_note is not None:
+        finding.resolution_note = str(data.resolution_note)[:5000]
+
+    finding.save(update_fields=["status", "resolved_at", "assigned_to", "resolution_note"])
+    return _serialize_finding(finding)

--- a/apps/core/engine/scans/api.py
+++ b/apps/core/engine/scans/api.py
@@ -5,7 +5,6 @@ import logging
 import uuid
 
 from django.core.paginator import Paginator
-from django.db import models
 from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -17,7 +16,6 @@ from ninja.errors import HttpError
 from apps.core.console.api.auth import JWTAuth
 from apps.core.constants import SEVERITY_LEVELS
 from apps.core.console.insights.builder import rebuild_finding_type_summaries
-from apps.core.queries import latest_session_ids
 from apps.core.engine.scans.models import ScanSession
 
 logger = logging.getLogger(__name__)
@@ -77,6 +75,10 @@ def _schedule_recurring(domain, recurrence, recurrence_time):
 
 router = Router(auth=JWTAuth())
 scheduled_router = Router(auth=JWTAuth())
+# Change-centric perspective (D-017): the scan-to-scan delta feed, mounted at
+# /api/changes/. Code lives here because ScanDelta is a scans-app model, but the
+# endpoint is a changes-centric view, not a scan resource.
+changes_router = Router(auth=JWTAuth())
 
 
 # ---------------------------------------------------------------------------
@@ -363,155 +365,6 @@ def start_scan(request, data: ScanStartRequest):
     raise HttpError(400, "schedule_type must be 'now', 'once', or 'recurring'")
 
 
-@router.get("/findings/")
-def list_findings(
-    request,
-    severity: str = "",
-    domain: str = "",
-    status: str = "",
-    source: str = "",
-    session_id: int = 0,
-    session_uuid: uuid.UUID | None = None,
-    page: int = 1,
-):
-    from apps.core.data.findings.models import Finding
-
-    # Allow callers to filter by scan UUID directly — matches list_urls and is
-    # what most external clients have on hand. Internally still keyed by
-    # session_id for the queries below.
-    if session_uuid is not None and not session_id:
-        session = get_object_or_404(ScanSession, uuid=str(session_uuid))
-        session_id = session.id
-
-    latest_ids = latest_session_ids()
-    base_qs = Finding.objects.select_related("session", "asset")
-    if not session_id:
-        base_qs = base_qs.filter(session_id__in=latest_ids)
-
-    if session_id:
-        count_base = Finding.objects.filter(session_id=session_id, status="open")
-    else:
-        count_base = Finding.objects.filter(session_id__in=latest_ids, status="open")
-    count_open_critical = count_base.filter(severity="critical").count()
-    count_open_high     = count_base.filter(severity="high").count()
-    count_open_medium   = count_base.filter(severity="medium").count()
-    count_open_low      = count_base.filter(severity="low").count()
-
-    qs = base_qs.order_by(
-        models.Case(
-            models.When(severity="critical", then=0),
-            models.When(severity="high", then=1),
-            models.When(severity="medium", then=2),
-            models.When(severity="low", then=3),
-            default=4,
-            output_field=models.IntegerField(),
-        ),
-        "-discovered_at",
-    )
-
-    if severity:
-        qs = qs.filter(severity=severity)
-    if session_id:
-        qs = qs.filter(session_id=session_id)
-    if domain:
-        qs = qs.filter(session__domain__icontains=domain)
-    if status:
-        qs = qs.filter(status=status)
-    if source:
-        qs = qs.filter(source=source)
-
-    paginator = Paginator(qs, 25)
-    p = paginator.get_page(page)
-
-    return {
-        "findings": [_serialize_finding(f) for f in p],
-        "counts": {
-            "open_critical": count_open_critical,
-            "open_high": count_open_high,
-            "open_medium": count_open_medium,
-            "open_low": count_open_low,
-        },
-        "total": paginator.count,
-        "page": p.number,
-        "total_pages": paginator.num_pages,
-        "has_next": p.has_next(),
-        "has_previous": p.has_previous(),
-    }
-
-
-@router.get("/urls/")
-def list_urls(
-    request,
-    domain: str = "",
-    session_uuid: uuid.UUID | None = None,
-    scheme: str = "",
-    status_code: str = "",
-    page: int = 1,
-):
-    from apps.core.data.web_assets.models import URL
-
-    if session_uuid is not None:
-        session = get_object_or_404(ScanSession, uuid=str(session_uuid))
-        qs = URL.objects.filter(session=session)
-    else:
-        latest_ids = latest_session_ids()
-        qs = URL.objects.filter(session_id__in=latest_ids)
-        if domain:
-            qs = qs.filter(session__domain__icontains=domain)
-
-    if scheme:
-        qs = qs.filter(scheme=scheme)
-    if status_code:
-        try:
-            qs = qs.filter(status_code=int(status_code))
-        except ValueError:
-            pass
-
-    qs = qs.select_related("port", "subdomain").order_by("url")
-    paginator = Paginator(qs, 50)
-    p = paginator.get_page(page)
-
-    return {
-        "results": [_serialize_url(u) for u in p],
-        "total": paginator.count,
-        "page": p.number,
-        "total_pages": paginator.num_pages,
-        "has_next": p.has_next(),
-        "has_previous": p.has_previous(),
-    }
-
-
-class FindingStatusRequest(Schema):
-    status: str
-    assigned_to: str | None = None
-    resolution_note: str | None = None
-
-
-@router.post("/findings/{finding_id}/status/")
-def update_finding_status(request, finding_id: int, data: FindingStatusRequest):
-    from apps.core.data.findings.models import Finding, STATUS_CHOICES
-
-    finding = get_object_or_404(Finding, id=finding_id)
-
-    valid_statuses = {s[0] for s in STATUS_CHOICES}
-    if data.status not in valid_statuses:
-        raise HttpError(400, f"status must be one of: {', '.join(sorted(valid_statuses))}")
-
-    finding.status = data.status
-    if data.status == "resolved" and not finding.resolved_at:
-        finding.resolved_at = timezone.now()
-    elif data.status != "resolved":
-        finding.resolved_at = None
-
-    if data.assigned_to is not None:
-        finding.assigned_to = str(data.assigned_to)[:150]
-    if data.resolution_note is not None:
-        finding.resolution_note = str(data.resolution_note)[:5000]
-
-    finding.save(update_fields=["status", "resolved_at", "assigned_to", "resolution_note"])
-    return _serialize_finding(finding)
-
-
 def _delta_row(d) -> dict:
     # item_identifier is "source:check_type:title" (the delta-detection key).
     # Split on the first two ":" so a title containing ":" stays intact.
@@ -530,7 +383,7 @@ def _delta_row(d) -> dict:
     }
 
 
-@router.get("/deltas/")
+@changes_router.get("/")
 def list_deltas(request, domain: str = "", change_type: str = "", page: int = 1):
     """Recent scan-to-scan changes (new / removed findings), newest first — the
     'changes since last scan' feed. Filter by domain / change_type."""

--- a/frontend/src/components/FindingDetailModal.jsx
+++ b/frontend/src/components/FindingDetailModal.jsx
@@ -120,7 +120,7 @@ export function FindingDetailModal({ finding, onClose, onStatusChanged }) {
     setStatus(next);
     setSaving(true);
     try {
-      await apiPost(`/scans/findings/${f.id}/status/`, { status: next });
+      await apiPost(`/findings/${f.id}/status/`, { status: next });
       toast.success('Status updated.');
       onStatusChanged && onStatusChanged();
     } catch (err) {

--- a/frontend/src/pages/ChangesPage.jsx
+++ b/frontend/src/pages/ChangesPage.jsx
@@ -21,8 +21,8 @@ export default function ChangesPage() {
   const [page,       setPage]       = useState(1);
 
   const { data, isLoading: loading, error } = useQuery({
-    queryKey: ['/scans/deltas/', changeType, domain, page],
-    queryFn: () => apiGet(`/scans/deltas/?change_type=${changeType}`
+    queryKey: ['/changes/', changeType, domain, page],
+    queryFn: () => apiGet(`/changes/?change_type=${changeType}`
       + `&domain=${encodeURIComponent(domain)}&page=${page}`),
   });
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -588,7 +588,7 @@ class TestScanDelete:
 
 class TestFindingsList:
     def test_returns_paginated_findings(self, auth_client, finding):
-        res = auth_client.get("/api/scans/findings/")
+        res = auth_client.get("/api/findings/")
         assert res.status_code == 200
         data = res.json()
         assert "findings" in data
@@ -596,7 +596,7 @@ class TestFindingsList:
         assert "total" in data
 
     def test_filter_by_severity(self, auth_client, finding):
-        res = auth_client.get("/api/scans/findings/?severity=info")
+        res = auth_client.get("/api/findings/?severity=info")
         assert res.status_code == 200
 
     def test_filter_by_session_uuid(self, auth_client, finding):
@@ -615,7 +615,7 @@ class TestFindingsList:
             description="d", remediation="r",
         )
 
-        res = auth_client.get(f"/api/scans/findings/?session_uuid={finding.session.uuid}")
+        res = auth_client.get(f"/api/findings/?session_uuid={finding.session.uuid}")
         assert res.status_code == 200
         data = res.json()
         uuids = {f["session_uuid"] for f in data["findings"]} if data["findings"] else set()
@@ -625,18 +625,18 @@ class TestFindingsList:
 
     def test_unknown_session_uuid_returns_404(self, auth_client):
         import uuid
-        res = auth_client.get(f"/api/scans/findings/?session_uuid={uuid.uuid4()}")
+        res = auth_client.get(f"/api/findings/?session_uuid={uuid.uuid4()}")
         assert res.status_code == 404
 
     def test_requires_auth(self, client):
-        assert client.get("/api/scans/findings/").status_code == 401
+        assert client.get("/api/findings/").status_code == 401
 
 
 class TestFindingStatusUpdate:
     def test_updates_status(self, auth_client, finding):
         res = post_json(
             auth_client,
-            f"/api/scans/findings/{finding.id}/status/",
+            f"/api/findings/{finding.id}/status/",
             {"status": "acknowledged"},
         )
         assert res.status_code == 200
@@ -645,7 +645,7 @@ class TestFindingStatusUpdate:
     def test_resolved_sets_resolved_at(self, auth_client, finding):
         res = post_json(
             auth_client,
-            f"/api/scans/findings/{finding.id}/status/",
+            f"/api/findings/{finding.id}/status/",
             {"status": "resolved", "resolution_note": "Fixed"},
         )
         assert res.status_code == 200
@@ -656,13 +656,13 @@ class TestFindingStatusUpdate:
     def test_invalid_status_returns_400(self, auth_client, finding):
         res = post_json(
             auth_client,
-            f"/api/scans/findings/{finding.id}/status/",
+            f"/api/findings/{finding.id}/status/",
             {"status": "invalid_status"},
         )
         assert res.status_code == 400
 
     def test_requires_auth(self, client, finding):
-        assert post_json(client, f"/api/scans/findings/{finding.id}/status/", {"status": "open"}).status_code == 401
+        assert post_json(client, f"/api/findings/{finding.id}/status/", {"status": "open"}).status_code == 401
 
 
 # ---------------------------------------------------------------------------
@@ -671,14 +671,14 @@ class TestFindingStatusUpdate:
 
 class TestUrlsList:
     def test_returns_paginated(self, auth_client, db):
-        res = auth_client.get("/api/scans/urls/")
+        res = auth_client.get("/api/assets/urls/")
         assert res.status_code == 200
         data = res.json()
         assert "results" in data
         assert "total" in data
 
     def test_requires_auth(self, client):
-        assert client.get("/api/scans/urls/").status_code == 401
+        assert client.get("/api/assets/urls/").status_code == 401
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_asset_inventory_api.py
+++ b/tests/unit/test_asset_inventory_api.py
@@ -139,7 +139,7 @@ class TestCrossLinks:
         a = _asset(d, "port", "1.2.3.4:443/tcp")
         s = _session()
         f = _finding(s, a, "high")
-        body = auth_client.get(f"/api/scans/findings/?session_uuid={s.uuid}").json()
+        body = auth_client.get(f"/api/findings/?session_uuid={s.uuid}").json()
         row = next(x for x in body["findings"] if x["id"] == f.id)
         assert row["asset_id"] == a.id
         assert row["asset_key"] == "1.2.3.4:443/tcp"
@@ -149,7 +149,7 @@ class TestCrossLinks:
         _domain()
         s = _session()
         f = _finding(s, asset=None, severity="low")
-        body = auth_client.get(f"/api/scans/findings/?session_uuid={s.uuid}").json()
+        body = auth_client.get(f"/api/findings/?session_uuid={s.uuid}").json()
         row = next(x for x in body["findings"] if x["id"] == f.id)
         assert row["asset_id"] is None and row["asset_key"] is None
 

--- a/tests/unit/test_deltas_api.py
+++ b/tests/unit/test_deltas_api.py
@@ -1,4 +1,4 @@
-"""/api/scans/deltas/ — the 'changes since last scan' feed (PR5)."""
+"""/api/changes/ — the 'changes since last scan' feed (PR5)."""
 
 import pytest
 
@@ -17,12 +17,12 @@ class TestDeltasAPI:
         )
 
     def test_requires_auth(self, client):
-        assert client.get("/api/scans/deltas/").status_code == 401
+        assert client.get("/api/changes/").status_code == 401
 
     def test_list_shape_and_key_parse(self, auth_client):
         s = self._session()
         self._delta(s, "new", "web_checker:missing_header:Missing CSP header")
-        body = auth_client.get("/api/scans/deltas/").json()
+        body = auth_client.get("/api/changes/").json()
         assert body["total"] == 1 and "page" in body and "total_pages" in body
         row = body["deltas"][0]
         assert row["change_type"] == "new"
@@ -34,7 +34,7 @@ class TestDeltasAPI:
         # split(":", 2) keeps colons in the title intact.
         s = self._session()
         self._delta(s, "new", "nmap:cve:CVE-2024-1: RCE in service X")
-        row = auth_client.get("/api/scans/deltas/").json()["deltas"][0]
+        row = auth_client.get("/api/changes/").json()["deltas"][0]
         assert row["source"] == "nmap" and row["check_type"] == "cve"
         assert row["title"] == "CVE-2024-1: RCE in service X"
 
@@ -42,14 +42,14 @@ class TestDeltasAPI:
         s = self._session()
         self._delta(s, "new", "a:b:c")
         self._delta(s, "removed", "d:e:f")
-        assert auth_client.get("/api/scans/deltas/?change_type=new").json()["total"] == 1
-        assert auth_client.get("/api/scans/deltas/?change_type=removed").json()["total"] == 1
+        assert auth_client.get("/api/changes/?change_type=new").json()["total"] == 1
+        assert auth_client.get("/api/changes/?change_type=removed").json()["total"] == 1
 
     def test_filter_domain(self, auth_client):
         self._delta(self._session("alpha.com"), ident="a:b:c")
         self._delta(self._session("beta.com"), ident="d:e:f")
-        assert auth_client.get("/api/scans/deltas/?domain=alpha.com").json()["total"] == 1
+        assert auth_client.get("/api/changes/?domain=alpha.com").json()["total"] == 1
 
     def test_route_not_shadowed_by_uuid_detail(self, auth_client):
         # /deltas/ must resolve to the feed, not be parsed as a scan UUID (200, not 404/422).
-        assert auth_client.get("/api/scans/deltas/").status_code == 200
+        assert auth_client.get("/api/changes/").status_code == 200


### PR DESCRIPTION
## What
Moves four endpoints off `/api/scans/` to the perspective namespaces the D-017 model calls for (you approved the mapping + clean break):

| Old | New |
|---|---|
| `GET /api/scans/findings/` | `GET /api/findings/` |
| `POST /api/scans/findings/{id}/status/` | `POST /api/findings/{id}/status/` |
| `GET /api/scans/urls/` | `GET /api/assets/urls/` |
| `GET /api/scans/deltas/` | `GET /api/changes/` |

**Breaking** — but a clean break: the in-repo React SPA is the only consumer and is updated in the same PR.

## How
- `findings_router` in `findings/api.py` — raw per-scan Finding instances, distinct from the `/api/issues/` register.
- `/urls/` added to the assets router, **ordered before `/{asset_id:int}/`** (else Ninja 422s on the literal `urls`).
- `deltas` → new `changes_router`.
- Small serializers duplicated into the destination modules to avoid cross-layer import cycles (matches the existing per-module-serializer style); `scan_detail` keeps its own.
- Frontend call sites updated (`FindingDetailModal`, `ChangesPage`); tests + CLAUDE.md URL layout updated; removed now-unused imports.

## Verify
Ruff + `manage.py check` clean; 227 backend tests across the affected suites pass; frontend build + 35 vitest tests pass. `~7` endpoints remain genuinely scan-centric under `/api/scans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)