### PR TITLE
fix: API-review LOW findings (findings counts, workflow_id, enum validation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -919,10 +919,11 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_login_ratelimit.py` | 14 | Login brute-force limiter — threshold lockout, window reset, success clears, **rightmost** X-Forwarded-For keying (leftmost is client-forgeable — spoofed-leftmost can't evade when trusted; untrusted-XFF fallback to REMOTE_ADDR), middleware integration (per-IP isolation, disabled bypass, refresh endpoint unaffected) |
 | `tests/unit/test_api_security_fixes.py` | 5 | API-review security fixes — webhook URL/secret not leaked in `/notifications/test/` error (H1); report download honours `must_change_password` gate via Bearer (M1); change-password blacklists outstanding refresh tokens (M2) + rejects >128-char password (M4) |
 | `tests/unit/test_api_robustness_fixes.py` | 11 | API-review robustness fixes — pagination clamp (page≤0 / huge page_size → 200 not 500) on `/ai/audit` + `/notifications/alerts` (L1); `authorize_domain` rejects invalid `auth_type` with 400, omitted→owner (L2); `schedule_type=once` rejects a past `scheduled_at` (L5) |
+| `tests/unit/test_api_review_lows.py` | 6 | Second-review LOW fixes — `/api/findings/` counts scoped to the `domain`/`source` filter (not whole-fleet); `workflow_id` on a scheduled scan → 400 (not silently dropped); `/api/scans/?status=` + `/api/changes/?change_type=` reject unknown enum values with 400 |
 
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1895 tests** (1849 fast + 46 slow domain_security)
+**Total: 1901 tests** (1855 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/apps/core/data/findings/api.py
+++ b/apps/core/data/findings/api.py
@@ -79,10 +79,18 @@ def list_findings(
     if not session_id:
         base_qs = base_qs.filter(session_id__in=latest_ids)
 
+    # Open-findings-by-severity KPI. Scope it to the SAME domain/source filters as
+    # the list (else `?domain=foo` shows a foo list with whole-fleet counts). Stays
+    # status="open" by definition and keeps a full severity breakdown, so the `status`
+    # and `severity` list-filters intentionally don't narrow it.
     if session_id:
         count_base = Finding.objects.filter(session_id=session_id, status="open")
     else:
         count_base = Finding.objects.filter(session_id__in=latest_ids, status="open")
+    if domain:
+        count_base = count_base.filter(session__domain__icontains=domain)
+    if source:
+        count_base = count_base.filter(source=source)
     count_open_critical = count_base.filter(severity="critical").count()
     count_open_high     = count_base.filter(severity="high").count()
     count_open_medium   = count_base.filter(severity="medium").count()

--- a/apps/core/engine/scans/api.py
+++ b/apps/core/engine/scans/api.py
@@ -260,6 +260,9 @@ def list_scans(request, domain: str = "", status: str = "", page: int = 1):
     if domain:
         qs = qs.filter(domain__icontains=domain)
     if status:
+        valid = {s for s, _ in ScanSession.STATUS_CHOICES}
+        if status not in valid:
+            raise HttpError(400, f"status must be one of: {', '.join(sorted(valid))}")
         qs = qs.filter(status=status)
 
     paginator = Paginator(qs, 25)
@@ -299,6 +302,12 @@ def start_scan(request, data: ScanStartRequest):
     # whether authorization is required BEFORE the gate. A passive-only workflow
     # never sends packets to the target, so it needs no DomainAuthorization.
     workflow = None
+    if data.workflow_id is not None and data.schedule_type != "now":
+        # Scheduled scans always run the default Full Scan (ScheduledScan has no
+        # workflow field). Reject rather than silently ignore a chosen workflow —
+        # symmetric with the `tools` guard below, and avoids the surprise of
+        # scheduling a "Passive Scan" that quietly runs the active Full Scan.
+        raise HttpError(400, "workflow_id may only be given for an immediate (now) scan")
     if data.schedule_type == "now" and data.workflow_id is not None:
         from apps.core.engine.workflows.models import Workflow
         try:
@@ -388,6 +397,11 @@ def list_deltas(request, domain: str = "", change_type: str = "", page: int = 1)
     """Recent scan-to-scan changes (new / removed findings), newest first — the
     'changes since last scan' feed. Filter by domain / change_type."""
     from apps.core.engine.scans.models import ScanDelta
+
+    if change_type:
+        valid = {c for c, _ in ScanDelta.CHANGE_TYPE_CHOICES}
+        if change_type not in valid:
+            raise HttpError(400, f"change_type must be one of: {', '.join(sorted(valid))}")
 
     qs = ScanDelta.objects.select_related("session").order_by("-created_at")
     if domain:

--- a/tests/unit/test_api_review_lows.py
+++ b/tests/unit/test_api_review_lows.py
@@ -1,0 +1,77 @@
+"""Tests for the API-review LOW fixes:
+- L-a: /api/findings/ counts respect the domain/source filters (not whole-fleet).
+- L-b: workflow_id on a scheduled scan → 400 (not silently dropped).
+- enum validation: /api/scans/?status= and /api/changes/?change_type= → 400 on unknown.
+"""
+
+import pytest
+from django.contrib.auth.models import User
+from django.test import Client
+from ninja_jwt.tokens import AccessToken
+
+from apps.core.data.findings.models import Finding
+from apps.core.engine.scans.models import ScanSession
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def auth(db):
+    u = User.objects.create_user(username="admin", password="longpass1")
+    return {"HTTP_AUTHORIZATION": f"Bearer {AccessToken.for_user(u)}"}
+
+
+def _open_crit(domain):
+    s = ScanSession.objects.create(domain=domain, status="completed")
+    Finding.objects.create(
+        session=s, source="nmap", check_type="cve", severity="critical",
+        status="open", title="t", description="d", remediation="r", target="x",
+    )
+    return s
+
+
+# --- L-a: findings counts scoped to the filter -------------------------------
+
+class TestFindingsCountsScoped:
+    def test_counts_respect_domain_filter(self, auth):
+        _open_crit("a.com")
+        _open_crit("b.com")
+        # unfiltered: counts see both domains' latest sessions
+        allc = Client().get("/api/findings/", **auth).json()["counts"]
+        assert allc["open_critical"] == 2
+        # filtered by domain: counts reflect only that domain (was the bug — showed 2)
+        ac = Client().get("/api/findings/?domain=a.com", **auth).json()["counts"]
+        assert ac["open_critical"] == 1
+
+
+# --- L-b: workflow_id rejected on scheduled scans ----------------------------
+
+class TestScheduledWorkflowIdRejected:
+    def test_workflow_id_on_scheduled_returns_400(self, auth):
+        resp = Client().post(
+            "/api/scans/start/",
+            data='{"domain":"ex.com","schedule_type":"once","scheduled_at":"2099-01-01T00:00:00","workflow_id":1}',
+            content_type="application/json", **auth,
+        )
+        assert resp.status_code == 400
+        assert "workflow_id" in resp.json()["error"]["message"]
+
+
+# --- enum validation ---------------------------------------------------------
+
+class TestFilterEnumValidation:
+    def test_list_scans_bad_status_400(self, auth):
+        resp = Client().get("/api/scans/?status=bogus", **auth)
+        assert resp.status_code == 400
+        assert "status" in resp.json()["error"]["message"]
+
+    def test_list_scans_valid_status_200(self, auth):
+        assert Client().get("/api/scans/?status=completed", **auth).status_code == 200
+
+    def test_list_changes_bad_change_type_400(self, auth):
+        resp = Client().get("/api/changes/?change_type=bogus", **auth)
+        assert resp.status_code == 400
+        assert "change_type" in resp.json()["error"]["message"]
+
+    def test_list_changes_valid_change_type_200(self, auth):
+        assert Client().get("/api/changes/?change_type=new", **auth).status_code == 200

--- a/tests/unit/test_passive_scan.py
+++ b/tests/unit/test_passive_scan.py
@@ -220,16 +220,18 @@ class TestPassiveScanAuthorizationGate:
             })
         assert resp.status_code == 201
 
-    def test_scheduled_passive_workflow_id_ignored_gate_applies(self, auth_client, domain):
-        # Scheduled (once/recurring) scans run the default active workflow
-        # regardless of any workflow_id, so the gate must still apply.
+    def test_scheduled_workflow_id_rejected(self, auth_client, domain):
+        # Scheduled (once/recurring) scans can't take a workflow_id — ScheduledScan
+        # has no workflow field, so rather than silently ignore it (and quietly run
+        # the default active Full Scan), the API now rejects it with 400 (L-b fix).
         resp = post_json(auth_client, "/api/scans/start/", {
             "domain": "example.com",
             "schedule_type": "once",
             "scheduled_at": "2030-01-01T03:00:00",
             "workflow_id": self._passive_workflow_id(),
         })
-        assert resp.status_code == 403
+        assert resp.status_code == 400
+        assert "workflow_id" in resp.json()["error"]["message"]
 
     def test_passive_tools_subset_bypasses_authorization(self, auth_client, domain):
         # A category-scoped scan of only passive tools on an unauthorized domain


### PR DESCRIPTION
## What
Fixes the actionable LOW findings from the full API review of current `main`. (All prior HIGH/MED fixes were verified still present, and the active-scan authorization gate re-verified holding — no high/medium issues found.)

- **L-a** — `/api/findings/` open-by-severity `counts` now respect the `domain`/`source` filters. Before, `?domain=foo` returned a foo-scoped list but **whole-fleet** counts (misleading KPI). Stays `status=open` + full severity breakdown by design.
- **L-b** — `workflow_id` on a **scheduled** (`once`/`recurring`) scan now **400s** instead of being silently dropped. Scheduling a "Passive Scan" by id no longer quietly runs the active Full Scan. Symmetric with the existing `tools`-on-non-now guard.
- **Enum validation** — `/api/scans/?status=` and `/api/changes/?change_type=` reject unknown values with **400** instead of silently returning an empty page (undiscoverable before).

## Deliberately left (per the review)
- **L3** (subscan validates tools vs `get_tool_runners` incl. core; start uses `get_tool_choices`) and **L6** (silent 200 no-op on `stop`/`cancel`) — behavior-change risk outweighs the benefit; documented as deferred.

## Tests
`tests/unit/test_api_review_lows.py` (6). Affected suites green (scans/deltas/subscan/api-endpoints — 175 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)