### PR TITLE
docs: drop tool-centric from D-017 UI perspectives

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -380,7 +380,7 @@ first-class entities (Asset, Scan, Finding, Issue, Tool) joined by relationships
 `Tool produces Finding`, `Finding promoted to Issue` — NOT a fixed hierarchy
 (`Scan → Finding → Asset`, nor `Asset → Finding → Scan`). A fixed nesting bakes one
 UI perspective into the schema; the relationship graph lets scan-/asset-/finding-/
-issue-/tool-centric views all sit over the same backend and change freely.
+issue-centric views all sit over the same backend and change freely.
 
 **Two layers, kept distinct.** (a) A **raw, scan-scoped layer** — `ScanSession`,
 per-scan `Subdomain/IPAddress/Port/URL`, per-scan `Finding` — is execution state +

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -28,7 +28,7 @@ facts are presented.**
   persistent layer at finalize.
 - **Execution structured separately:** `API ↕ DBOS workflow → pipeline → tools →
   normalized data`.
-- **UI perspectives** (scan-/asset-/finding-/issue-/tool-centric) are views over the
+- **UI perspectives** (scan-/asset-/finding-/issue-centric) are views over the
   same backend and free to change. One backend already serves three of them.
 
 Full rationale + the dev order (entities → pipeline → API+DBOS → normalize →


### PR DESCRIPTION
## What
Removes **tool-centric** from the enumerated UI perspectives in `DECISIONS.md` (D-017) and `DESIGN.md`. The perspectives are now **scan- / asset- / finding- / issue-centric**.

## Why
Tool-centric isn't a product goal for OpenEASD (single-user, security-literate audience; the value is assets/findings/issues, not scanner telemetry). The genuinely useful tool data is already reachable without a dedicated perspective:
- per-tool step results in a scan's `/status/`
- `/api/workflows/tools/` (registry)
- `/api/findings/?source=<tool>`
- `verify_tools` / health check

Building a `/api/tools/` perspective + UI would be speculative generality — exactly the YAGNI caution D-017 sets. If a concrete need ever appears (recurring silent tool failures), the cheaper answer is per-tool counters on `/metrics`, not a whole perspective.

The `Tool → produces → Finding` **producer relationship stays** in the data model (it's real dataflow) — it's just not a UI perspective we commit to building.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)