### PR TITLE
chore: release v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+## [v2.18.0] — 2026-09-13
+
+Backend structure aligned to the D-017 domain-centric model, plus a second API
+security/robustness review. **Breaking API-path changes** (below) — the in-repo
+React SPA is updated; any other client must update paths. Migrations are
+**state-only** (no data change).
+
+### Changed (breaking — API paths relocated to perspective namespaces, D-017)
+- `GET /api/scans/findings/` → **`GET /api/findings/`**
+- `POST /api/scans/findings/{id}/status/` → **`POST /api/findings/{id}/status/`**
+- `GET /api/scans/urls/` → **`GET /api/assets/urls/`**
+- `GET /api/scans/deltas/` → **`GET /api/changes/`**
+  So `/api/scans/` is now cleanly scan-lifecycle-only (~7 endpoints).
+
+### Changed (structure)
+- **`Issue` split into its own `apps/core/data/issues` app** (persistent
+  cross-scan register), paralleling `asset_inventory` for assets — raw
+  (`findings`) vs persistent (`issues`) now symmetric. Model move is
+  **state-only** (`SeparateDatabaseAndState`, keeps table `findings_issue`) — no
+  data migration.
+
+### Fixed (second API review — all LOW; HIGH/MED from v2.17.x verified still present)
+- `/api/findings/` open-by-severity `counts` now respect the `domain`/`source`
+  filter (was whole-fleet — misleading KPI).
+- `workflow_id` on a scheduled scan → **400** (was silently dropped, quietly
+  running the default Full Scan).
+- `/api/scans/?status=` and `/api/changes/?change_type=` reject unknown enum
+  values with 400 (were silent-empty).
+
+### Docs
+- **D-017 tool-centric perspective dropped** — not a product goal; the 4 backed
+  perspectives are scan / asset / finding / issue.
+
 ## [v2.17.2] — 2026-09-13
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 External Attack Surface Detection platform. Scans domains for network and
 web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 
-## Status (v2.17.2 — 2026-09-13)
+## Status (v2.18.0 — 2026-09-13)
 
 - **Released**: v2.16.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
   `:v2.16.0` / `:v2.16` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openeasd"
-version = "2.17.2"
+version = "2.18.0"
 description = "OpenEASD - Automated External Attack Surface Detection"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "openeasd"
-version = "2.17.2"
+version = "2.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Release v2.18.0

Minor bump — the endpoint relocation is a **breaking API-path change**, so this flags "API surface changed" rather than hiding it in a patch.

**Breaking (API paths → perspective namespaces, D-017):** `/api/scans/findings/`→`/api/findings/`, `.../findings/{id}/status/`→`/api/findings/{id}/status/`, `/api/scans/urls/`→`/api/assets/urls/`, `/api/scans/deltas/`→`/api/changes/`. In-repo SPA updated; other clients must update.
**Structure:** `Issue` split into its own `issues` app (state-only migration, keeps `findings_issue` table).
**Fixed (2nd API review, LOW):** findings counts scope, `workflow_id` 400 on scheduled, enum validation.
**Docs:** tool-centric dropped from D-017.

Migrations are **state-only** (no data change) — the promote is a clean image bump. Bumps pyproject + uv.lock → 2.18.0, `[v2.18.0]` CHANGELOG, CLAUDE.md status. After merge: tag `v2.18.0` → GHCR + auto Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)