### PR TITLE
feat: re-enable github_recon (GitHub Org Recon) tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ commits to recover the reasoning.
 
 ## [Unreleased]
 
+### Added
+- **`github_recon` (GitHub Org Recon) tool restored** — passive, phase-3 "Asset
+  Discovery". Enumerates the target org's PUBLIC GitHub repos via GitHub's REST
+  API and surfaces infrastructure references (internal hostnames/subdomains,
+  cloud-bucket URLs, API endpoints) leaked in that public code/config
+  (`github_public_repos` info + `github_infra_exposure` low findings). Keyless at
+  GitHub's 60 req/hr public limit (capped by `GITHUB_MAX_REPOS`/`GITHUB_MAX_REQUESTS`),
+  richer with a `GITHUB_TOKEN`; passive (queries GitHub, not the target → no
+  `DomainAuthorization`), fail-graceful. Re-added to Full Scan + Passive Scan
+  (migration `workflow/0034`). Registry count **29 → 30**. **Why:** it was retired
+  in v2.x (#438) as overlapping with `github_secrets`, but the two are
+  complementary — `github_secrets` finds leaked *secrets*, `github_recon` finds
+  *infra exposure* (recon surface). +39 tests (`test_github_recon.py`).
+  Its phase group moved from the retired "Surface Enumeration" to "Asset
+  Discovery" (beside `asn_discovery`, its passive-infra-recon analog).
+
 ## [v2.18.0] — 2026-09-13
 
 Backend structure aligned to the D-017 domain-centric model, plus a second API

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ web vulnerabilities using a dynamic workflow engine with auto-registered tools.
 - **Released**: v2.16.0 — images `ghcr.io/cybersecify/openeasd-{web,worker}` at
   `:v2.16.0` / `:v2.16` / `:latest` (web on python:3.12-slim, worker on Ubuntu 24.04/3.12 — both Python 3.12; Django 5.2 LTS). 3-tier deploy: `db` (postgres:17) + `web`
   (gunicorn, no tools) + `worker` (`dbos_worker` + scanner matrix, `NET_RAW`).
-- **Scope**: 29 registered scan tools across 13 pipeline phases; single-user
+- **Scope**: 30 registered scan tools across 13 pipeline phases; single-user
   (one admin, no RBAC) by design.
 - **Engine**: DBOS durable workflows on PostgreSQL — one multi-step `run_scan`
   workflow per scan (checkpoint/resume) + `@durable_task` for one-step tasks
@@ -480,7 +480,7 @@ a terminal tree (`--format text`), or JSON (`--format json`). Because it reads
 `tool_meta` live, it can never drift; a test (`test_render_pipeline_diagram.py`)
 guards that every registered tool appears in the output.
 
-### Tool apps (29 registered tools)
+### Tool apps (30 registered tools)
 
 | App | Phase | Phase Group | produces_findings | Description |
 |---|---|---|---|---|
@@ -494,6 +494,7 @@ guards that every registered tool appears in the output.
 | `apps/subfinder/` | 3 | Asset Discovery | No | Passive subdomain enumeration |
 | `apps/amass/` | 3 | Asset Discovery | No | Active subdomain enumeration |
 | `apps/asn_discovery/` | 3 | Asset Discovery | Yes | Owned ASN / CIDR discovery via `amass intel` (passive registry/BGP recon); reports ranges only, no auto-scan expansion |
+| `apps/github_recon/` | 3 | Asset Discovery | Yes | **Passive** GitHub Org Recon — enumerates the target org's PUBLIC GitHub repos via GitHub's REST API and surfaces infrastructure references (internal hostnames/subdomains, cloud-bucket URLs, API endpoints) leaked in that public code/config (`check_type` `github_public_repos`/`github_infra_exposure`; complements `github_secrets`, which finds actual secrets). Queries GitHub, not the target → no auth; keyless at 60 req/hr (capped), richer with `GITHUB_TOKEN`; fail-graceful |
 | `apps/alterx/` | 3 | Asset Discovery | No | Subdomain permutation via alterx (generates candidates from discovered subdomains) |
 | `apps/dnsx/` | 4 | Asset Discovery | No | DNS resolution, public IP filtering |
 | `apps/takeover_check/` | 5 | Asset Exposure | Yes | Subdomain takeover detection via subzy (dangling DNS → unclaimed cloud) |
@@ -544,6 +545,7 @@ Phase 2  breach_check        → Finding (data-breach exposure: XposedOrNot / HI
 Phase 3  subfinder          → Subdomain (passive enumeration)
 Phase 3  amass              → Subdomain (active enumeration)
 Phase 3  asn_discovery      → Finding (owned ASN/CIDR ranges via amass intel — informational)
+Phase 3  github_recon       → Finding (infra refs in the org's public GitHub repos — passive)
 Phase 3  alterx             → Subdomain (permutation candidates from existing subdomains)
 Phase 4  dnsx               → IPAddress (public-only filter)
 Phase 5  takeover_check     → Finding (subzy — dangling DNS → unclaimed cloud)
@@ -577,8 +579,8 @@ the registry via `get_tool_active()` and `is_passive_tool_set(tools)`.
   `DomainAuthorization`**.
   Passive tools: `domain_security`, `subfinder`, `alterx`, `dnsx`,
   `historical_urls`, `cloud_assets`, `cve_intel`, `asn_discovery`, `hudson_rock`,
-  `shodan`, `typosquat`, `breach_check`, `github_secrets`, `dns_history`,
-  `asn_cluster`.
+  `shodan`, `typosquat`, `breach_check`, `github_secrets`, `github_recon`,
+  `dns_history`, `asn_cluster`.
 - **Active** (`active=True`): probes the target directly (port scans, HTTP/TLS/SSH
   connections, crawling, vuln templates, AXFR/SMTP/mta-sts probes). **Requires
   `DomainAuthorization`.**
@@ -855,6 +857,7 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_breach_check.py` | 29 | Two-tier BYOK — free XposedOrNot parse (keyless + honest UA) + HIBP `breacheddomain` path (key set → HIBP used, `hibp-api-key` header sent, 404/403 = no-data), fail-graceful (timeout/500/429/bad-JSON never raise), 429 backoff, analyzer (severity high on large-account/recent, counts + attribution, no-finding-when-zero, breach-name cap), **PRIVACY: alias keys/emails/credentials never persisted (collector + analyzer + end-to-end)**, scanner |
 | `tests/unit/test_shodan.py` | 20 | collector tier selection (free InternetDB vs paid host API, BYO-key), `SHODAN_MAX_IPS` cap on paid path only, fail-graceful (404/timeout/500/429/bad-JSON never raise), analyzer (exposure + CVE findings, `extra["cve_ids"]` for cve_intel enrichment, invalid-CVE filter), scanner |
 | `tests/unit/test_js_secrets.py` | 26 | `.js` URL filter + cap, fetch-error handling, gitleaks JSON parser, analyzer Findings + dedup + secret redaction (full secret never stored), scanner, binary-missing/timeout |
+| `tests/unit/test_github_recon.py` | 39 | GitHub Org Recon — org resolution (override / apex-label derivation), org/user account confirmation, repo listing (fork-skip, cap, pagination), well-known-file fetch (base64 decode, size/count caps), request-budget guard, rate-limit backoff (403/429 + Retry-After), collector fail-graceful (network/non-200/bad-JSON never raise), `extract_infra_refs` (hostname/api_endpoint/cloud_bucket, apex-excluded), analyzer Findings (`github_public_repos` info + `github_infra_exposure` low, dedup, cap), scanner |
 | `tests/unit/test_github_secrets.py` | 32 | no-token skip (BYOK gate), org resolution (override high-confidence / apex-label low-confidence), org-scoped query building + global-search opt-in, rate-limit helpers (429/403-zero-remaining/secondary + capped backoff), collector fail-graceful (network/500/429-exhausted/bad-JSON never raise) + 429-then-success backoff, search→fetch→gitleaks happy path, gitleaks binary-missing/timeout raise, redaction (full secret never persisted — asserted at DB level), analyzer Finding shape + dedup, scanner |
 | `tests/unit/test_k8s_manifests.py` | 66 | k8s manifest structure — split web/worker Deployments, tier labels, Service→web-only selector, envFrom order, probes + probe-host, worker NET_RAW/role/entrypoint, no-PVC, kustomization |
 | `tests/unit/test_katana.py` | 19 | JSONL parser, Port/Subdomain FK links, scanner orchestrator, honest UA |
@@ -924,6 +927,6 @@ GET  /api/ai/audit/                       — paginated AI call log (metadata on
 | `tests/unit/test_asset_inventory.py` | 11 | Asset-inventory rollup — upsert per kind, dedup across scans, honest gone-marking (completed-only, observed-kinds-only, not on partial/subscan), no-Domain skip, Finding→Asset linkage (url/port/target) |
 | `tests/unit/test_asset_inventory_api.py` | 14 | `/api/assets/` — auth required, list (filters kind/status/domain/q, pagination, per-asset open-finding counts), summary (totals + by_kind), detail (metadata/findings/seen_in_scans, 404); Finding→Asset cross-link in the findings API; dashboard asset KPI |
 
-**Total: 1901 tests** (1855 fast + 46 slow domain_security)
+**Total: 2012 tests** (1966 fast + 46 slow domain_security)
 
 Frontend: **22 Vitest + Testing Library tests** (`frontend/src/**/*.test.{js,jsx}`, happy-dom env) — auth token helpers, the `Badge` component, the axios 401-refresh interceptor, the Assets `SeverityChips`, and the Credentials source-label mapping. Run with `cd frontend && npm run test:run`.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Open http://localhost:8000 → log in with `admin` / `admin` (you'll be forced t
 
 ## Features
 
-- **Automated pipeline**: 29-tool scan workflow from domain to findings
+- **Automated pipeline**: 30-tool scan workflow from domain to findings
 - **Network attack surface scanning**: CVEs, TLS/cert issues, SSH config, network protocol vulnerabilities
 - **CVE prioritisation**: EPSS exploit-probability scores + CISA KEV (known-exploited-in-the-wild) flags enrich CVE findings in place, so you triage by real-world risk rather than severity alone
 - **Dynamic workflows**: Create custom scan configurations, enable/disable tools per workflow
@@ -213,6 +213,8 @@ Phase 3  Subfinder         - Passive subdomain enumeration
 Phase 3  Amass             - Active subdomain enumeration
 Phase 3  Alterx            - Subdomain permutation from discovered subdomains
 Phase 3  ASN Discovery     - Owned ASN/CIDR ranges via amass intel (reports only)
+Phase 3  GitHub Org Recon  - Infra references (hostnames/buckets/API endpoints) in
+                             the org's public GitHub repos (passive; BYO token opt.)
 Phase 4  DNSx              - DNS resolution, public IP filtering
 
 ── Asset Exposure ───────────────────────────────────────────────────────────
@@ -285,6 +287,7 @@ apps/                   - Tool apps (add/remove freely)
   domain_security/      - DNS, email, RDAP checks
   hudson_rock/          - Infostealer-log exposure (Hudson Rock Cavalier API)
   github_secrets/       - Leaked secrets in public GitHub (gitleaks, BYO token)
+  github_recon/         - Infra references in the org's public GitHub repos (BYO token opt.)
   breach_check/         - Data-breach exposure (XposedOrNot free / HIBP BYO key)
   subfinder/            - Passive subdomain enumeration
   amass/                - Active subdomain enumeration

--- a/apps/core/console/reports/views.py
+++ b/apps/core/console/reports/views.py
@@ -123,6 +123,13 @@ _CWE_BY_CHECK = {
     "lookalike_domain": "CWE-451: User Interface (UI) Misrepresentation of Critical Information",
     # asn_cluster — lookalikes sharing one ASN = coordinated impersonation infra.
     "lookalike_cluster": "CWE-451: User Interface (UI) Misrepresentation of Critical Information",
+    # github_recon — infra references (internal hostnames/subdomains, cloud-bucket
+    # URLs, API endpoints) and the public-repo surface leaked in the org's PUBLIC
+    # GitHub source. CWE-200 (Exposure of Sensitive Information to an Unauthorized
+    # Actor) is the exact category: the data is not itself a vuln, but exposing it
+    # hands an attacker recon they should have had to work for.
+    "github_infra_exposure": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor",
+    "github_public_repos": "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor",
 }
 
 

--- a/apps/core/engine/workflows/migrations/0034_readd_github_recon_to_workflows.py
+++ b/apps/core/engine/workflows/migrations/0034_readd_github_recon_to_workflows.py
@@ -1,0 +1,51 @@
+"""Re-add github_recon (GitHub Org Recon) to the default workflows.
+
+github_recon was retired in migration 0033 (#438) and its app deleted. It is now
+restored: a passive, phase-3 "Asset Discovery" tool that enumerates the target
+org's PUBLIC GitHub repos and surfaces infrastructure references (internal
+hostnames/subdomains, cloud-bucket URLs, API endpoints) leaked in that public
+code/config. It joins:
+
+  * Full Scan    — the invariant test_full_scan_covers_every_registered_tool
+                   requires every non-core registered tool to be in the default
+                   Full Scan.
+  * Passive Scan — it is passive (active=False; only GitHub's public API is
+                   touched, never the target), so it belongs in the no-auth
+                   passive recon workflow too.
+
+Additive and idempotent (skips if already present), matching 0029/0030/0031/0032.
+Execution order is unaffected — the runner regroups steps by registry phase.
+"""
+
+from django.db import migrations
+
+_TOOL = "github_recon"
+_WORKFLOWS = ["Full Scan", "Passive Scan"]
+
+
+def add_tool(apps, schema_editor):
+    Workflow = apps.get_model("workflow", "Workflow")
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    for name in _WORKFLOWS:
+        wf = Workflow.objects.filter(name=name).first()
+        if wf is None or wf.steps.filter(tool=_TOOL).exists():
+            continue
+        next_order = (
+            wf.steps.order_by("-order").values_list("order", flat=True).first() or 0
+        ) + 1
+        WorkflowStep.objects.create(workflow=wf, tool=_TOOL, order=next_order, enabled=True)
+
+
+def remove_tool(apps, schema_editor):
+    WorkflowStep = apps.get_model("workflow", "WorkflowStep")
+    WorkflowStep.objects.filter(tool=_TOOL).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("workflow", "0033_remove_github_recon"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_tool, remove_tool),
+    ]

--- a/apps/github_recon/analyzer.py
+++ b/apps/github_recon/analyzer.py
@@ -1,0 +1,192 @@
+"""GitHub Org Recon analyzer — turns public-repo metadata/config into Findings.
+
+Two Finding shapes (aggregate, low-noise — this complements github_secrets, which
+finds actual secrets; this one finds *infra exposure*):
+
+  * ``github_public_repos`` (info): one summary per scan — "N public repos discovered
+    for org X". Establishes the source-code attack surface.
+  * ``github_infra_exposure`` (low): one per unique infrastructure reference found in
+    that public code/config — an internal hostname/subdomain of the target domain, a
+    cloud-bucket URL (S3/Azure/GCP), or an API endpoint. Says WHICH repo and file it
+    came from so the operator can verify and remediate.
+
+We store the reference itself (a hostname / bucket name / URL) — NOT any secret. If a
+secret is what's exposed, github_secrets is the tool that reports it.
+"""
+
+import logging
+import re
+
+from apps.core.data.findings.models import Finding
+
+logger = logging.getLogger(__name__)
+
+_MAX_FINDINGS = 200  # hard cap so a huge org can't flood the report
+
+# Cloud-storage bucket references. In an org's OWN public code these are very likely
+# the org's own buckets, so we surface all providers (not just target-domain matches).
+_BUCKET_RES = (
+    re.compile(r"s3://[a-z0-9][a-z0-9.\-]{1,254}", re.I),
+    re.compile(r"[a-z0-9][a-z0-9.\-]{1,254}\.s3(?:[.\-][a-z0-9\-]+)*\.amazonaws\.com", re.I),
+    re.compile(r"[a-z0-9][a-z0-9\-]{1,62}\.blob\.core\.windows\.net", re.I),
+    re.compile(r"storage\.googleapis\.com/[a-z0-9._\-]+", re.I),
+    re.compile(r"[a-z0-9][a-z0-9._\-]{1,254}\.storage\.googleapis\.com", re.I),
+)
+
+
+# A URL whose PATH exposes an API surface (avoids a bare `"/api" in url` substring
+# check, which static analysis flags as an incomplete-URL-sanitization pattern).
+_API_PATH_RE = re.compile(r"/(?:api|graphql)(?:[/.?]|$)", re.I)
+
+
+def _host_re(domain: str):
+    # A hostname that is a SUBDOMAIN of the target domain (>=1 label before it).
+    return re.compile(rf"\b((?:[a-z0-9_-]+\.)+{re.escape(domain)})\b", re.I)
+
+
+def _url_re(domain: str):
+    # A URL pointing at the target domain (used to catch /api paths on the apex).
+    return re.compile(rf"https?://[a-z0-9_.\-]*{re.escape(domain)}[^\s\"'<>()]*", re.I)
+
+
+def _looks_like_api(host: str) -> bool:
+    parts = host.split(".")
+    return parts[0] in ("api", "apis", "graphql", "gateway") or "api" in parts
+
+
+def extract_infra_refs(text: str, domain: str) -> set:
+    """Return a set of ``(ref_type, value)`` infra references found in ``text``.
+
+    ref_type is one of ``hostname``, ``api_endpoint``, ``cloud_bucket``. Pure /
+    side-effect-free so it is unit-testable in isolation.
+    """
+    refs: set = set()
+    if not text or not domain:
+        return refs
+    domain = domain.lower()
+
+    for host in _host_re(domain).findall(text):
+        host = host.lower().rstrip(".")
+        if host == domain:
+            continue
+        refs.add(("api_endpoint" if _looks_like_api(host) else "hostname", host))
+
+    for url in _url_re(domain).findall(text):
+        clean = url.rstrip("/").lower()
+        if _API_PATH_RE.search(clean):
+            refs.add(("api_endpoint", clean))
+
+    for rx in _BUCKET_RES:
+        for match in rx.findall(text):
+            refs.add(("cloud_bucket", match.lower().rstrip("/")))
+
+    return refs
+
+
+_TITLE_BY_TYPE = {
+    "hostname": "Internal hostname exposed in public GitHub repo",
+    "api_endpoint": "API endpoint exposed in public GitHub repo",
+    "cloud_bucket": "Cloud storage reference exposed in public GitHub repo",
+}
+
+
+def _infra_finding(session, domain, org, ref_type, value, repo, repo_url, location) -> Finding:
+    title = _TITLE_BY_TYPE.get(ref_type, "Infrastructure reference exposed in public GitHub repo")
+    return Finding(
+        session=session,
+        source="github_recon",
+        check_type="github_infra_exposure",
+        severity="low",
+        target=value,
+        title=f"{title}: {value}",
+        description=(
+            f"The {ref_type.replace('_', ' ')} '{value}' appears in the public GitHub "
+            f"repository '{repo}' ({location}). Public source code and configuration "
+            f"can leak internal infrastructure references — hostnames, storage buckets, "
+            f"and API endpoints — that widen your external attack surface even though "
+            f"the target itself was never scanned.\nRepository: {repo_url}"
+        ),
+        remediation=(
+            "Confirm whether this reference should be public. Remove internal hostnames, "
+            "bucket names, and API endpoints from public repositories (and their git "
+            "history), rotate anything sensitive, and ensure the referenced "
+            "infrastructure is firewalled / access-controlled and not implicitly trusted."
+        ),
+        extra={
+            "ref_type": ref_type,
+            "value": value,
+            "repo": repo,
+            "repo_url": repo_url,
+            "location": location,
+            "org": org,
+            "source_data": "github_recon",
+        },
+    )
+
+
+def analyze(session, domain, data) -> list[Finding]:
+    findings: list[Finding] = []
+    if not isinstance(data, dict):
+        return findings
+
+    org = data.get("org")
+    repos = data.get("repos") or []
+
+    if data.get("org_confirmed") and org and repos:
+        findings.append(Finding(
+            session=session,
+            source="github_recon",
+            check_type="github_public_repos",
+            severity="info",
+            target=str(org),
+            title=f"{len(repos)} public GitHub repositor{'y' if len(repos) == 1 else 'ies'} discovered for '{org}'",
+            description=(
+                f"{len(repos)} public repositor{'y' if len(repos) == 1 else 'ies'} were "
+                f"found under the GitHub {data.get('kind') or 'account'} '{org}' "
+                f"({data.get('org_url') or ''}). Public source code is part of your "
+                f"external attack surface — the individual findings below flag specific "
+                f"infrastructure references leaked in that code/config."
+            ),
+            remediation=(
+                "Review which repositories should be public. Audit them for internal "
+                "hostnames, credentials, and infrastructure details, and move private "
+                "work into private repositories."
+            ),
+            extra={
+                "org": org,
+                "kind": data.get("kind"),
+                "org_url": data.get("org_url"),
+                "repo_count": len(repos),
+                "source_data": "github_recon",
+            },
+        ))
+
+    seen: set = set()
+    for repo in repos:
+        if not isinstance(repo, dict):
+            continue
+        name = repo.get("name") or ""
+        repo_url = repo.get("html_url") or ""
+        sources = [
+            ("description", repo.get("description") or ""),
+            ("homepage", repo.get("homepage") or ""),
+            ("topics", " ".join(repo.get("topics") or [])),
+        ]
+        for f in repo.get("files") or []:
+            if isinstance(f, dict):
+                sources.append((f"file:{f.get('path')}", f.get("content") or ""))
+
+        for location, text in sources:
+            for ref_type, value in extract_infra_refs(text, domain):
+                key = (ref_type, value)
+                if key in seen:
+                    continue
+                seen.add(key)
+                findings.append(
+                    _infra_finding(session, domain, org, ref_type, value, name, repo_url, location)
+                )
+                if len(findings) >= _MAX_FINDINGS:
+                    logger.info("github_recon: hit finding cap (%d) — truncating", _MAX_FINDINGS)
+                    return findings
+
+    return findings

--- a/apps/github_recon/analyzer.py
+++ b/apps/github_recon/analyzer.py
@@ -27,7 +27,11 @@ _MAX_FINDINGS = 200  # hard cap so a huge org can't flood the report
 # the org's own buckets, so we surface all providers (not just target-domain matches).
 _BUCKET_RES = (
     re.compile(r"s3://[a-z0-9][a-z0-9.\-]{1,254}", re.I),
-    re.compile(r"[a-z0-9][a-z0-9.\-]{1,254}\.s3(?:[.\-][a-z0-9\-]+)*\.amazonaws\.com", re.I),
+    # Region part is a single bounded [a-z0-9.-] run (not a nested `(?:...)*`) so the
+    # pattern can't backtrack exponentially (ReDoS). Still matches the no-region
+    # (`x.s3.amazonaws.com`), dot-region (`x.s3.us-east-1.…`), dash-region
+    # (`x.s3-us-west-2.…`), and dualstack (`x.s3.dualstack.us-east-1.…`) forms.
+    re.compile(r"[a-z0-9][a-z0-9.\-]{1,63}\.s3[a-z0-9.\-]{0,40}\.amazonaws\.com", re.I),
     re.compile(r"[a-z0-9][a-z0-9\-]{1,62}\.blob\.core\.windows\.net", re.I),
     re.compile(r"storage\.googleapis\.com/[a-z0-9._\-]+", re.I),
     re.compile(r"[a-z0-9][a-z0-9._\-]{1,254}\.storage\.googleapis\.com", re.I),

--- a/apps/github_recon/apps.py
+++ b/apps/github_recon/apps.py
@@ -1,0 +1,24 @@
+from django.apps import AppConfig
+
+
+class GithubReconConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.github_recon"
+    label = "github_recon"
+    verbose_name = "GitHub Org Recon"
+    tool_meta = {
+        "label": "GitHub Org Recon",
+        "runner": "apps.github_recon.scanner.run_github_recon",
+        "phase": 3,
+        "phase_group": "Asset Discovery",
+        "requires": [],
+        "produces_findings": True,
+        # Passive: queries GitHub's PUBLIC REST API for the org's public repos and
+        # the infra references (internal hostnames/subdomains, cloud-bucket URLs,
+        # API endpoints) exposed in that public code/config. Sends ZERO packets to
+        # the target's own systems — this is third-party (GitHub) data, so it needs
+        # NO DomainAuthorization. BYO-token is OPTIONAL: unauthenticated works at
+        # GitHub's 60 req/hr public limit (we cap requests to stay well under it);
+        # a GITHUB_TOKEN raises the ceiling to 5000 req/hr for richer coverage.
+        "active": False,
+    }

--- a/apps/github_recon/collector.py
+++ b/apps/github_recon/collector.py
@@ -1,0 +1,288 @@
+"""GitHub Org Recon collector — passive, two-tier (free + BYO-token).
+
+Enumerates the target org's PUBLIC GitHub repos via GitHub's official REST API and
+pulls lightweight metadata (+ a small, capped set of well-known config files) so the
+analyzer can surface exposed infrastructure references (internal hostnames /
+subdomains, cloud-bucket URLs, API endpoints) found in that public code/config.
+
+Two tiers, chosen automatically by whether a token is configured:
+
+  * FREE (default, no token): unauthenticated GitHub API, 60 requests/hr. We cap
+    total requests (``GITHUB_MAX_REQUESTS``) and repos (``GITHUB_MAX_REPOS``) to stay
+    well under it — every deployment gets useful recon out of the box.
+  * ENHANCED (``GITHUB_TOKEN`` set): authenticated API, 5000 requests/hr — deeper
+    repo + file coverage within the same caps.
+
+Design contract (mirrors apps/shodan, apps/hudson_rock — additive intelligence):
+  * FAIL-GRACEFUL, ALWAYS. Any timeout / non-200 / exhausted rate-limit / JSON error
+    is logged and skipped; the collector never raises. There is no binary, so it does
+    NOT raise ToolBinaryMissing / ToolTimeout.
+  * Uses ONLY GitHub's official API (never scrapes, never touches the target) and
+    sends the honest OpenEASD User-Agent so GitHub can identify us — GitHub rejects
+    requests with no UA. Honours GitHub's rate limits (403/429 + X-RateLimit-*).
+  * A 404 means "no such org/user/file" — normal, not an error.
+"""
+
+import base64
+import logging
+import time
+
+import requests
+from django.conf import settings
+from apps.core.console.credentials.resolver import get_credential
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 10  # seconds, per call
+_MAX_RETRIES = 2  # extra attempts after a rate-limit response
+_DEFAULT_BACKOFF = 2  # seconds, when no Retry-After header
+_MAX_BACKOFF = 10  # cap the honoured Retry-After so we never stall a scan
+
+_PER_PAGE = 100  # GitHub's max page size for repo listings
+_DEFAULT_MAX_REPOS = 50  # cap repos inspected per scan
+_DEFAULT_MAX_REQUESTS = 100  # hard ceiling on total API calls per scan (free-tier guard)
+_MAX_FILES_PER_REPO = 4  # capped well-known config files fetched per repo
+_MAX_FILE_BYTES = 200_000  # skip config files larger than this (bound bytes parsed)
+
+# Well-known, low-risk config files most likely to carry infra references. Bounded
+# by _MAX_FILES_PER_REPO — we never fetch a repo's full tree.
+_WELL_KNOWN_FILES = (
+    "README.md",
+    ".env.example",
+    ".env.sample",
+    "docker-compose.yml",
+    ".github/workflows/ci.yml",
+)
+
+
+def _api_base() -> str:
+    return getattr(settings, "GITHUB_API_BASE", "https://api.github.com").rstrip("/")
+
+
+def _user_agent() -> str:
+    return getattr(settings, "OPENEASD_USER_AGENT", "OpenEASD/1.0")
+
+
+def _headers() -> dict:
+    headers = {
+        "User-Agent": _user_agent(),
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = get_credential("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _max_repos() -> int:
+    return getattr(settings, "GITHUB_MAX_REPOS", _DEFAULT_MAX_REPOS) or _DEFAULT_MAX_REPOS
+
+
+def _max_requests() -> int:
+    return getattr(settings, "GITHUB_MAX_REQUESTS", _DEFAULT_MAX_REQUESTS) or _DEFAULT_MAX_REQUESTS
+
+
+def _is_rate_limited(resp) -> bool:
+    """A 403/429 that is specifically GitHub's rate limit (vs a hard forbidden)."""
+    if resp.headers.get("Retry-After"):
+        return True
+    remaining = resp.headers.get("X-RateLimit-Remaining")
+    return remaining is not None and str(remaining) == "0"
+
+
+def _get_json(url: str, budget: dict, params: dict | None = None):
+    """GET a GitHub API endpoint. Returns parsed JSON, ``{}`` on 404 (no such
+    resource), or ``None`` on any failure. Never raises. Honours GitHub's rate
+    limits (403/429 + Retry-After / X-RateLimit-*) with capped backoff.
+
+    Counts every call against ``budget`` so the caller can stop before blowing the
+    free-tier request ceiling.
+    """
+    budget["used"] += 1
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            resp = requests.get(url, params=params, headers=_headers(), timeout=REQUEST_TIMEOUT)
+        except requests.RequestException as exc:
+            logger.warning("github_recon: request to %s failed: %s", url, exc)
+            return None
+
+        if resp.status_code in (403, 429):
+            if _is_rate_limited(resp) and attempt < _MAX_RETRIES:
+                backoff = _DEFAULT_BACKOFF
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after:
+                    try:
+                        backoff = min(int(retry_after), _MAX_BACKOFF)
+                    except (ValueError, TypeError):
+                        backoff = _DEFAULT_BACKOFF
+                logger.info("github_recon: %s rate-limited, backing off %ss", url, backoff)
+                time.sleep(backoff)
+                continue
+            logger.warning("github_recon: %s returned HTTP %s (rate limit / forbidden)", url, resp.status_code)
+            return None
+
+        if resp.status_code == 404:
+            return {}  # no such org/user/file — normal.
+
+        if resp.status_code != 200:
+            logger.warning("github_recon: %s returned HTTP %s", url, resp.status_code)
+            return None
+
+        try:
+            return resp.json()
+        except ValueError as exc:
+            logger.warning("github_recon: %s returned non-JSON body: %s", url, exc)
+            return None
+
+    return None
+
+
+def _resolve_org(domain: str) -> str | None:
+    """Candidate GitHub org/user login for a domain.
+
+    ``GITHUB_ORG`` (per-deployment override) wins. Otherwise derive from the domain:
+    the registrable label is the second-to-last dot label — ``example.com`` and
+    ``www.example.com`` both -> ``example``. Multi-part TLDs (``example.co.uk``)
+    resolve imperfectly (-> ``co``); set ``GITHUB_ORG`` for those.
+    """
+    override = getattr(settings, "GITHUB_ORG", "")
+    if override:
+        return override.strip()
+    if not domain:
+        return None
+    labels = [label for label in str(domain).strip().lower().split(".") if label]
+    if len(labels) >= 2:
+        return labels[-2]
+    if labels:
+        return labels[0]
+    return None
+
+
+def _confirm_account(org: str, budget: dict) -> dict:
+    """Confirm the login exists as an org or user. Returns a dict with ``login``,
+    ``kind`` ('org'|'user'), and ``html_url``; ``login`` is None if unconfirmed."""
+    base = _api_base()
+    info = _get_json(f"{base}/orgs/{org}", budget)
+    if isinstance(info, dict) and info.get("login"):
+        return {"login": info["login"], "kind": "org", "html_url": info.get("html_url")}
+
+    if budget["used"] >= budget["max"]:
+        return {"login": None, "kind": None, "html_url": None}
+
+    info = _get_json(f"{base}/users/{org}", budget)
+    if isinstance(info, dict) and info.get("login"):
+        kind = "org" if str(info.get("type", "")).lower() == "organization" else "user"
+        return {"login": info["login"], "kind": kind, "html_url": info.get("html_url")}
+
+    return {"login": None, "kind": None, "html_url": None}
+
+
+def _repo_record(item: dict) -> dict:
+    return {
+        "name": item.get("name") or "",
+        "full_name": item.get("full_name") or "",
+        "description": item.get("description") or "",
+        "homepage": item.get("homepage") or "",
+        "topics": [t for t in (item.get("topics") or []) if isinstance(t, str)],
+        "html_url": item.get("html_url") or "",
+        "size": item.get("size") or 0,
+        "files": [],
+    }
+
+
+def _list_repos(login: str, kind: str, budget: dict) -> list[dict]:
+    """Paginate the account's PUBLIC repos, capped at GITHUB_MAX_REPOS. Skips forks
+    (their infra refs belong to the upstream, not the org)."""
+    base = _api_base()
+    repos_path = f"/orgs/{login}/repos" if kind == "org" else f"/users/{login}/repos"
+    repo_type = "public" if kind == "org" else "owner"
+    cap = _max_repos()
+
+    repos: list[dict] = []
+    page = 1
+    while len(repos) < cap and budget["used"] < budget["max"]:
+        data = _get_json(
+            f"{base}{repos_path}",
+            budget,
+            params={"type": repo_type, "per_page": _PER_PAGE, "page": page},
+        )
+        if not isinstance(data, list) or not data:
+            break
+        for item in data:
+            if not isinstance(item, dict) or item.get("fork"):
+                continue
+            repos.append(_repo_record(item))
+            if len(repos) >= cap:
+                break
+        if len(data) < _PER_PAGE:
+            break
+        page += 1
+    return repos
+
+
+def _fetch_files(login: str, repo: str, budget: dict) -> list[dict]:
+    """Fetch a small, capped set of well-known config files' text via the contents
+    API. Bounds both file count (_MAX_FILES_PER_REPO) and bytes (_MAX_FILE_BYTES)."""
+    base = _api_base()
+    files: list[dict] = []
+    attempted = 0
+    for path in _WELL_KNOWN_FILES:
+        if attempted >= _MAX_FILES_PER_REPO or budget["used"] >= budget["max"]:
+            break
+        attempted += 1
+        data = _get_json(f"{base}/repos/{login}/{repo}/contents/{path}", budget)
+        if not isinstance(data, dict) or data.get("encoding") != "base64":
+            continue  # {} for 404 (absent), or a directory listing (a list) — skip
+        if (data.get("size") or 0) > _MAX_FILE_BYTES or not data.get("content"):
+            continue
+        try:
+            text = base64.b64decode(data["content"]).decode("utf-8", "replace")
+        except (ValueError, TypeError) as exc:
+            logger.warning("github_recon: could not decode %s in %s: %s", path, repo, exc)
+            continue
+        files.append({"path": path, "content": text})
+    return files
+
+
+def collect(domain: str) -> dict:
+    """Enumerate the target org's public repos + capped config files.
+
+    Returns ``{"org", "org_confirmed", "org_url", "kind", "repos"}``. Always returns
+    a dict; never raises.
+    """
+    org = _resolve_org(domain)
+    empty = {"org": org, "org_confirmed": False, "org_url": None, "kind": None, "repos": []}
+    if not org:
+        logger.info("github_recon: no org resolvable from domain %r — skipping", domain)
+        return empty
+
+    budget = {"used": 0, "max": _max_requests()}
+    account = _confirm_account(org, budget)
+    if not account["login"]:
+        logger.info("github_recon: no GitHub org/user '%s' — skipping", org)
+        return empty
+
+    login, kind = account["login"], account["kind"]
+    repos = _list_repos(login, kind, budget)
+    for repo in repos:
+        if budget["used"] >= budget["max"]:
+            logger.info(
+                "github_recon: request budget (%d) reached — %d repo(s) not file-scanned",
+                budget["max"], len(repos) - repos.index(repo),
+            )
+            break
+        repo["files"] = _fetch_files(login, repo["name"], budget)
+
+    logger.info(
+        "github_recon: org '%s' (%s) — %d public repo(s) inspected in %d API call(s)%s",
+        login, kind, len(repos), budget["used"],
+        "" if get_credential("GITHUB_TOKEN") else " (unauthenticated free tier)",
+    )
+    return {
+        "org": login,
+        "org_confirmed": True,
+        "org_url": account["html_url"] or f"https://github.com/{login}",
+        "kind": kind,
+        "repos": repos,
+    }

--- a/apps/github_recon/models.py
+++ b/apps/github_recon/models.py
@@ -1,0 +1,2 @@
+# github_recon writes to the shared apps/core/findings/ model. No tool-specific
+# models — see analyzer.py for the Finding shapes produced.

--- a/apps/github_recon/scanner.py
+++ b/apps/github_recon/scanner.py
@@ -1,0 +1,37 @@
+"""GitHub Org Recon scanner — thin orchestrator: collect -> analyze -> save.
+
+Passive additive intelligence. Any failure inside collect/analyze is swallowed and
+the scan continues with zero findings — this tool must never fail a scan.
+"""
+
+import logging
+
+from apps.core.data.findings.models import Finding
+
+from .analyzer import analyze
+from .collector import collect
+
+logger = logging.getLogger(__name__)
+
+
+def run_github_recon(session) -> list[Finding]:
+    domain = session.domain  # CharField: "example.com"
+    if not domain:
+        logger.info("[github_recon:%s] no domain — skipping", session.id)
+        return []
+
+    try:
+        data = collect(domain)
+        findings = analyze(session, domain, data)
+    except Exception:  # noqa: BLE001 — never let this tool fail a scan
+        logger.exception("[github_recon:%s] unexpected error — skipping", session.id)
+        return []
+
+    if not findings:
+        logger.info("[github_recon:%s] no GitHub exposure — nothing to save", session.id)
+        return []
+
+    Finding.objects.bulk_create(findings, ignore_conflicts=True)
+    saved = list(Finding.objects.filter(session=session, source="github_recon"))
+    logger.info("[github_recon:%s] saved %d GitHub recon finding(s)", session.id, len(saved))
+    return saved

--- a/openeasd/settings/base.py
+++ b/openeasd/settings/base.py
@@ -152,6 +152,7 @@ INSTALLED_APPS = [
     "apps.shodan",
     "apps.typosquat",
     "apps.github_secrets",
+    "apps.github_recon",
     "apps.cve_intel",
 ]
 

--- a/tests/unit/test_github_recon.py
+++ b/tests/unit/test_github_recon.py
@@ -1,0 +1,437 @@
+"""Unit tests for apps/github_recon — collector (two-tier BYO-token), infra-reference
+extraction, analyzer, scanner.
+
+github_recon is a passive tool: it enumerates the target org's PUBLIC GitHub repos
+via GitHub's official REST API and surfaces exposed infrastructure references
+(internal hostnames/subdomains, cloud-bucket URLs, API endpoints) in that public
+code/config. It must be fail-graceful (never raise) and stay within a capped request
+budget so the unauthenticated free tier (60 req/hr) is never blown.
+"""
+
+import base64
+import re
+
+import pytest
+import requests
+from unittest.mock import MagicMock, patch
+
+from apps.github_recon.analyzer import analyze, extract_infra_refs
+from apps.github_recon.collector import _resolve_org, collect
+from apps.github_recon.scanner import run_github_recon
+
+
+def _session(domain="example.com"):
+    from apps.core.engine.scans.models import ScanSession
+    return ScanSession.objects.create(domain=domain, scan_type="full")
+
+
+def _resp(status=200, json_body=None, headers=None):
+    r = MagicMock()
+    r.status_code = status
+    r.headers = headers or {}
+    r.json.return_value = json_body if json_body is not None else {}
+    return r
+
+
+def _b64_file(text, size=None):
+    encoded = base64.b64encode(text.encode()).decode()
+    return {"encoding": "base64", "content": encoded, "size": size if size is not None else len(text)}
+
+
+def _router(handlers):
+    """Build a requests.get side_effect that dispatches on the URL.
+
+    handlers: list of (path_pattern, response). First pattern that matches the
+    request URL (via re.search — avoids a flagged `needle in url` substring check)
+    wins. A final catch-all 404 is returned otherwise.
+    """
+    def _get(url, params=None, headers=None, timeout=None):
+        for pattern, resp in handlers:
+            if re.search(pattern, url):
+                return resp
+        return _resp(status=404)
+    return _get
+
+
+# ---------------------------------------------------------------------------
+# Org resolution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestResolveOrg:
+    def test_derives_registrable_label(self, settings):
+        settings.GITHUB_ORG = ""
+        assert _resolve_org("example.com") == "example"
+
+    def test_strips_subdomain(self, settings):
+        settings.GITHUB_ORG = ""
+        assert _resolve_org("www.example.com") == "example"
+
+    def test_override_wins(self, settings):
+        settings.GITHUB_ORG = "acme-labs"
+        assert _resolve_org("example.com") == "acme-labs"
+
+    def test_empty_domain(self, settings):
+        settings.GITHUB_ORG = ""
+        assert _resolve_org("") is None
+
+
+# ---------------------------------------------------------------------------
+# Collector — enumeration happy paths
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCollectorEnumeration:
+    def _org_ok(self, login="example"):
+        return _resp(json_body={"login": login, "html_url": f"https://github.com/{login}"})
+
+    def test_org_confirmed_and_repos_parsed(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        repos = [{"name": "web", "full_name": "example/web", "description": "d",
+                  "homepage": "https://example.com", "topics": ["infra"],
+                  "html_url": "https://github.com/example/web", "fork": False, "size": 1}]
+        handlers = [
+            ("/orgs/example/repos", _resp(json_body=repos)),
+            ("/orgs/example", self._org_ok()),
+            ("/contents/", _resp(status=404)),
+        ]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert data["org_confirmed"] is True
+        assert data["org"] == "example"
+        assert data["kind"] == "org"
+        assert [r["name"] for r in data["repos"]] == ["web"]
+
+    def test_repos_endpoint_uses_orgs_path_first(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        captured = {}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            if url.endswith("/orgs/example"):
+                return self._org_ok()
+            if "/orgs/example/repos" in url:
+                captured["repos_url"] = url
+                return _resp(json_body=[])
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert captured["repos_url"].startswith("https://api.github.com/orgs/example/repos")
+
+    def test_user_fallback_when_org_404(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        handlers = [
+            ("/users/example/repos", _resp(json_body=[])),
+            ("/orgs/example", _resp(status=404)),
+            ("/users/example", _resp(json_body={"login": "example", "type": "User",
+                                                "html_url": "https://github.com/example"})),
+        ]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert data["org_confirmed"] is True
+        assert data["kind"] == "user"
+
+    def test_unknown_account_not_confirmed(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        with patch("apps.github_recon.collector.requests.get", return_value=_resp(status=404)):
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+        assert data["repos"] == []
+
+    def test_forks_skipped(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        repos = [
+            {"name": "own", "fork": False, "html_url": "u"},
+            {"name": "forked", "fork": True, "html_url": "u"},
+        ]
+        handlers = [("/orgs/example/repos", _resp(json_body=repos)),
+                    ("/orgs/example", self._org_ok())]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert [r["name"] for r in data["repos"]] == ["own"]
+
+    def test_repos_capped_at_max(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        settings.GITHUB_MAX_REPOS = 3
+        settings.GITHUB_MAX_REQUESTS = 100
+        repos = [{"name": f"r{i}", "fork": False, "html_url": "u"} for i in range(50)]
+        handlers = [("/orgs/example/repos", _resp(json_body=repos)),
+                    ("/orgs/example", self._org_ok()),
+                    ("/contents/", _resp(status=404))]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert len(data["repos"]) == 3
+
+    def test_config_file_fetched_and_decoded(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        settings.GITHUB_MAX_REQUESTS = 100
+        repos = [{"name": "web", "fork": False, "html_url": "u"}]
+        readme = _b64_file("see internal.example.com and s3://acme-backups")
+        handlers = [
+            ("/orgs/example/repos", _resp(json_body=repos)),
+            ("/orgs/example", self._org_ok()),
+            ("/contents/README.md", _resp(json_body=readme)),
+            ("/contents/", _resp(status=404)),
+        ]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        files = data["repos"][0]["files"]
+        assert files and files[0]["path"] == "README.md"
+        assert files[0]["content"] == "see internal.example.com and s3://acme-backups"
+
+    def test_oversized_file_skipped(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        repos = [{"name": "web", "fork": False, "html_url": "u"}]
+        big = _b64_file("x", size=999_999)
+        handlers = [("/orgs/example/repos", _resp(json_body=repos)),
+                    ("/orgs/example", self._org_ok()),
+                    ("/contents/", _resp(json_body=big))]
+        with patch("apps.github_recon.collector.requests.get", side_effect=_router(handlers)):
+            data = collect("example.com")
+        assert data["repos"][0]["files"] == []
+
+    def test_request_budget_caps_total_calls(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        settings.GITHUB_MAX_REPOS = 50
+        settings.GITHUB_MAX_REQUESTS = 3  # confirm(1) + repos(1) leaves ~1 for files
+        repos = [{"name": f"r{i}", "fork": False, "html_url": "u"} for i in range(10)]
+        calls = {"n": 0}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            calls["n"] += 1
+            if url.endswith("/orgs/example"):
+                return self._org_ok()
+            if "/orgs/example/repos" in url:
+                return _resp(json_body=repos)
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert calls["n"] <= 3  # never exceeds GITHUB_MAX_REQUESTS
+
+    def test_token_sets_auth_header(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = "ghp_secret"
+        captured = {}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            captured["headers"] = headers
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert captured["headers"]["Authorization"] == "Bearer ghp_secret"
+
+    def test_no_token_no_auth_header(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        captured = {}
+
+        def _get(url, params=None, headers=None, timeout=None):
+            captured["headers"] = headers
+            return _resp(status=404)
+
+        with patch("apps.github_recon.collector.requests.get", side_effect=_get):
+            collect("example.com")
+        assert "Authorization" not in captured["headers"]
+        assert captured["headers"]["User-Agent"]  # honest UA always sent
+
+
+# ---------------------------------------------------------------------------
+# Collector — fail-graceful contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestCollectorFailGraceful:
+    def test_request_exception_never_raises(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        with patch("apps.github_recon.collector.requests.get",
+                   side_effect=requests.RequestException("boom")):
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+
+    def test_500_never_raises(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        with patch("apps.github_recon.collector.requests.get", return_value=_resp(status=500)):
+            assert collect("example.com")["org_confirmed"] is False
+
+    def test_rate_limit_retries_then_gives_up(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        limited = _resp(status=403, headers={"Retry-After": "0", "X-RateLimit-Remaining": "0"})
+        with patch("apps.github_recon.collector.requests.get", return_value=limited), \
+             patch("apps.github_recon.collector.time.sleep") as slept:
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+        assert slept.called  # honoured the backoff before giving up
+
+    def test_hard_403_not_retried(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        # A 403 that is NOT a rate limit (no Retry-After, remaining not zero).
+        forbidden = _resp(status=403, headers={"X-RateLimit-Remaining": "42"})
+        with patch("apps.github_recon.collector.requests.get", return_value=forbidden), \
+             patch("apps.github_recon.collector.time.sleep") as slept:
+            data = collect("example.com")
+        assert data["org_confirmed"] is False
+        assert not slept.called  # did not treat a hard 403 as a rate limit
+
+    def test_bad_json_never_raises(self, settings):
+        settings.GITHUB_ORG = ""
+        settings.GITHUB_TOKEN = ""
+        r = _resp(status=200)
+        r.json.side_effect = ValueError("not json")
+        with patch("apps.github_recon.collector.requests.get", return_value=r):
+            assert collect("example.com")["org_confirmed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Infra-reference extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractInfraRefs:
+    def test_subdomain_hostname(self):
+        refs = extract_infra_refs("connect to internal.example.com now", "example.com")
+        assert ("hostname", "internal.example.com") in refs
+
+    def test_api_subdomain_classified_as_api(self):
+        refs = extract_infra_refs("base https://api.example.com/v1", "example.com")
+        assert ("api_endpoint", "api.example.com") in refs
+
+    def test_api_path_on_apex(self):
+        refs = extract_infra_refs("call https://example.com/api/v1/users", "example.com")
+        assert ("api_endpoint", "https://example.com/api/v1/users") in refs
+
+    def test_apex_alone_not_reported(self):
+        # The bare apex is not an interesting infra leak — only subdomains/URLs are.
+        refs = extract_infra_refs("visit example.com", "example.com")
+        assert refs == set()
+
+    def test_s3_bucket_uri(self):
+        refs = extract_infra_refs("backup to s3://acme-prod-backups/db", "example.com")
+        # The bucket name is the identifier we surface (object path is dropped).
+        assert ("cloud_bucket", "s3://acme-prod-backups") in refs
+
+    def test_s3_virtual_host(self):
+        refs = extract_infra_refs("https://assets.s3.amazonaws.com/logo.png", "example.com")
+        assert ("cloud_bucket", "assets.s3.amazonaws.com") in refs
+
+    def test_azure_blob(self):
+        refs = extract_infra_refs("https://acmestore.blob.core.windows.net/x", "example.com")
+        assert ("cloud_bucket", "acmestore.blob.core.windows.net") in refs
+
+    def test_gcp_bucket(self):
+        refs = extract_infra_refs("gs at storage.googleapis.com/acme-assets", "example.com")
+        assert ("cloud_bucket", "storage.googleapis.com/acme-assets") in refs
+
+    def test_empty_and_none(self):
+        assert extract_infra_refs("", "example.com") == set()
+        assert extract_infra_refs("nothing here", "example.com") == set()
+        assert extract_infra_refs("internal.example.com", "") == set()
+
+
+# ---------------------------------------------------------------------------
+# Analyzer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestAnalyzer:
+    def _data(self, repos, org="example", confirmed=True):
+        return {"org": org, "org_confirmed": confirmed, "kind": "org",
+                "org_url": f"https://github.com/{org}", "repos": repos}
+
+    def test_summary_finding_emitted(self):
+        sess = _session()
+        data = self._data([{"name": "web", "html_url": "u", "description": "", "topics": [], "files": []}])
+        findings = analyze(sess, "example.com", data)
+        summary = [f for f in findings if f.check_type == "github_public_repos"]
+        assert len(summary) == 1
+        assert summary[0].severity == "info"
+        assert summary[0].source == "github_recon"
+        assert summary[0].extra["repo_count"] == 1
+
+    def test_infra_finding_shape(self):
+        sess = _session()
+        repo = {"name": "web", "html_url": "https://github.com/example/web",
+                "description": "uses internal.example.com", "topics": [], "files": []}
+        findings = analyze(sess, "example.com", self._data([repo]))
+        infra = [f for f in findings if f.check_type == "github_infra_exposure"]
+        assert len(infra) == 1
+        f = infra[0]
+        assert f.severity == "low"
+        assert f.source == "github_recon"
+        assert f.target == "internal.example.com"
+        assert f.extra["ref_type"] == "hostname"
+        assert f.extra["repo"] == "web"
+        assert f.extra["source_data"] == "github_recon"
+
+    def test_refs_deduped_across_repos(self):
+        sess = _session()
+        repos = [
+            {"name": "a", "html_url": "u", "description": "internal.example.com", "topics": [], "files": []},
+            {"name": "b", "html_url": "u", "description": "internal.example.com", "topics": [], "files": []},
+        ]
+        findings = analyze(sess, "example.com", self._data(repos))
+        infra = [f for f in findings if f.check_type == "github_infra_exposure"]
+        assert len(infra) == 1  # same reference reported once
+
+    def test_no_summary_when_unconfirmed(self):
+        sess = _session()
+        findings = analyze(sess, "example.com", self._data([], confirmed=False))
+        assert findings == []
+
+    def test_finding_from_file_content(self):
+        sess = _session()
+        repo = {"name": "web", "html_url": "u", "description": "", "topics": [],
+                "files": [{"path": "README.md", "content": "bucket s3://acme-prod"}]}
+        findings = analyze(sess, "example.com", self._data([repo]))
+        buckets = [f for f in findings if f.extra.get("ref_type") == "cloud_bucket"]
+        assert buckets and buckets[0].extra["location"] == "file:README.md"
+
+    def test_non_dict_data_safe(self):
+        assert analyze(_session(), "example.com", None) == []
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestScanner:
+    def test_saves_findings(self):
+        from apps.core.data.findings.models import Finding
+        sess = _session()
+        data = {"org": "example", "org_confirmed": True, "kind": "org",
+                "org_url": "https://github.com/example",
+                "repos": [{"name": "web", "html_url": "u",
+                           "description": "internal.example.com", "topics": [], "files": []}]}
+        with patch("apps.github_recon.scanner.collect", return_value=data):
+            saved = run_github_recon(sess)
+        assert len(saved) == 2  # summary + one infra exposure
+        assert Finding.objects.filter(session=sess, source="github_recon").count() == 2
+
+    def test_empty_when_no_data(self):
+        sess = _session()
+        with patch("apps.github_recon.scanner.collect",
+                   return_value={"org": None, "org_confirmed": False, "repos": []}):
+            assert run_github_recon(sess) == []
+
+    def test_never_raises_on_collect_error(self):
+        sess = _session()
+        with patch("apps.github_recon.scanner.collect", side_effect=RuntimeError("boom")):
+            assert run_github_recon(sess) == []
+
+    def test_no_domain_skips(self):
+        sess = _session(domain="")
+        assert run_github_recon(sess) == []


### PR DESCRIPTION
## What

Re-enables the **`github_recon`** (GitHub Org Recon) tool, retired in #438. It is a **passive, phase-3 "Asset Discovery"** tool that enumerates the target org's **public** GitHub repos via GitHub's REST API and surfaces **infrastructure references** — internal hostnames/subdomains, cloud-bucket URLs, API endpoints — leaked in that public code/config.

Two Finding shapes:
- `github_public_repos` (info) — "N public repos discovered for org X"
- `github_infra_exposure` (low) — one per unique infra reference, with the repo + file it came from

## Why

It was retired as overlapping with `github_secrets`, but the two are **complementary**: `github_secrets` finds leaked *secrets*; `github_recon` finds *infra exposure* (recon surface). Restoring it closes that gap. Passive (queries GitHub, not the target → **no `DomainAuthorization`**), keyless at GitHub's 60 req/hr public limit (capped by `GITHUB_MAX_REPOS`/`GITHUB_MAX_REQUESTS`), richer with a `GITHUB_TOKEN`, fail-graceful — never fails a scan.

## Definition of done (CLAUDE.md 6-point checklist)

- [x] Added to `INSTALLED_APPS`
- [x] Added to the default **Full Scan** + **Passive Scan** via data migration `workflow/0034`
- [x] `"active": False` (passive — no target contact, no auth)
- [x] `README.md` — tool count 29 → 30, pipeline diagram, app tree
- [x] `CHANGELOG.md` + `CLAUDE.md` tool tables, passive-tool list, pipeline, test table
- [ ] cybersecify.com website tool count/cards — **flagging for follow-up** (out of repo)

## Notes

- Phase group moved from the retired **"Surface Enumeration"** (gone since the #429 phase renumber) to **"Asset Discovery"**, beside `asn_discovery` (its passive-infra-recon analog). Phase stays 3.
- App source, tests (`test_github_recon.py`, 39 tests), and the two `CWE-200` report mappings restored faithfully from the pre-retirement commit.
- Registry now **30 registered tools**; full fast suite green (1966 passed, 1 skipped live-AI test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)